### PR TITLE
Max detail height affected only by waves

### DIFF
--- a/crest/Assets/Crest/Crest-Examples/Whirlpool/Scripts/Whirlpool.cs
+++ b/crest/Assets/Crest/Crest-Examples/Whirlpool/Scripts/Whirlpool.cs
@@ -79,7 +79,8 @@ namespace Crest
 
         void Update()
         {
-            OceanRenderer.Instance.ReportMaxDisplacementFromShape(0, _amplitude);
+            OceanRenderer.Instance.ReportMaxDisplacementFromShape(0f, _amplitude, 0f);
+
             UpdateMaterials();
         }
     }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterAnimWavesInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterAnimWavesInput.cs
@@ -21,9 +21,9 @@ namespace Crest
             }
         }
 
-        [SerializeField, Tooltip("Inform ocean how much this input will displace the shape vertically. This is used to set bounding box heights for the ocean tiles.")]
+        [SerializeField, Tooltip("Inform ocean how much this input will displace the ocean surface vertically. This is used to set bounding box heights for the ocean tiles.")]
         float _maxDisplacementVertical = 0f;
-        [SerializeField, Tooltip("Inform ocean how much this input will displace the shape horizontally. This is used to set bounding box widths for the ocean tiles.")]
+        [SerializeField, Tooltip("Inform ocean how much this input will displace the ocean surface horizontally. This is used to set bounding box widths for the ocean tiles.")]
         float _maxDisplacementHorizontal = 0f;
 
         [SerializeField, Tooltip("Use the bounding box of an attached renderer component to determine the max vertical displacement.")]
@@ -55,7 +55,7 @@ namespace Crest
 
             if (_maxDisplacementHorizontal > 0f || _maxDisplacementVertical > 0f)
             {
-                OceanRenderer.Instance.ReportMaxDisplacementFromShape(_maxDisplacementHorizontal, maxDispVert);
+                OceanRenderer.Instance.ReportMaxDisplacementFromShape(_maxDisplacementHorizontal, maxDispVert, 0f);
             }
         }
     }

--- a/crest/Assets/Crest/Crest/Scripts/OceanChunkRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanChunkRenderer.cs
@@ -158,9 +158,9 @@ namespace Crest
         // can change depending on view altitude
         public static void ExpandBoundsForDisplacements(Transform transform, ref Bounds bounds)
         {
-            float boundsPadding = OceanRenderer.Instance.MaxHorizDisplacement;
-            float expandXZ = boundsPadding / transform.lossyScale.x;
-            float boundsY = OceanRenderer.Instance.MaxVertDisplacement / transform.lossyScale.y;
+            var boundsPadding = OceanRenderer.Instance.MaxHorizDisplacement;
+            var expandXZ = boundsPadding / transform.lossyScale.x;
+            var boundsY = OceanRenderer.Instance.MaxVertDisplacement / transform.lossyScale.y;
             // extend the kinematic bounds slightly to give room for dynamic sim stuff
             boundsY = Mathf.Max(boundsY, 1f);
             bounds.extents = new Vector3(bounds.extents.x + expandXZ, boundsY, bounds.extents.z + expandXZ);

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -260,12 +260,12 @@ namespace Crest
             // reach maximum detail at slightly below sea level. this should combat cases where visual range can be lost
             // when water height is low and camera is suspended in air. i tried a scheme where it was based on difference
             // to water height but this does help with the problem of horizontal range getting limited at bad times.
-            float maxDetailY = SeaLevel - _maxVertDispFromShape / 5f;
-            // scale ocean mesh based on camera distance to sea level, to keep uniform detail.
-            float camY = Mathf.Max(Mathf.Abs(_viewpoint.position.y - SeaLevel) - maxDetailY, 0f);
+            float maxDetailY = SeaLevel - _maxVertDispFromWaves / 5f;
+            float camDistance = Mathf.Abs(_viewpoint.position.y - maxDetailY);
 
+            // scale ocean mesh based on camera distance to sea level, to keep uniform detail.
             const float HEIGHT_LOD_MUL = 2f;
-            float level = camY * HEIGHT_LOD_MUL;
+            float level = camDistance * HEIGHT_LOD_MUL;
             level = Mathf.Max(level, _minScale);
             if (_maxScale != -1f) level = Mathf.Min(level, 1.99f * _maxScale);
 
@@ -320,19 +320,22 @@ namespace Crest
         /// Shape scripts can report in how far they might displace the shape horizontally. The max value is saved here.
         /// Later the bounding boxes for the ocean tiles will be expanded to account for this potential displacement.
         /// </summary>
-        public void ReportMaxDisplacementFromShape(float maxHorizDisp, float maxVertDisp)
+        public void ReportMaxDisplacementFromShape(float maxHorizDisp, float maxVertDisp, float maxVertDispFromWaves)
         {
             if (Time.frameCount != _maxDisplacementCachedTime)
             {
-                _maxHorizDispFromShape = _maxVertDispFromShape = 0f;
+                _maxHorizDispFromShape = _maxVertDispFromShape = _maxVertDispFromWaves = 0f;
             }
 
             _maxHorizDispFromShape += maxHorizDisp;
             _maxVertDispFromShape += maxVertDisp;
+            _maxVertDispFromWaves += maxVertDispFromWaves;
 
             _maxDisplacementCachedTime = Time.frameCount;
         }
-        float _maxHorizDispFromShape = 0f, _maxVertDispFromShape = 0f;
+        float _maxHorizDispFromShape = 0f;
+        float _maxVertDispFromShape = 0f;
+        float _maxVertDispFromWaves = 0f;
         int _maxDisplacementCachedTime = 0;
         /// <summary>
         /// The maximum horizontal distance that the shape scripts are displacing the shape.

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -317,8 +317,8 @@ namespace Crest
         public bool ScaleCouldDecrease { get { return _minScale == -1f || transform.localScale.x > _minScale * 1.01f; } }
 
         /// <summary>
-        /// Shape scripts can report in how far they might displace the shape horizontally. The max value is saved here.
-        /// Later the bounding boxes for the ocean tiles will be expanded to account for this potential displacement.
+        /// User shape inputs can report in how far they might displace the shape horizontally and vertically. The max value is
+        /// saved here. Later the bounding boxes for the ocean tiles will be expanded to account for this potential displacement.
         /// </summary>
         public void ReportMaxDisplacementFromShape(float maxHorizDisp, float maxVertDisp, float maxVertDispFromWaves)
         {

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
@@ -225,7 +225,7 @@ namespace Crest
             {
                 ampSum += _amplitudes[i] * _spectrum._chopScales[i / _componentsPerOctave];
             }
-            OceanRenderer.Instance.ReportMaxDisplacementFromShape(ampSum * _spectrum._chop, ampSum);
+            OceanRenderer.Instance.ReportMaxDisplacementFromShape(ampSum * _spectrum._chop, ampSum, ampSum);
         }
 
         void InitBatches()


### PR DESCRIPTION
Max detail height - camera height relative to sea level where ocean is to minimum scale to maximise detail - was affected a lot by . It caused it to lower which mean ocean was not at full when camera was around sea level. Some lowering is ok - helps for gerstner waves which drop the average surface height lot - but the whirlpool should not lower it, so i've split out some so it can distuingish between gerstner displacements and other.

Editorial note: i doubt this is going to make any sense. maybe we can discuss it tomrrow. a second pair of eyes on testing might be useful if you find the time, no worries if not.
