### PR TITLE
Fix edit and continue in editor

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Helpers/PropertyWrapper.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/PropertyWrapper.cs
@@ -50,6 +50,7 @@ namespace Crest
         public MaterialPropertyBlock materialPropertyBlock { get; private set; }
     }
 
+    [System.Serializable]
     public class PropertyWrapperCompute : IPropertyWrapper
     {
         private CommandBuffer _commandBuffer = null;

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrAnimWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrAnimWaves.cs
@@ -36,14 +36,14 @@ namespace Crest
 
         const string ShaderName = "ShapeCombine";
 
-        static int krnl_ShapeCombine = -1;
-        static int krnl_ShapeCombine_DISABLE_COMBINE = -1;
-        static int krnl_ShapeCombine_FLOW_ON = -1;
-        static int krnl_ShapeCombine_FLOW_ON_DISABLE_COMBINE = -1;
-        static int krnl_ShapeCombine_DYNAMIC_WAVE_SIM_ON = -1;
-        static int krnl_ShapeCombine_DYNAMIC_WAVE_SIM_ON_DISABLE_COMBINE = -1;
-        static int krnl_ShapeCombine_FLOW_ON_DYNAMIC_WAVE_SIM_ON = -1;
-        static int krnl_ShapeCombine_FLOW_ON_DYNAMIC_WAVE_SIM_ON_DISABLE_COMBINE = -1;
+        int krnl_ShapeCombine = -1;
+        int krnl_ShapeCombine_DISABLE_COMBINE = -1;
+        int krnl_ShapeCombine_FLOW_ON = -1;
+        int krnl_ShapeCombine_FLOW_ON_DISABLE_COMBINE = -1;
+        int krnl_ShapeCombine_DYNAMIC_WAVE_SIM_ON = -1;
+        int krnl_ShapeCombine_DYNAMIC_WAVE_SIM_ON_DISABLE_COMBINE = -1;
+        int krnl_ShapeCombine_FLOW_ON_DYNAMIC_WAVE_SIM_ON = -1;
+        int krnl_ShapeCombine_FLOW_ON_DYNAMIC_WAVE_SIM_ON_DISABLE_COMBINE = -1;
 
         ComputeShader _combineShader;
         PropertyWrapperCompute _combineProperties;

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodTransform.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodTransform.cs
@@ -19,6 +19,7 @@ namespace Crest
         static int s_paramsOcean = Shader.PropertyToID("_LD_Params");
         static int s_paramsOceanSource = Shader.PropertyToID("_LD_Params_Source");
 
+        [System.Serializable]
         public struct RenderData
         {
             public float _texelWidth;


### PR DESCRIPTION
Makes it gracefully(ish) allow editing scripts and recompiling in play mode.

Its a shame about making the kernel indices non-static. An alternative would be to reinit them when a compilation is detected. Given that LodDataAnimWaves is basically a singleton anyway, i thought the below is ok.

Making RenderData serializable has the side effect of making it visible in LodTransform inspector, which is actually quite cool as it can be inspected at runtime.
