### PR TITLE
Refactor depth cache shaders

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
@@ -49,22 +49,6 @@ namespace Crest
             }
         }
 
-        private void OnEnable()
-        {
-            if (UseGeometryShader)
-            {
-                Shader.EnableKeyword(ENABLE_GEOMETRY_SHADER_KEYWORD);
-            }
-        }
-
-        private void OnDisable()
-        {
-            if (UseGeometryShader)
-            {
-                Shader.DisableKeyword(ENABLE_GEOMETRY_SHADER_KEYWORD);
-            }
-        }
-
         public static string ShaderName
         {
             get

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
@@ -53,6 +53,11 @@ namespace Crest
         {
             get
             {
+                // Although GS and CS version of this shader are *identical*
+                // besides having a #define enabled/disabled - Unity doesn't
+                // support using keywords to enable/disable shader pipeline
+                // stages (like `#pragma geometry`) so we have to split them
+                // out into separate files unfortunately.
                 if (UseGeometryShader)
                 {
                     return "Crest/Inputs/Depth/Cached Depths Geometry";

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
@@ -24,46 +24,60 @@ namespace Crest
         private static int sp_CurrentLodCount = Shader.PropertyToID("_CurrentLodCount");
         private const string ENABLE_GEOMETRY_SHADER_KEYWORD = "_ENABLE_GEOMETRY_SHADER";
 
-        private static bool UseGeometryShader { get {
-            // Only use geometry shader if target device supports it.
-            // See https://docs.unity3d.com/2018.1/Documentation/Manual/SL-ShaderCompileTargets.html
-            // See https://docs.unity3d.com/ScriptReference/SystemInfo-graphicsShaderLevel.html
+        private static bool UseGeometryShader
+        {
+            get
+            {
+                // Only use geometry shader if target device supports it.
+                // See https://docs.unity3d.com/2018.1/Documentation/Manual/SL-ShaderCompileTargets.html
+                // See https://docs.unity3d.com/ScriptReference/SystemInfo-graphicsShaderLevel.html
 #if PLATFORM_ANDROID
             if(SystemInfo.graphicsDeviceType == GraphicsDeviceType.Vulkan)
             {
                 return false;
             }
 #endif
-            if (SystemInfo.graphicsDeviceType == GraphicsDeviceType.Metal)
-            {
-                return false;
+                if (SystemInfo.graphicsDeviceType == GraphicsDeviceType.Metal)
+                {
+                    return false;
+                }
+                if (SystemInfo.graphicsShaderLevel <= 35 || SystemInfo.graphicsShaderLevel == 45)
+                {
+                    return false;
+                }
+                return true;
             }
-            if(SystemInfo.graphicsShaderLevel <= 35 || SystemInfo.graphicsShaderLevel == 45)
-            {
-                return false;
-            }
-            return true;
-        }}
-
-        public static string ShaderName { get {
-            if(UseGeometryShader)
-            {
-                return "Crest/Inputs/Depth/Cached Depths";
-            }
-            else
-            {
-                return "Crest/Inputs/Depth/Cached Depths Geometry";
-            }
-        }}
+        }
 
         private void OnEnable()
         {
-            if(UseGeometryShader) { Shader.EnableKeyword(ENABLE_GEOMETRY_SHADER_KEYWORD); }
+            if (UseGeometryShader)
+            {
+                Shader.EnableKeyword(ENABLE_GEOMETRY_SHADER_KEYWORD);
+            }
         }
 
         private void OnDisable()
         {
-            if(UseGeometryShader) { Shader.DisableKeyword(ENABLE_GEOMETRY_SHADER_KEYWORD); }
+            if (UseGeometryShader)
+            {
+                Shader.DisableKeyword(ENABLE_GEOMETRY_SHADER_KEYWORD);
+            }
+        }
+
+        public static string ShaderName
+        {
+            get
+            {
+                if (UseGeometryShader)
+                {
+                    return "Crest/Inputs/Depth/Cached Depths";
+                }
+                else
+                {
+                    return "Crest/Inputs/Depth/Cached Depths Geometry";
+                }
+            }
         }
 
         public override void BuildCommandBuffer(OceanRenderer ocean, CommandBuffer buf)
@@ -76,7 +90,8 @@ namespace Crest
                 return;
             }
 
-            if(UseGeometryShader) {
+            if (UseGeometryShader)
+            {
                 buf.SetRenderTarget(_targets, 0, CubemapFace.Unknown, -1);
                 buf.ClearRenderTarget(false, true, Color.white * 1000f);
 

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
@@ -55,11 +55,11 @@ namespace Crest
             {
                 if (UseGeometryShader)
                 {
-                    return "Crest/Inputs/Depth/Cached Depths";
+                    return "Crest/Inputs/Depth/Cached Depths Geometry";
                 }
                 else
                 {
-                    return "Crest/Inputs/Depth/Cached Depths Geometry";
+                    return "Crest/Inputs/Depth/Cached Depths";
                 }
             }
         }

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/OceanDepthsCache.shader
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/OceanDepthsCache.shader
@@ -25,6 +25,9 @@ Shader "Crest/Inputs/Depth/Cached Depths Geometry"
 			#pragma vertex Vert
 			#pragma fragment Frag
 
+			#include "UnityCG.cginc"
+			#include "../../OceanLODData.hlsl"
+
 			#define SlicedVaryings Varyings
 			#include "OceanDepthsCacheCommon.hlsl"
 

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/OceanDepthsCache.shader
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/OceanDepthsCache.shader
@@ -2,7 +2,6 @@
 
 // This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
 
-
 // Draw cached depths into current frame ocean depth data
 Shader "Crest/Inputs/Depth/Cached Depths Geometry"
 {
@@ -26,14 +25,8 @@ Shader "Crest/Inputs/Depth/Cached Depths Geometry"
 
 			#include "UnityCG.cginc"
 			#include "../../OceanLODData.hlsl"
-
-			#define SlicedVaryings Varyings
 			#include "OceanDepthsCacheCommon.hlsl"
 
-			float4 ObjectToPosition(float3 positionOS)
-			{
-				return UnityObjectToClipPos(positionOS);
-			}
 			ENDCG
 		}
 	}

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/OceanDepthsCache.shader
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/OceanDepthsCache.shader
@@ -23,6 +23,10 @@ Shader "Crest/Inputs/Depth/Cached Depths Geometry"
 			#pragma vertex Vert
 			#pragma fragment Frag
 
+			sampler2D _MainTex;
+			float4 _MainTex_ST;
+			int _CurrentLodCount;
+
 			#include "UnityCG.cginc"
 			#include "../../OceanLODData.hlsl"
 			#include "OceanDepthsCacheCommon.hlsl"

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/OceanDepthsCache.shader
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/OceanDepthsCache.shader
@@ -23,14 +23,16 @@ Shader "Crest/Inputs/Depth/Cached Depths"
 			#pragma vertex Vert
 			#pragma fragment Frag
 
+			#include "../../OceanLODData.hlsl"
+
 			sampler2D _MainTex;
 			float4 _MainTex_ST;
 			int _CurrentLodCount;
+			float4x4 _SliceViewProjMatrices[MAX_LOD_COUNT];
 
 			#include "UnityCG.cginc"
-			#include "../../OceanLODData.hlsl"
-			#include "OceanDepthsCacheCommon.hlsl"
 
+			#include "OceanDepthsCacheCommon.hlsl"
 			ENDCG
 		}
 	}

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/OceanDepthsCache.shader
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/OceanDepthsCache.shader
@@ -3,7 +3,7 @@
 // This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
 
 // Draw cached depths into current frame ocean depth data
-Shader "Crest/Inputs/Depth/Cached Depths Geometry"
+Shader "Crest/Inputs/Depth/Cached Depths"
 {
 	Properties
 	{

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/OceanDepthsCache.shader
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/OceanDepthsCache.shader
@@ -21,7 +21,6 @@ Shader "Crest/Inputs/Depth/Cached Depths Geometry"
 			BlendOp Min
 
 			CGPROGRAM
-			#pragma multi_compile_local __ _ENABLE_GEOMETRY_SHADER
 			#pragma vertex Vert
 			#pragma fragment Frag
 

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/OceanDepthsCacheCommon.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/OceanDepthsCacheCommon.hlsl
@@ -2,10 +2,6 @@
 
 // This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
 
-sampler2D _MainTex;
-float4 _MainTex_ST;
-int _CurrentLodCount;
-
 struct Attributes
 {
 	float3 positionOS : POSITION;

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/OceanDepthsCacheCommon.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/OceanDepthsCacheCommon.hlsl
@@ -1,5 +1,6 @@
-#include "UnityCG.cginc"
-#include "../../OceanLODData.hlsl"
+// Crest Ocean System
+
+// This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
 
 sampler2D _MainTex;
 float4 _MainTex_ST;

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/OceanDepthsCacheGeometry.shader
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/OceanDepthsCacheGeometry.shader
@@ -3,7 +3,7 @@
 // This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
 
 // Draw cached depths into current frame ocean depth data
-Shader "Crest/Inputs/Depth/Cached Depths"
+Shader "Crest/Inputs/Depth/Cached Depths Geometry"
 {
 	Properties
 	{

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/OceanDepthsCacheGeometry.shader
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/OceanDepthsCacheGeometry.shader
@@ -2,7 +2,6 @@
 
 // This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
 
-
 // Draw cached depths into current frame ocean depth data
 Shader "Crest/Inputs/Depth/Cached Depths"
 {
@@ -31,6 +30,10 @@ Shader "Crest/Inputs/Depth/Cached Depths"
 				float2 uv : TEXCOORD0;
 				uint sliceIndex : SV_RenderTargetArrayIndex;
 			};
+
+			#include "UnityCG.cginc"
+			#include "../../OceanLODData.hlsl"
+
 			#include "OceanDepthsCacheCommon.hlsl"
 
 			float4x4 _SliceViewProjMatrices[MAX_LOD_COUNT];

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/OceanDepthsCacheGeometry.shader
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/OceanDepthsCacheGeometry.shader
@@ -34,28 +34,8 @@ Shader "Crest/Inputs/Depth/Cached Depths Geometry"
 			float4x4 _SliceViewProjMatrices[MAX_LOD_COUNT];
 
 			#include "UnityCG.cginc"
-			#include "OceanDepthsCacheCommon.hlsl"
 
-			[maxvertexcount(MAX_LOD_COUNT * 3)]
-			void Geometry(
-				triangle Varyings input[3],
-				inout TriangleStream<Varyings> outStream
-			)
-			{
-				Varyings output;
-				for(int sliceIndex = 0; sliceIndex < _CurrentLodCount; sliceIndex++)
-				{
-					output.sliceIndex = sliceIndex;
-					for(int vertex = 0; vertex < 3; vertex++)
-					{
-						// Project to each slice
-						output.position = mul(_SliceViewProjMatrices[sliceIndex], input[vertex].position);
-						output.uv = input[vertex].uv;
-						outStream.Append(output);
-					}
-					outStream.RestartStrip();
-				}
-			}
+			#include "OceanDepthsCacheCommon.hlsl"
 			ENDCG
 		}
 	}

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/OceanDepthsCacheGeometry.shader
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/OceanDepthsCacheGeometry.shader
@@ -26,13 +26,14 @@ Shader "Crest/Inputs/Depth/Cached Depths"
 
 			#define CREST_OCEAN_DEPTHS_GEOM_SHADER_ON
 
+			#include "../../OceanLODData.hlsl"
+
 			sampler2D _MainTex;
 			float4 _MainTex_ST;
 			int _CurrentLodCount;
 			float4x4 _SliceViewProjMatrices[MAX_LOD_COUNT];
 
 			#include "UnityCG.cginc"
-			#include "../../OceanLODData.hlsl"
 			#include "OceanDepthsCacheCommon.hlsl"
 
 			[maxvertexcount(MAX_LOD_COUNT * 3)]

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/OceanDepthsCacheGeometry.shader
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/OceanDepthsCacheGeometry.shader
@@ -29,12 +29,11 @@ Shader "Crest/Inputs/Depth/Cached Depths"
 			sampler2D _MainTex;
 			float4 _MainTex_ST;
 			int _CurrentLodCount;
+			float4x4 _SliceViewProjMatrices[MAX_LOD_COUNT];
 
 			#include "UnityCG.cginc"
 			#include "../../OceanLODData.hlsl"
 			#include "OceanDepthsCacheCommon.hlsl"
-
-			float4x4 _SliceViewProjMatrices[MAX_LOD_COUNT];
 
 			[maxvertexcount(MAX_LOD_COUNT * 3)]
 			void Geometry(

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/OceanDepthsCacheGeometry.shader
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/OceanDepthsCacheGeometry.shader
@@ -24,43 +24,28 @@ Shader "Crest/Inputs/Depth/Cached Depths"
  			#pragma geometry Geometry
 			#pragma fragment Frag
 
-			struct SlicedVaryings
-			{
-				float4 position : SV_POSITION;
-				float2 uv : TEXCOORD0;
-				uint sliceIndex : SV_RenderTargetArrayIndex;
-			};
+			#define CREST_OCEAN_DEPTHS_GEOM_SHADER_ON
 
 			#include "UnityCG.cginc"
 			#include "../../OceanLODData.hlsl"
-
 			#include "OceanDepthsCacheCommon.hlsl"
 
 			float4x4 _SliceViewProjMatrices[MAX_LOD_COUNT];
-			float4 ObjectToPosition(float3 positionOS)
-			{
-				return mul(unity_ObjectToWorld, float4(positionOS, 1));
-			}
-
-
-			float4 WorldToClipPos(float4 positionWS, uint sliceIndex)
-			{
-				return mul(_SliceViewProjMatrices[sliceIndex], positionWS);
-			}
 
 			[maxvertexcount(MAX_LOD_COUNT * 3)]
 			void Geometry(
 				triangle Varyings input[3],
-				inout TriangleStream<SlicedVaryings> outStream
+				inout TriangleStream<Varyings> outStream
 			)
 			{
-				SlicedVaryings output;
+				Varyings output;
 				for(int sliceIndex = 0; sliceIndex < _CurrentLodCount; sliceIndex++)
 				{
 					output.sliceIndex = sliceIndex;
 					for(int vertex = 0; vertex < 3; vertex++)
 					{
-						output.position = WorldToClipPos(input[vertex].position, sliceIndex);
+						// Project to each slice
+						output.position = mul(_SliceViewProjMatrices[sliceIndex], input[vertex].position);
 						output.uv = input[vertex].uv;
 						outStream.Append(output);
 					}

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/OceanDepthsCacheGeometry.shader
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/OceanDepthsCacheGeometry.shader
@@ -26,6 +26,10 @@ Shader "Crest/Inputs/Depth/Cached Depths"
 
 			#define CREST_OCEAN_DEPTHS_GEOM_SHADER_ON
 
+			sampler2D _MainTex;
+			float4 _MainTex_ST;
+			int _CurrentLodCount;
+
 			#include "UnityCG.cginc"
 			#include "../../OceanLODData.hlsl"
 			#include "OceanDepthsCacheCommon.hlsl"


### PR DESCRIPTION
As discussed on discord. I took one of your thumbs up emojis as a "go for it" :). This might be best reviewed by-commit as i re-org'd them into logical change sets before pushing (mostly).

The main thing to review - it doesnt seem to me that the GS shader feature/multi compile was being used? I tested with GS turned on/off and the new code seems to work (in main.unity).

A future step could be to bring back the multi compile actually, and unify into one shader - it might be that only one line in the .shader file needs to be turned on/off with the multicompile:

 			#pragma geometry Geometry
