### PR TITLE
Add dyn waves from texture

### DIFF
--- a/crest/Assets/Crest/Crest-Examples/BoatDev/Scenes/threeboats.unity
+++ b/crest/Assets/Crest/Crest-Examples/BoatDev/Scenes/threeboats.unity
@@ -642,11 +642,11 @@ MonoBehaviour:
   _timeProvider: {fileID: 0}
   _material: {fileID: 2100000, guid: 9def92ac79181fe41b238e91663f0fad, type: 2}
   _layerName: Water
-  _windDirectionAngle: 0
   _gravityMultiplier: 1
   _minTexelsPerWave: 3
   _minScale: 8
   _maxScale: 256
+  _dropDetailHeightBasedOnWaves: 0.2
   _lodDataResolution: 256
   _geometryDownSampleFactor: 2
   _lodCount: 8
@@ -861,7 +861,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!114 &1680820176
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1029,9 +1029,15 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _spectrum: {fileID: 11400000, guid: 691aad324f2d2be4abf8123c36963da5, type: 2}
+  _windDirectionAngle: 0
   _componentsPerOctave: 8
   _weight: 1
   _randomSeed: 0
+  _evaluateSpectrumAtRuntime: 1
+  _wavelengths: []
+  _amplitudes: []
+  _angleDegs: []
+  _phases: []
   _directTowardsPoint: 0
   _pointPositionXZ: {x: 0, y: 0}
   _pointRadii: {x: 100, y: 200}

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrPersistent.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrPersistent.cs
@@ -26,7 +26,7 @@ namespace Crest
 
         float _substepDtPrevious = 1f / 60f;
 
-        static int sp_SimDeltaTime = Shader.PropertyToID("_SimDeltaTime");
+        public static int sp_SimDeltaTime = Shader.PropertyToID("_SimDeltaTime");
         static int sp_SimDeltaTimePrev = Shader.PropertyToID("_SimDeltaTimePrev");
 
         protected override void Start()

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
@@ -58,6 +58,7 @@ namespace Crest
             if (_renderer && weight > 0f)
             {
                 _materials[isTransition].SetFloat(sp_Weight, weight);
+                _materials[isTransition].SetFloat(LodDataMgrPersistent.sp_SimDeltaTime, OceanRenderer.Instance.DeltaTimeDynamics);
 
                 buf.DrawRenderer(_renderer, _materials[isTransition]);
             }

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/DynWavesAddBump.shader
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/DynWavesAddBump.shader
@@ -7,7 +7,7 @@ Shader "Crest/Inputs/Dynamic Waves/Add Bump"
 	Properties
 	{
 		_Amplitude( "Amplitude", float ) = 1
-		_Radius( "Radius", float) = 3
+		_Radius("Radius", float) = 3
 	}
 
 	SubShader

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/DynWavesAddFromTex.shader
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/DynWavesAddFromTex.shader
@@ -1,0 +1,62 @@
+// Crest Ocean System
+
+// This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
+
+Shader "Crest/Inputs/Dynamic Waves/Add From Texture"
+{
+	Properties
+	{
+		_MainTex("Texture", 2D) = "white" {}
+		_Strength( "Strength", float ) = 1
+	}
+
+	SubShader
+	{
+		// base simulation runs on the Geometry queue, before this shader.
+		// this shader adds interaction forces on top of the simulation result.
+		Blend One One
+
+		Pass
+		{
+			CGPROGRAM
+			#pragma vertex Vert
+			#pragma fragment Frag
+
+			#include "UnityCG.cginc"
+
+			sampler2D _MainTex;
+			
+			float4 _MainTex_ST;
+			float _Strength;
+			float _SimDeltaTime;
+
+			struct Attributes
+			{
+				float3 positionOS : POSITION;
+				float2 uv : TEXCOORD0;
+			};
+
+			struct Varyings
+			{
+				float4 positionCS : SV_POSITION;
+				float2 uv : TEXCOORD0;
+			};
+
+			Varyings Vert(Attributes input)
+			{
+				Varyings o;
+				o.positionCS = UnityObjectToClipPos(input.positionOS);
+				o.uv = TRANSFORM_TEX(input.uv, _MainTex);
+				return o;
+			}
+
+			float4 Frag(Varyings input) : SV_Target
+			{
+				// Integrate acceleration onto velocity
+				return float4(0.0, _SimDeltaTime*_Strength*tex2D(_MainTex, input.uv).x, 0.0, 0.0);
+			}
+
+			ENDCG
+		}
+	}
+}

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/DynWavesAddFromTex.shader.meta
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/DynWavesAddFromTex.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: c2a26b18708ad5944b30fc3e73a3ec34
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
As discussed with @holdingjason on discord.

Adds a shader to inject dynamic waves from a texture (similar to add foam from texture).

Was almost straightforward, but its annoying the _SimDeltaTime needs to be set to integrate the forces into the sim correctly. An alternative approach would be to make it a global shader var which may save costs in some ways, but i felt it was unnecessary to go global with it.

Let me know what you think