### PR TITLE
Sample in data from larger cascade for foam and shadow

### DIFF
--- a/crest/Assets/Crest/Crest/Materials/Ocean-Underwater.mat
+++ b/crest/Assets/Crest/Crest/Materials/Ocean-Underwater.mat
@@ -164,7 +164,7 @@ Material:
     - _DepthFogDensity: {r: 0.33, g: 0.23, b: 0.27, a: 1}
     - _Diffuse: {r: 0, g: 0.012440592, b: 0.5660378, a: 1}
     - _DiffuseGrazing: {r: 0.06345675, g: 0.10691091, b: 0.5849056, a: 1}
-    - _DiffuseShadow: {r: 0.21067381, g: 0.26255617, b: 0.294, a: 1}
+    - _DiffuseShadow: {r: 0, g: 0.3560004, b: 0.5647059, a: 1}
     - _FoamBubbleColor: {r: 0.5482029, g: 0.71300006, b: 0.7062737, a: 1}
     - _FoamWhiteColor: {r: 1, g: 0.99634784, b: 0.97199994, a: 0.6862745}
     - _SkyAwayFromSun: {r: 0.15419213, g: 0.22129796, b: 0.5372549, a: 1}

--- a/crest/Assets/Crest/Crest/Shaders/Resources/UpdateFoam.compute
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/UpdateFoam.compute
@@ -30,25 +30,33 @@ void UpdateFoam(uint3 id : SV_DispatchThreadID)
 	const float2 input_uv = IDtoUV(id.xy, width, height);
 	const float2 worldPosXZ = UVToWorld(input_uv, sliceIndex);
 	const float3 uv_slice = float3(input_uv, id.z);
-	const float3 uv_slice_source = WorldToUV_Source(worldPosXZ, sliceIndexSource);
-	// #if _FLOW_ON
-	half3 velocity = half3(_LD_TexArray_Flow.SampleLevel(LODData_linear_clamp_sampler, uv_slice, 0).xy, 0.0);
-	half foam = _LD_TexArray_Foam_Source.SampleLevel(LODData_linear_clamp_sampler, uv_slice_source
-		- ((_SimDeltaTime * _LD_Params_Source[sliceIndexSource].w) * velocity), 0
-		).x;
-	// #else
-	// // sampler will clamp the uv_slice currently
-	// half foam = tex2Dlod(_LD_TexArray_Foam_Source, uv_slice_source).x;
-	// #endif
 
+	half2 velocity = _LD_TexArray_Flow.SampleLevel(LODData_linear_clamp_sampler, uv_slice, 0).xy;
+	const float2 worldPosXZ_flowed = worldPosXZ - _SimDeltaTime * velocity;
+
+	half foam = 0.0;
+	const half r_max = 0.5 - _LD_Params_Source[sliceIndexSource].w;
+
+	const float3 uv_slice_source = WorldToUV_Source(worldPosXZ_flowed, sliceIndexSource);
 	half2 r = abs(uv_slice_source.xy - 0.5);
 
-	if (
-		(sliceIndexSource < 0) || (sliceIndexSource > depth) ||
-		(max(r.x, r.y) > 0.5 - _LD_Params_Source[sliceIndexSource].w)
-	) {
-		// no border wrap mode for RTs in unity it seems, so make any off-texture reads 0 manually
-		foam = 0.0;
+	if (sliceIndexSource < 0 || sliceIndexSource >= depth)
+	{
+		// Leave foam at 0 if going off the array
+	}
+	else if (max(r.x, r.y) <= r_max)
+	{
+		foam = _LD_TexArray_Foam_Source.SampleLevel(LODData_linear_clamp_sampler, uv_slice_source, 0).x;
+	}
+	else
+	{
+		// Try again from larger cascade
+		float3 uv_slice_source_nextlod = WorldToUV_Source(worldPosXZ_flowed, sliceIndexSource + 1.0);
+		half2 r2 = abs(uv_slice_source_nextlod.xy - 0.5);
+		if (max(r2.x, r2.y) <= r_max)
+		{
+			foam = _LD_TexArray_Foam_Source.SampleLevel(LODData_linear_clamp_sampler, uv_slice_source_nextlod, 0.0).x;
+		}
 	}
 
 	// fade

--- a/crest/Assets/Crest/Crest/Shaders/Resources/UpdateFoam.compute
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/UpdateFoam.compute
@@ -48,7 +48,7 @@ void UpdateFoam(uint3 id : SV_DispatchThreadID)
 	{
 		foam = _LD_TexArray_Foam_Source.SampleLevel(LODData_linear_clamp_sampler, uv_slice_source, 0).x;
 	}
-	else
+	else if (sliceIndexSource + 1.0 < depth)
 	{
 		// Try again from larger cascade
 		float3 uv_slice_source_nextlod = WorldToUV_Source(worldPosXZ_flowed, sliceIndexSource + 1.0);

--- a/crest/Assets/Crest/Crest/Shaders/Resources/UpdateShadow.compute
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/UpdateShadow.compute
@@ -124,14 +124,24 @@ void UpdateShadow(uint3 id : SV_DispatchThreadID)
 		shadowCoords.MainCameraCoords = mul(_MainCameraProjectionMatrix, wpos);
 	}
 
-	fixed2 shadow = 0.0;
+	half2 shadow = 0.0;
+	const half r_max = 0.5 - _LD_Params_Source[_LD_SliceIndex_Source].w;
 
 	// Shadow from last frame - manually implement black border
 	float3 uv_source = WorldToUV_Source(shadowCoords._WorldPosViewZ.xz, _LD_SliceIndex_Source);
 	half2 r = abs(uv_source.xy - 0.5);
-	if (max(r.x, r.y) < 0.49)
+	if (max(r.x, r.y) <= r_max)
 	{
 		SampleShadow(_LD_TexArray_Shadow_Source, uv_source, 1.0, shadow);
+	}
+	else
+	{
+		float3 uv_source_nextlod = WorldToUV_Source(shadowCoords._WorldPosViewZ.xz, _LD_SliceIndex_Source + 1.0);
+		half2 r2 = abs(uv_source_nextlod.xy - 0.5);
+		if (max(r2.x, r2.y) < r_max)
+		{
+			SampleShadow(_LD_TexArray_Shadow_Source, uv_source_nextlod, 1.0, shadow);
+		}
 	}
 
 	// Check if the current sample is visible in the main camera (and therefore shadow map can be sampled)

--- a/crest/Assets/Crest/Crest/Shaders/Resources/UpdateShadow.compute
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/UpdateShadow.compute
@@ -134,7 +134,7 @@ void UpdateShadow(uint3 id : SV_DispatchThreadID)
 	{
 		SampleShadow(_LD_TexArray_Shadow_Source, uv_source, 1.0, shadow);
 	}
-	else
+	else if (_LD_SliceIndex_Source + 1.0 < depth)
 	{
 		float3 uv_source_nextlod = WorldToUV_Source(shadowCoords._WorldPosViewZ.xz, _LD_SliceIndex_Source + 1.0);
 		half2 r2 = abs(uv_source_nextlod.xy - 0.5);


### PR DESCRIPTION
This avoids objectional boundaries between cascades that visible when the camera moves around, in the shadow and foam. The result is much more robust now.
