### PR TITLE
Change ocean input registration to allow ocean to be switched on/off

### DIFF
--- a/crest/Assets/Crest/Crest-Examples/Main/Scenes/main.unity
+++ b/crest/Assets/Crest/Crest-Examples/Main/Scenes/main.unity
@@ -420,7 +420,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &847119698
 Transform:
   m_ObjectHideFlags: 0
@@ -958,7 +958,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1899543705}
   m_LocalRotation: {x: -0, y: 0.27672777, z: -0, w: 0.96094835}
-  m_LocalPosition: {x: 0, y: 5, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 540, y: 540, z: 540}
   m_Children: []
   m_Father: {fileID: 1591410378}

--- a/crest/Assets/Crest/Crest-Examples/Main/Scenes/main.unity
+++ b/crest/Assets/Crest/Crest-Examples/Main/Scenes/main.unity
@@ -420,7 +420,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!4 &847119698
 Transform:
   m_ObjectHideFlags: 0

--- a/crest/Assets/Crest/Crest-Examples/Shared/Scripts/OceanDebugGUI.cs
+++ b/crest/Assets/Crest/Crest-Examples/Shared/Scripts/OceanDebugGUI.cs
@@ -10,7 +10,7 @@ public class OceanDebugGUI : MonoBehaviour
     [SerializeField] bool _showSimTargets = false;
     [SerializeField] bool _guiVisible = true;
     static float _leftPanelWidth = 180f;
-    ShapeGerstnerBatched[] gerstners;
+    ShapeGerstnerBatched[] _gerstners;
 
     static Dictionary<System.Type, bool> _drawTargets = new Dictionary<System.Type, bool>();
     static Dictionary<System.Type, string> _simNames = new Dictionary<System.Type, string>();
@@ -27,15 +27,18 @@ public class OceanDebugGUI : MonoBehaviour
             enabled = false;
             return;
         }
-
-        gerstners = FindObjectsOfType<ShapeGerstnerBatched>();
-        // i am getting the array in the reverse order compared to the hierarchy which bugs me. sort them based on sibling index,
-        // which helps if the gerstners are on sibling GOs.
-        System.Array.Sort(gerstners, (a, b) => a.transform.GetSiblingIndex().CompareTo(b.transform.GetSiblingIndex()));
     }
 
     private void Update()
     {
+        if(_gerstners == null)
+        {
+            _gerstners = FindObjectsOfType<ShapeGerstnerBatched>();
+            // i am getting the array in the reverse order compared to the hierarchy which bugs me. sort them based on sibling index,
+            // which helps if the gerstners are on sibling GOs.
+            System.Array.Sort(_gerstners, (a, b) => a.transform.GetSiblingIndex().CompareTo(b.transform.GetSiblingIndex()));
+        }
+
         if (Input.GetKeyDown(KeyCode.G))
         {
             ToggleGUI();
@@ -76,7 +79,7 @@ public class OceanDebugGUI : MonoBehaviour
             }
 
             GUI.Label(new Rect(x, y, w, h), "Gerstner weight(s)"); y += h;
-            foreach (var gerstner in gerstners)
+            foreach (var gerstner in _gerstners)
             {
                 var specW = 75f;
                 gerstner._weight = GUI.HorizontalSlider(new Rect(x, y, w - specW - 5f, h), gerstner._weight, 0f, 1f);

--- a/crest/Assets/Crest/Crest-Examples/Shared/Scripts/OceanDebugGUI.cs
+++ b/crest/Assets/Crest/Crest-Examples/Shared/Scripts/OceanDebugGUI.cs
@@ -22,7 +22,7 @@ public class OceanDebugGUI : MonoBehaviour
 
     private void Update()
     {
-        if(_gerstners == null)
+        if (_gerstners == null)
         {
             _gerstners = FindObjectsOfType<ShapeGerstnerBatched>();
             // i am getting the array in the reverse order compared to the hierarchy which bugs me. sort them based on sibling index,
@@ -107,7 +107,7 @@ public class OceanDebugGUI : MonoBehaviour
                 GUI.Label(new Rect(x, y, w, h), string.Format("Coll Queue Lengths: [{0}, {1}]", min, max)); y += h;
             }
 
-            if(OceanRenderer.Instance)
+            if (OceanRenderer.Instance)
             {
                 if (OceanRenderer.Instance._simSettingsAnimatedWaves.CachedHeightQueries)
                 {

--- a/crest/Assets/Crest/Crest-Examples/Shared/Scripts/OceanDebugGUI.cs
+++ b/crest/Assets/Crest/Crest-Examples/Shared/Scripts/OceanDebugGUI.cs
@@ -20,15 +20,6 @@ public class OceanDebugGUI : MonoBehaviour
         return screenPosition.x < _leftPanelWidth;
     }
 
-    private void Start()
-    {
-        if (OceanRenderer.Instance == null)
-        {
-            enabled = false;
-            return;
-        }
-    }
-
     private void Update()
     {
         if(_gerstners == null)
@@ -116,18 +107,31 @@ public class OceanDebugGUI : MonoBehaviour
                 GUI.Label(new Rect(x, y, w, h), string.Format("Coll Queue Lengths: [{0}, {1}]", min, max)); y += h;
             }
 
-            if (OceanRenderer.Instance._simSettingsAnimatedWaves.CachedHeightQueries)
+            if(OceanRenderer.Instance)
             {
-                var cache = OceanRenderer.Instance.CollisionProvider as CollProviderCache;
-                // generates garbage
-                GUI.Label(new Rect(x, y, w, h), string.Format("Cache hits: {0}/{1}", cache.CacheHits, cache.CacheChecks)); y += h;
-            }
+                if (OceanRenderer.Instance._simSettingsAnimatedWaves.CachedHeightQueries)
+                {
+                    var cache = OceanRenderer.Instance.CollisionProvider as CollProviderCache;
+                    // generates garbage
+                    GUI.Label(new Rect(x, y, w, h), string.Format("Cache hits: {0}/{1}", cache.CacheHits, cache.CacheChecks)); y += h;
+                }
 
-            if (OceanRenderer.Instance._lodDataDynWaves != null)
-            {
-                int steps; float dt;
-                OceanRenderer.Instance._lodDataDynWaves.GetSimSubstepData(Time.deltaTime, out steps, out dt);
-                GUI.Label(new Rect(x, y, w, h), string.Format("Sim steps: {0:0.00000} x {1}", dt, steps)); y += h;
+                if (OceanRenderer.Instance._lodDataDynWaves != null)
+                {
+                    int steps; float dt;
+                    OceanRenderer.Instance._lodDataDynWaves.GetSimSubstepData(Time.deltaTime, out steps, out dt);
+                    GUI.Label(new Rect(x, y, w, h), string.Format("Sim steps: {0:0.00000} x {1}", dt, steps)); y += h;
+                }
+
+#if UNITY_EDITOR
+                if (GUI.Button(new Rect(x, y, w, h), "Select Ocean Mat"))
+                {
+                    var path = UnityEditor.AssetDatabase.GetAssetPath(OceanRenderer.Instance.OceanMaterial);
+                    var asset = UnityEditor.AssetDatabase.LoadMainAssetAtPath(path);
+                    UnityEditor.Selection.activeObject = asset;
+                }
+                y += h;
+#endif
             }
 
             if (GUI.Button(new Rect(x, y, w, h), "Hide GUI (G)"))
@@ -135,16 +139,6 @@ public class OceanDebugGUI : MonoBehaviour
                 ToggleGUI();
             }
             y += h;
-
-#if UNITY_EDITOR
-            if (GUI.Button(new Rect(x, y, w, h), "Select Ocean Mat"))
-            {
-                var path = UnityEditor.AssetDatabase.GetAssetPath(OceanRenderer.Instance.OceanMaterial);
-                var asset = UnityEditor.AssetDatabase.LoadMainAssetAtPath(path);
-                UnityEditor.Selection.activeObject = asset;
-            }
-            y += h;
-#endif
         }
 
         // draw source textures to screen
@@ -158,6 +152,8 @@ public class OceanDebugGUI : MonoBehaviour
 
     void DrawShapeTargets()
     {
+        if (OceanRenderer.Instance == null) return;
+
         // draw sim data
         float column = 1f;
 

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgr.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgr.cs
@@ -2,7 +2,6 @@
 
 // This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
 
-using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Rendering;
 
@@ -40,8 +39,6 @@ namespace Crest
 
         int _scaleDifferencePow2 = 0;
         protected int ScaleDifferencePow2 { get { return _scaleDifferencePow2; } }
-
-        protected List<ILodDataInput> _drawList = new List<ILodDataInput>();
 
         protected virtual void Start()
         {
@@ -141,30 +138,6 @@ namespace Crest
         {
         }
 
-        public void AddDraw(ILodDataInput data)
-        {
-            if (OceanRenderer.Instance == null)
-            {
-                // Ocean has unloaded, clear out
-                _drawList.Clear();
-                return;
-            }
-
-            _drawList.Add(data);
-        }
-
-        public void RemoveDraw(ILodDataInput data)
-        {
-            if (OceanRenderer.Instance == null)
-            {
-                // Ocean has unloaded, clear out
-                _drawList.Clear();
-                return;
-            }
-
-            _drawList.Remove(data);
-        }
-
         protected void SwapRTs(ref RenderTexture o_a, ref RenderTexture o_b)
         {
             var temp = o_a;
@@ -184,7 +157,8 @@ namespace Crest
 
             lt.SetViewProjectionMatrices(lodIdx, buf);
 
-            foreach (var draw in _drawList)
+            var drawList = RegisterLodDataInputBase.GetRegistrar(GetType());
+            foreach (var draw in drawList)
             {
                 draw.Draw(buf, 1f, 0);
             }
@@ -197,7 +171,8 @@ namespace Crest
 
             lt.SetViewProjectionMatrices(lodIdx, buf);
 
-            foreach (var draw in _drawList)
+            var drawList = RegisterLodDataInputBase.GetRegistrar(GetType());
+            foreach (var draw in drawList)
             {
                 if (!draw.Enabled)
                 {

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrFlow.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrFlow.cs
@@ -56,7 +56,8 @@ namespace Crest
             base.BuildCommandBuffer(ocean, buf);
 
             // if there is nothing in the scene tagged up for depth rendering, and we have cleared the RTs, then we can early out
-            if (_drawList.Count == 0 && _targetsClear)
+            var drawList = RegisterLodDataInputBase.GetRegistrar(GetType());
+            if (drawList.Count == 0 && _targetsClear)
             {
                 return;
             }
@@ -70,7 +71,7 @@ namespace Crest
             }
 
             // targets have now been cleared, we can early out next time around
-            if (_drawList.Count == 0)
+            if (drawList.Count == 0)
             {
                 _targetsClear = true;
             }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
@@ -71,7 +71,8 @@ namespace Crest
             base.BuildCommandBuffer(ocean, buf);
 
             // if there is nothing in the scene tagged up for depth rendering, and we have cleared the RTs, then we can early out
-            if (_drawList.Count == 0 && _targetsClear)
+            var drawList = RegisterLodDataInputBase.GetRegistrar(GetType());
+            if (drawList.Count == 0 && _targetsClear)
             {
                 return;
             }
@@ -94,7 +95,7 @@ namespace Crest
                 buf.SetGlobalMatrixArray(sp_SliceViewProjMatrices, matrixArray);
                 buf.SetGlobalInt(sp_CurrentLodCount, OceanRenderer.Instance.CurrentLodCount);
 
-                foreach (var draw in _drawList)
+                foreach (var draw in drawList)
                 {
                     draw.Draw(buf, 1f, 0);
                 }
@@ -111,7 +112,7 @@ namespace Crest
             }
 
             // targets have now been cleared, we can early out next time around
-            if (_drawList.Count == 0)
+            if (drawList.Count == 0)
             {
                 _targetsClear = true;
             }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
@@ -48,12 +48,6 @@ namespace Crest
                 return;
             }
 
-            if (OceanRenderer.Instance == null)
-            {
-                enabled = false;
-                return;
-            }
-
             if (_populateOnStartup)
             {
                 PopulateCache();
@@ -146,8 +140,18 @@ namespace Crest
                 _camDepthCache.gameObject.SetActive(false);
             }
 
+            // Shader needs sea level to determine water depth
+            var centerPoint = Vector3.zero;
+            if (OceanRenderer.Instance != null)
+            {
+                centerPoint.y = OceanRenderer.Instance.transform.position.y;
+            }
+            else
+            {
+                centerPoint.y = transform.position.y;
+            }
             // Hackety-hack: this seems to be the only way to pass parameters to the shader when using RenderWithShader!
-            Shader.SetGlobalVector("_OceanCenterPosWorld", OceanRenderer.Instance.transform.position);
+            Shader.SetGlobalVector("_OceanCenterPosWorld", centerPoint);
             _camDepthCache.RenderWithShader(Shader.Find("Crest/Inputs/Depth/Ocean Depth From Geometry"), null);
         }
 

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
@@ -2,6 +2,7 @@
 
 // This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
 
+using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Rendering;
 
@@ -25,6 +26,19 @@ namespace Crest
 
         public static int sp_Weight = Shader.PropertyToID("_Weight");
 
+        static Dictionary<System.Type, List<ILodDataInput>> _registrar = new Dictionary<System.Type, List<ILodDataInput>>();
+
+        public static List<ILodDataInput> GetRegistrar(System.Type lodDataMgrType)
+        {
+            List<ILodDataInput> registered;
+            if (!_registrar.TryGetValue(lodDataMgrType, out registered))
+            {
+                registered = new List<ILodDataInput>();
+                _registrar.Add(lodDataMgrType, registered);
+            }
+            return registered;
+        }
+
         Renderer _renderer;
         Material[] _materials = new Material[2];
 
@@ -32,7 +46,7 @@ namespace Crest
         {
             _renderer = GetComponent<Renderer>();
 
-            if(_renderer)
+            if (_renderer)
             {
                 _materials[0] = _renderer.sharedMaterial;
                 _materials[1] = new Material(_renderer.sharedMaterial);
@@ -44,7 +58,7 @@ namespace Crest
             if (_renderer && weight > 0f)
             {
                 _materials[isTransition].SetFloat(sp_Weight, weight);
-                
+
                 buf.DrawRenderer(_renderer, _materials[isTransition]);
             }
         }
@@ -60,34 +74,25 @@ namespace Crest
 
         protected virtual void OnEnable()
         {
-            var rend = GetComponent<Renderer>();
-            var ocean = OceanRenderer.Instance;
-            if (rend && ocean)
+            if (_disableRenderer)
             {
-                if (_disableRenderer)
+                var rend = GetComponent<Renderer>();
+                if (rend)
                 {
                     rend.enabled = false;
                 }
-
-                var ld = ocean.GetComponent<LodDataType>();
-                if (ld)
-                {
-                    ld.AddDraw(this);
-                }
             }
+
+            var registrar = GetRegistrar(typeof(LodDataType));
+            registrar.Add(this);
         }
 
         protected virtual void OnDisable()
         {
-            var rend = GetComponent<Renderer>();
-            var ocean = OceanRenderer.Instance;
-            if (rend && ocean)
+            var registered = GetRegistrar(typeof(LodDataType));
+            if (registered != null)
             {
-                var ld = ocean.GetComponent<LodDataType>();
-                if (ld)
-                {
-                    ld.RemoveDraw(this);
-                }
+                registered.Remove(this);
             }
         }
     }

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -199,8 +199,10 @@ namespace Crest
 
         void InitTimeProvider()
         {
-            if (_timeProvider == null)
+            // Used assigned time provider, or use one attached to this game object
+            if (_timeProvider == null && (_timeProvider = GetComponent<TimeProviderBase>()) == null)
             {
+                // None found - create
                 _timeProvider = gameObject.AddComponent<TimeProviderDefault>();
             }
         }

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
@@ -245,6 +245,16 @@ namespace Crest
             {
                 _batches[i] = new GerstnerBatch(_waveShader, _directTowardsPoint);
             }
+
+            // Submit draws to create the Gerstner waves. LODs from 0 to N-2 render the Gerstner waves from their lod. Additionally, any waves
+            // in the biggest lod, or too big for the biggest lod, are rendered into both of the last two LODs N-1 and N-2, as this allows us to
+            // move these waves between LODs without pops when the camera changes heights and the LODs need to change scale.
+
+            var registered = RegisterLodDataInputBase.GetRegistrar(typeof(LodDataMgrAnimWaves));
+            foreach (var batch in _batches)
+            {
+                registered.Add(batch);
+            }
         }
 
         /// <summary>
@@ -433,29 +443,17 @@ namespace Crest
             }
         }
 
-        /// <summary>
-        /// Submit draws to create the Gerstner waves. LODs from 0 to N-2 render the Gerstner waves from their lod. Additionally, any waves
-        /// in the biggest lod, or too big for the biggest lod, are rendered into both of the last two LODs N-1 and N-2, as this allows us to
-        /// move these waves between LODs without pops when the camera changes heights and the LODs need to change scale.
-        /// </summary>
-        void OnEnable()
-        {
-            if (_batches == null)
-            {
-                InitBatches();
-            }
-
-            foreach (var batch in _batches)
-            {
-                OceanRenderer.Instance._lodDataAnimWaves.AddDraw(batch);
-            }
-        }
-
         void OnDisable()
         {
-            foreach (var batch in _batches)
+            if (OceanRenderer.Instance != null && _batches != null)
             {
-                OceanRenderer.Instance._lodDataAnimWaves.RemoveDraw(batch);
+                var registered = RegisterLodDataInputBase.GetRegistrar(typeof(LodDataMgrAnimWaves));
+                foreach (var batch in _batches)
+                {
+                    registered.Remove(batch);
+                }
+
+                _batches = null;
             }
         }
 


### PR DESCRIPTION
Should fix #285.

Made lists of ocean inputs static and moved them outside loddatamgr classes so that registration happens even if ocean structure has not been created. This means scene can initialised without ocean active/present, and it can be enabled later and find its inputs.