### PR TITLE
Disable geometry shaders on PS4

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
@@ -30,7 +30,7 @@ namespace Crest
             {
                 // Only use geometry shader if target device supports it.
                 // Check for specific platforms which have poor/lacking geometry
-                // shader support first, before
+                // shader support first, before checking runtime platform info.
 #if UNITY_PS4 || UNITY_ANDROID || UNITY_IOS
                 // Mobile Devices don't support geometry shaders at all in a way
                 // that makes sense to support them:

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
@@ -29,23 +29,30 @@ namespace Crest
             get
             {
                 // Only use geometry shader if target device supports it.
+                // Check for specific platforms which have poor/lacking geometry
+                // shader support first, before
+#if UNITY_PS4 || UNITY_ANDROID || UNITY_IOS
+                // Mobile Devices don't support geometry shaders at all in a way
+                // that makes sense to support them:
+                // https://www.reddit.com/r/vulkan/comments/91q0qx/do_geometry_shaders_still_suck/
+
+                // Note: Whilst the PS4 supports geometry shaders, we get weird
+                // stippling artifacts which need to be investigated:
+                // https://github.com/crest-ocean/crest/issues/290
+                return false;
+#else
+                // Check runtime platform info for geometry shader support just
+                // in case.
                 // See https://docs.unity3d.com/2018.1/Documentation/Manual/SL-ShaderCompileTargets.html
                 // See https://docs.unity3d.com/ScriptReference/SystemInfo-graphicsShaderLevel.html
-#if PLATFORM_ANDROID
-            if(SystemInfo.graphicsDeviceType == GraphicsDeviceType.Vulkan)
-            {
-                return false;
-            }
-#endif
-                if (SystemInfo.graphicsDeviceType == GraphicsDeviceType.Metal)
-                {
-                    return false;
-                }
-                if (SystemInfo.graphicsShaderLevel <= 35 || SystemInfo.graphicsShaderLevel == 45)
+                if (SystemInfo.graphicsShaderLevel <= 35 ||
+                    SystemInfo.graphicsShaderLevel == 45 ||
+                    SystemInfo.graphicsDeviceType == GraphicsDeviceType.Metal)
                 {
                     return false;
                 }
                 return true;
+#endif
             }
         }
 


### PR DESCRIPTION
Furthermore, cleanup how geometry shader support is reported in general.

The big change is that we now just disable geometry shader support on
all mobile devices, as they don't seem to have good support for them
anyway, even for APIs where they have them.

Resolves issue #290.