### PR TITLE
Refactor LodTransform Behaviour

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Helpers/PropertyWrapper.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/PropertyWrapper.cs
@@ -16,6 +16,7 @@ namespace Crest
         void SetFloatArray(int param, float[] value);
         void SetVector(int param, Vector4 value);
         void SetVectorArray(int param, Vector4[] value);
+        void SetBuffer(int param, ComputeBuffer value);
         void SetTexture(int param, Texture value);
         void SetMatrix(int param, Matrix4x4 matrix);
         void SetInt(int param, int value);
@@ -30,6 +31,7 @@ namespace Crest
         public void SetTexture(int param, Texture value) { material.SetTexture(param, value); }
         public void SetVector(int param, Vector4 value) { material.SetVector(param, value); }
         public void SetVectorArray(int param, Vector4[] value) { material.SetVectorArray(param, value); }
+        public void SetBuffer(int param, ComputeBuffer value) { material.SetBuffer(param, value); }
         public void SetMatrix(int param, Matrix4x4 value) { material.SetMatrix(param, value); }
         public void SetInt(int param, int value) { material.SetInt(param, value); }
 
@@ -44,6 +46,7 @@ namespace Crest
         public void SetTexture(int param, Texture value) { materialPropertyBlock.SetTexture(param, value); }
         public void SetVector(int param, Vector4 value) { materialPropertyBlock.SetVector(param, value); }
         public void SetVectorArray(int param, Vector4[] value) { materialPropertyBlock.SetVectorArray(param, value); }
+        public void SetBuffer(int param, ComputeBuffer value) { materialPropertyBlock.SetBuffer(param, value); }
         public void SetMatrix(int param, Matrix4x4 value) { materialPropertyBlock.SetMatrix(param, value); }
         public void SetInt(int param, int value) { materialPropertyBlock.SetInt(param, value); }
 
@@ -72,6 +75,7 @@ namespace Crest
         public void SetTexture(int param, Texture value) { _commandBuffer.SetComputeTextureParam(_computeShader, _computeKernel, param, value); }
         public void SetVector(int param, Vector4 value) { _commandBuffer.SetComputeVectorParam(_computeShader, param, value); }
         public void SetVectorArray(int param, Vector4[] value) { _commandBuffer.SetComputeVectorArrayParam(_computeShader, param, value); }
+        public void SetBuffer(int param, ComputeBuffer value) { _commandBuffer.SetComputeBufferParam(_computeShader, _computeKernel, param, value); }
         public void SetMatrix(int param, Matrix4x4 value) { _commandBuffer.SetComputeMatrixParam(_computeShader, param, value); }
 
         // NOTE: these MUST match the values in OceanLODData.hlsl

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgr.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgr.cs
@@ -94,16 +94,16 @@ namespace Crest
             _scaleDifferencePow2 = Mathf.RoundToInt(ratio_l2);
         }
 
-        public void BindResultData(IPropertyWrapper properties, bool blendOut = true)
+        public void BindResultData(IPropertyWrapper properties)
         {
-            BindData(properties, _targets, blendOut, ref OceanRenderer.Instance._lodTransform._renderData);
+            BindData(properties, _targets, ref OceanRenderer.Instance._lodTransform._renderData);
         }
 
         // Avoid heap allocations instead BindData
         private Vector4[] _BindData_paramIdPosScales = new Vector4[MAX_LOD_COUNT];
         // Used in child
         protected Vector4[] _BindData_paramIdOceans = new Vector4[MAX_LOD_COUNT];
-        protected virtual void BindData(IPropertyWrapper properties, Texture applyData, bool blendOut, ref LodTransform.RenderData[] renderData, bool sourceLod = false)
+        protected virtual void BindData(IPropertyWrapper properties, Texture applyData, ref LodTransform.RenderData[] renderData, bool sourceLod = false)
         {
             if (applyData)
             {
@@ -111,16 +111,7 @@ namespace Crest
             }
 
             var lt = OceanRenderer.Instance._lodTransform;
-            for (int lodIdx = 0; lodIdx < OceanRenderer.Instance.CurrentLodCount; lodIdx++)
-            {
-                // NOTE: gets zeroed by unity, see https://www.alanzucconi.com/2016/10/24/arrays-shaders-unity-5-4/
-                _BindData_paramIdPosScales[lodIdx] = new Vector4(
-                    renderData[lodIdx]._posSnapped.x, renderData[lodIdx]._posSnapped.z,
-                    OceanRenderer.Instance.CalcLodScale(lodIdx), 0f);
-                _BindData_paramIdOceans[lodIdx] = new Vector4(renderData[lodIdx]._texelWidth, renderData[lodIdx]._textureRes, 1f, 1f / renderData[lodIdx]._textureRes);
-            }
-            properties.SetVectorArray(LodTransform.ParamIdPosScale(sourceLod), _BindData_paramIdPosScales);
-            properties.SetVectorArray(LodTransform.ParamIdOcean(sourceLod), _BindData_paramIdOceans);
+            lt.BindData(properties, sourceLod);
         }
 
         public static LodDataType Create<LodDataType, LodDataSettings>(GameObject attachGO, ref LodDataSettings settings)

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgr.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgr.cs
@@ -99,10 +99,6 @@ namespace Crest
             BindData(properties, _targets, ref OceanRenderer.Instance._lodTransform._renderData);
         }
 
-        // Avoid heap allocations instead BindData
-        private Vector4[] _BindData_paramIdPosScales = new Vector4[MAX_LOD_COUNT];
-        // Used in child
-        protected Vector4[] _BindData_paramIdOceans = new Vector4[MAX_LOD_COUNT];
         protected virtual void BindData(IPropertyWrapper properties, Texture applyData, ref LodTransform.RenderData[] renderData, bool sourceLod = false)
         {
             if (applyData)

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrAnimWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrAnimWaves.cs
@@ -236,26 +236,15 @@ namespace Crest
                 lt._renderData[lodIdx].Validate(0, this);
             }
             properties.SetTexture(Shader.PropertyToID("_LD_TexArray_WaveBuffer"), _waveBuffers);
-            BindData(properties, null, true, ref lt._renderData, sourceLod);
+            BindData(properties, null, ref lt._renderData, sourceLod);
         }
 
-        protected override void BindData(IPropertyWrapper properties, Texture applyData, bool blendOut, ref LodTransform.RenderData[] renderData, bool sourceLod = false)
+        protected override void BindData(IPropertyWrapper properties, Texture applyData, ref LodTransform.RenderData[] renderData, bool sourceLod = false)
         {
-            base.BindData(properties, applyData, blendOut, ref renderData, sourceLod);
+            base.BindData(properties, applyData, ref renderData, sourceLod);
 
             var lt = OceanRenderer.Instance._lodTransform;
-
-            for (int lodIdx = 0; lodIdx < OceanRenderer.Instance.CurrentLodCount; lodIdx++)
-            {
-                // need to blend out shape if this is the largest lod, and the ocean might get scaled down later (so the largest lod will disappear)
-                bool needToBlendOutShape = lodIdx == OceanRenderer.Instance.CurrentLodCount - 1 && OceanRenderer.Instance.ScaleCouldDecrease && blendOut;
-                float shapeWeight = needToBlendOutShape ? OceanRenderer.Instance.ViewerAltitudeLevelAlpha : 1f;
-                _BindData_paramIdOceans[lodIdx] = new Vector4(
-                    lt._renderData[lodIdx]._texelWidth,
-                    lt._renderData[lodIdx]._textureRes, shapeWeight,
-                    1f / lt._renderData[lodIdx]._textureRes);
-            }
-            properties.SetVectorArray(LodTransform.ParamIdOcean(sourceLod), _BindData_paramIdOceans);
+            lt.BindDataAnimWaves(properties, sourceLod);
         }
 
         /// <summary>

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrPersistent.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrPersistent.cs
@@ -82,7 +82,7 @@ namespace Crest
                 OceanRenderer.Instance._lodTransform._renderDataSource
                 : OceanRenderer.Instance._lodTransform._renderData;
 
-            BindData(properties, paramsOnly ? TextureArrayHelpers.BlackTextureArray : (Texture)_sources, true, ref renderData, sourceLod);
+            BindData(properties, paramsOnly ? TextureArrayHelpers.BlackTextureArray : (Texture)_sources, ref renderData, sourceLod);
         }
 
         public abstract void GetSimSubstepData(float frameDt, out int numSubsteps, out float substepDt);

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
@@ -87,7 +87,7 @@ namespace Crest
 
         void OnDestroy()
         {
-            _Buffer_sliceViewProjMatrices.Release();
+            if (_Buffer_sliceViewProjMatrices != null) _Buffer_sliceViewProjMatrices.Release();
         }
 
         public override void BuildCommandBuffer(OceanRenderer ocean, CommandBuffer buf)

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
@@ -28,46 +28,54 @@ namespace Crest
         private ComputeBuffer _Buffer_sliceViewProjMatrices;
 
 
-        public static bool UseGeometryShader { get {
-            // Only use geometry shader if target device supports it.
-            // See https://docs.unity3d.com/2018.1/Documentation/Manual/SL-ShaderCompileTargets.html
-            // See https://docs.unity3d.com/ScriptReference/SystemInfo-graphicsShaderLevel.html
+        public static bool UseGeometryShader
+        {
+            get
+            {
+                // Only use geometry shader if target device supports it.
+                // See https://docs.unity3d.com/2018.1/Documentation/Manual/SL-ShaderCompileTargets.html
+                // See https://docs.unity3d.com/ScriptReference/SystemInfo-graphicsShaderLevel.html
 #if PLATFORM_ANDROID
             if(SystemInfo.graphicsDeviceType == GraphicsDeviceType.Vulkan)
             {
                 return false;
             }
 #endif
-            if (SystemInfo.graphicsDeviceType == GraphicsDeviceType.Metal)
-            {
-                return false;
+                if (SystemInfo.graphicsDeviceType == GraphicsDeviceType.Metal)
+                {
+                    return false;
+                }
+                if (SystemInfo.graphicsShaderLevel <= 35 || SystemInfo.graphicsShaderLevel == 45)
+                {
+                    return false;
+                }
+                return true;
             }
-            if(SystemInfo.graphicsShaderLevel <= 35 || SystemInfo.graphicsShaderLevel == 45)
-            {
-                return false;
-            }
-            return true;
-        }}
+        }
 
-        public static string ShaderName { get {
-            if(UseGeometryShader)
+        public static string ShaderName
+        {
+            get
             {
-                return "Crest/Inputs/Depth/Cached Depths";
+                if (UseGeometryShader)
+                {
+                    return "Crest/Inputs/Depth/Cached Depths";
+                }
+                else
+                {
+                    return "Crest/Inputs/Depth/Cached Depths Geometry";
+                }
             }
-            else
-            {
-                return "Crest/Inputs/Depth/Cached Depths Geometry";
-            }
-        }}
+        }
 
         private void OnEnable()
         {
-            if(UseGeometryShader) { Shader.EnableKeyword(ENABLE_GEOMETRY_SHADER_KEYWORD); }
+            if (UseGeometryShader) { Shader.EnableKeyword(ENABLE_GEOMETRY_SHADER_KEYWORD); }
         }
 
         private void OnDisable()
         {
-            if(UseGeometryShader) { Shader.DisableKeyword(ENABLE_GEOMETRY_SHADER_KEYWORD); }
+            if (UseGeometryShader) { Shader.DisableKeyword(ENABLE_GEOMETRY_SHADER_KEYWORD); }
         }
 
         protected override void InitData()
@@ -92,7 +100,8 @@ namespace Crest
                 return;
             }
 
-            if(UseGeometryShader) {
+            if (UseGeometryShader)
+            {
                 buf.SetRenderTarget(_targets, 0, CubemapFace.Unknown, -1);
                 buf.ClearRenderTarget(false, true, Color.white * 1000f);
 

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
@@ -77,6 +77,11 @@ namespace Crest
             _Buffer_sliceViewProjMatrices = new ComputeBuffer(OceanRenderer.Instance.CurrentLodCount, sizeof(float) * 4 * 4);
         }
 
+        void OnDestroy()
+        {
+            _Buffer_sliceViewProjMatrices.Release();
+        }
+
         public override void BuildCommandBuffer(OceanRenderer ocean, CommandBuffer buf)
         {
             base.BuildCommandBuffer(ocean, buf);

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrShadow.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrShadow.cs
@@ -219,7 +219,7 @@ namespace Crest
         public void BindSourceData(IPropertyWrapper simMaterial, bool paramsOnly)
         {
             var rd = OceanRenderer.Instance._lodTransform._renderDataSource;
-            BindData(simMaterial, paramsOnly ? Texture2D.blackTexture : _sources as Texture, true, ref rd, true);
+            BindData(simMaterial, paramsOnly ? Texture2D.blackTexture : _sources as Texture, ref rd, true);
         }
 
         void OnEnable()

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodTransform.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodTransform.cs
@@ -97,30 +97,12 @@ namespace Crest
 
         void OnDestroy()
         {
-            if (_Buffer_paramIdPosScales != null)
-            {
-                _Buffer_paramIdPosScales.Release();
-            }
-            if (_Buffer_paramIdPosScalesSource != null)
-            {
-                _Buffer_paramIdPosScalesSource.Release();
-            }
-            if (_Buffer_paramIdOceans != null)
-            {
-                _Buffer_paramIdOceans.Release();
-            }
-            if (_Buffer_paramIdOceansSource != null)
-            {
-                _Buffer_paramIdOceansSource.Release();
-            }
-            if (_Buffer_paramIdOceansAnimWaves != null)
-            {
-                _Buffer_paramIdOceansAnimWaves.Release();
-            }
-            if (_Buffer_paramIdOceansAnimWavesSource != null)
-            {
-                _Buffer_paramIdOceansAnimWavesSource.Release();
-            }
+            if (_Buffer_paramIdPosScales != null) _Buffer_paramIdPosScales.Release();
+            if (_Buffer_paramIdPosScalesSource != null) _Buffer_paramIdPosScalesSource.Release();
+            if (_Buffer_paramIdOceans != null) _Buffer_paramIdOceans.Release();
+            if (_Buffer_paramIdOceansSource != null) _Buffer_paramIdOceansSource.Release();
+            if (_Buffer_paramIdOceansAnimWaves != null) _Buffer_paramIdOceansAnimWaves.Release();
+            if (_Buffer_paramIdOceansAnimWavesSource != null) _Buffer_paramIdOceansAnimWavesSource.Release();
         }
 
         public void UpdateTransforms()

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodTransform.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodTransform.cs
@@ -88,12 +88,40 @@ namespace Crest
         private Vector4[] _BindData_paramIdOceans;
         private Vector4[] _BindData_paramIdOceansAnimWaves;
 
-        private ComputeBuffer _Buffer_paramIdPosScales;
-        private ComputeBuffer _Buffer_paramIdOceans;
-        private ComputeBuffer _Buffer_paramIdOceansAnimWaves;
-        private ComputeBuffer _Buffer_paramIdPosScalesSource;
-        private ComputeBuffer _Buffer_paramIdOceansSource;
-        private ComputeBuffer _Buffer_paramIdOceansAnimWavesSource;
+        private ComputeBuffer _Buffer_paramIdPosScales = null;
+        private ComputeBuffer _Buffer_paramIdOceans = null;
+        private ComputeBuffer _Buffer_paramIdOceansAnimWaves = null;
+        private ComputeBuffer _Buffer_paramIdPosScalesSource = null;
+        private ComputeBuffer _Buffer_paramIdOceansSource = null;
+        private ComputeBuffer _Buffer_paramIdOceansAnimWavesSource = null;
+
+        void OnDestroy()
+        {
+            if (_Buffer_paramIdPosScales != null)
+            {
+                _Buffer_paramIdPosScales.Release();
+            }
+            if (_Buffer_paramIdPosScalesSource != null)
+            {
+                _Buffer_paramIdPosScalesSource.Release();
+            }
+            if (_Buffer_paramIdOceans != null)
+            {
+                _Buffer_paramIdOceans.Release();
+            }
+            if (_Buffer_paramIdOceansSource != null)
+            {
+                _Buffer_paramIdOceansSource.Release();
+            }
+            if (_Buffer_paramIdOceansAnimWaves != null)
+            {
+                _Buffer_paramIdOceansAnimWaves.Release();
+            }
+            if (_Buffer_paramIdOceansAnimWavesSource != null)
+            {
+                _Buffer_paramIdOceansAnimWavesSource.Release();
+            }
+        }
 
         public void UpdateTransforms()
         {

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodTransform.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodTransform.cs
@@ -77,7 +77,7 @@ namespace Crest
         private Vector4[] _BindData_paramIdOceans = new Vector4[LodDataMgr.MAX_LOD_COUNT];
         private Vector4[] _BindData_paramIdOceansAnimWaves = new Vector4[LodDataMgr.MAX_LOD_COUNT];
         private Vector4[] _BindData_paramIdPosScalesSource = new Vector4[LodDataMgr.MAX_LOD_COUNT];
-        private Vector4[] _BindData_paramIdOceansSource  = new Vector4[LodDataMgr.MAX_LOD_COUNT];
+        private Vector4[] _BindData_paramIdOceansSource = new Vector4[LodDataMgr.MAX_LOD_COUNT];
         private Vector4[] _BindData_paramIdOceansAnimWavesSource = new Vector4[LodDataMgr.MAX_LOD_COUNT];
 
         public void UpdateTransforms()
@@ -180,7 +180,7 @@ namespace Crest
 
         public static int ParamIdPosScale(bool sourceLod = false)
         {
-            if(sourceLod)
+            if (sourceLod)
             {
                 return s_paramsPosScaleSource;
             }
@@ -192,7 +192,7 @@ namespace Crest
 
         public static int ParamIdOcean(bool sourceLod = false)
         {
-            if(sourceLod)
+            if (sourceLod)
             {
                 return s_paramsOceanSource;
             }
@@ -204,7 +204,7 @@ namespace Crest
 
         public void SetOrigin(Vector3 newOrigin)
         {
-            for(int lodIdx = 0; lodIdx < LodCount; lodIdx++)
+            for (int lodIdx = 0; lodIdx < LodCount; lodIdx++)
             {
                 _renderData[lodIdx]._posSnapped -= newOrigin;
                 _renderDataSource[lodIdx]._posSnapped -= newOrigin;

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
@@ -355,7 +355,7 @@ namespace Crest
 
             if (OceanRenderer.Instance._lodDataSeaDepths)
             {
-                OceanRenderer.Instance._lodDataSeaDepths.BindResultData(property, false);
+                OceanRenderer.Instance._lodDataSeaDepths.BindResultData(property);
             }
 
             return numInBatch;

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/OceanDepthsCacheGeometry.shader
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/OceanDepthsCacheGeometry.shader
@@ -33,7 +33,7 @@ Shader "Crest/Inputs/Depth/Cached Depths"
 			};
 			#include "OceanDepthsCacheCommon.hlsl"
 
-			float4x4 _SliceViewProjMatrices[MAX_LOD_COUNT];
+			StructuredBuffer<float4x4> _SliceViewProjMatrices;
 			float4 ObjectToPosition(float3 positionOS)
 			{
 				return mul(unity_ObjectToWorld, float4(positionOS, 1));

--- a/crest/Assets/Crest/Crest/Shaders/OceanLODData.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanLODData.hlsl
@@ -21,8 +21,8 @@ Texture2DArray _LD_TexArray_Foam;
 Texture2DArray _LD_TexArray_Flow;
 Texture2DArray _LD_TexArray_DynamicWaves;
 Texture2DArray _LD_TexArray_Shadow;
-uniform float4 _LD_Params[MAX_LOD_COUNT];
-uniform float3 _LD_Pos_Scale[MAX_LOD_COUNT];
+StructuredBuffer<float4> _LD_Params;
+StructuredBuffer<float3> _LD_Pos_Scale;
 uniform const float _LD_SliceIndex;
 
 // These are used in lods where we operate on data from
@@ -35,8 +35,8 @@ Texture2DArray _LD_TexArray_Foam_Source;
 Texture2DArray _LD_TexArray_Flow_Source;
 Texture2DArray _LD_TexArray_DynamicWaves_Source;
 Texture2DArray _LD_TexArray_Shadow_Source;
-uniform float4 _LD_Params_Source[MAX_LOD_COUNT];
-uniform float3 _LD_Pos_Scale_Source[MAX_LOD_COUNT];
+StructuredBuffer<float4> _LD_Params_Source;
+StructuredBuffer<float3> _LD_Pos_Scale_Source;
 
 SamplerState LODData_linear_clamp_sampler;
 


### PR DESCRIPTION
The goal of this change is to simplify the run-time behavior of Crest, reducing the amount of work it has to do and remove dependencies on compile-time hardcoded values.

This is done with two changes:
- Having LodTransform cache data that is often sent to the GPU, so that parameters can be more easily bound in LodDataMgrs. 
- Replacing hardcoded fixed-length arrays with compute buffers in shaders, increasing their flexibility and reducing dependencies on `MAX_LOD_COUNT`. 

Garbage that was generated by the depth manager has been eliminated as well.