### PR TITLE
Add support for texture slices for each anim wave channel

### DIFF
--- a/crest/Assets/Crest/Crest-Examples/Main/Data.meta
+++ b/crest/Assets/Crest/Crest-Examples/Main/Data.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fa180ad7bf100dd478bb36448899d289
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/crest/Assets/Crest/Crest-Examples/Main/Data/AnimWaveSettingsMain.asset
+++ b/crest/Assets/Crest/Crest-Examples/Main/Data/AnimWaveSettingsMain.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6fcc1742c5d877741b8e82fe2bb66a75, type: 3}
+  m_Name: AnimWaveSettingsMain
+  m_EditorClassIdentifier: 
+  _attenuationInShallows: 0.95
+  _collisionSource: 0
+  _cachedHeightQueries: 0
+  _minObjectWidth: 3
+  _maxObjectWidth: 500

--- a/crest/Assets/Crest/Crest-Examples/Main/Data/AnimWaveSettingsMain.asset.meta
+++ b/crest/Assets/Crest/Crest-Examples/Main/Data/AnimWaveSettingsMain.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bf7d1806cf993cb4b9ea04b4900780fd
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/crest/Assets/Crest/Crest-Examples/Main/Scenes/main.unity
+++ b/crest/Assets/Crest/Crest-Examples/Main/Scenes/main.unity
@@ -474,10 +474,12 @@ MonoBehaviour:
   _minTexelsPerWave: 3
   _minScale: 4
   _maxScale: 256
+  _dropDetailHeightBasedOnWaves: 0.2
   _lodDataResolution: 384
   _geometryDownSampleFactor: 4
   _lodCount: 7
-  _simSettingsAnimatedWaves: {fileID: 0}
+  _simSettingsAnimatedWaves: {fileID: 11400000, guid: bf7d1806cf993cb4b9ea04b4900780fd,
+    type: 2}
   _createSeaFloorDepthData: 1
   _createFoamSim: 1
   _simSettingsFoam: {fileID: 0}

--- a/crest/Assets/Crest/Crest-Examples/Shared/Scripts/OceanDebugGUI.cs
+++ b/crest/Assets/Crest/Crest-Examples/Shared/Scripts/OceanDebugGUI.cs
@@ -182,13 +182,13 @@ public class OceanDebugGUI : MonoBehaviour
         }
 
         float b = 7f;
-        float h = Screen.height / (float)lodData.DataTexture.volumeDepth;
+        float h = Screen.height / (float) (lodData.DataTexture.volumeDepth / lodData.DepthMultiplier);
         float w = h + b;
         float x = Screen.width - w * offset + b * (offset - 1f);
 
         if (_drawTargets[type])
         {
-            for (int idx = 0; idx < lodData.DataTexture.volumeDepth; idx++)
+            for (int idx = 0; idx < lodData.DataTexture.volumeDepth / lodData.DepthMultiplier; idx++)
             {
                 float y = idx * h;
                 if (offset == 1f) w += b;
@@ -204,6 +204,8 @@ public class OceanDebugGUI : MonoBehaviour
                     shapes.Add(lodData.DataTexture.format, rt);
                 }
 
+                // TODO(TRC): Find a way to superimpose depth multiplied textures?
+                // (There is probably a better name for that variable as well).
                 RenderTexture shape = shapes[lodData.DataTexture.format];
                 Graphics.CopyTexture(lodData.DataTexture, idx, 0, shape, 0, 0);
 

--- a/crest/Assets/Crest/Crest-Examples/Shared/Scripts/OceanDebugGUI.cs
+++ b/crest/Assets/Crest/Crest-Examples/Shared/Scripts/OceanDebugGUI.cs
@@ -182,13 +182,13 @@ public class OceanDebugGUI : MonoBehaviour
         }
 
         float b = 7f;
-        float h = Screen.height / (float) (lodData.DataTexture.volumeDepth / lodData.DepthMultiplier);
+        float h = Screen.height / (float) (lodData.DataTexture.volumeDepth / lodData.ArrayCountMultiplier);
         float w = h + b;
         float x = Screen.width - w * offset + b * (offset - 1f);
 
         if (_drawTargets[type])
         {
-            for (int idx = 0; idx < lodData.DataTexture.volumeDepth / lodData.DepthMultiplier; idx++)
+            for (int idx = 0; idx < lodData.DataTexture.volumeDepth / lodData.ArrayCountMultiplier; idx++)
             {
                 float y = idx * h;
                 if (offset == 1f) w += b;

--- a/crest/Assets/Crest/Crest-Examples/Shared/Scripts/OceanDebugGUI.cs
+++ b/crest/Assets/Crest/Crest-Examples/Shared/Scripts/OceanDebugGUI.cs
@@ -204,8 +204,6 @@ public class OceanDebugGUI : MonoBehaviour
                     shapes.Add(lodData.DataTexture.format, rt);
                 }
 
-                // TODO(TRC): Find a way to superimpose depth multiplied textures?
-                // (There is probably a better name for that variable as well).
                 RenderTexture shape = shapes[lodData.DataTexture.format];
                 Graphics.CopyTexture(lodData.DataTexture, idx, 0, shape, 0, 0);
 

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgr.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgr.cs
@@ -55,7 +55,8 @@ namespace Crest
             result.useMipMap = false;
             result.name = name;
             result.dimension = TextureDimension.Tex2DArray;
-            result.volumeDepth = OceanRenderer.Instance.CurrentLodCount;
+            // TODO(TRC): Fix this hack!
+            result.volumeDepth = OceanRenderer.Instance.CurrentLodCount * 4;
             result.enableRandomWrite = needToReadWriteTextureData;
             result.Create();
             return result;

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgr.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgr.cs
@@ -27,6 +27,8 @@ namespace Crest
 
         protected abstract bool NeedToReadWriteTextureData { get; }
 
+        protected virtual int DepthMultiplier { get { return 1; }}
+
         protected RenderTexture _targets;
 
         public RenderTexture DataTexture { get { return _targets; } }
@@ -45,7 +47,7 @@ namespace Crest
             InitData();
         }
 
-        public static RenderTexture CreateLodDataTextures(RenderTextureDescriptor desc, string name, bool needToReadWriteTextureData)
+        protected RenderTexture CreateLodDataTextures(RenderTextureDescriptor desc, string name, bool needToReadWriteTextureData)
         {
             RenderTexture result = new RenderTexture(desc);
             result.wrapMode = TextureWrapMode.Clamp;
@@ -56,7 +58,7 @@ namespace Crest
             result.name = name;
             result.dimension = TextureDimension.Tex2DArray;
             // TODO(TRC): Fix this hack!
-            result.volumeDepth = OceanRenderer.Instance.CurrentLodCount * 4;
+            result.volumeDepth = OceanRenderer.Instance.CurrentLodCount * DepthMultiplier;
             result.enableRandomWrite = needToReadWriteTextureData;
             result.Create();
             return result;

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgr.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgr.cs
@@ -27,7 +27,7 @@ namespace Crest
 
         protected abstract bool NeedToReadWriteTextureData { get; }
 
-        public virtual int DepthMultiplier { get { return 1; }}
+        public virtual int ArrayCountMultiplier { get { return 1; }}
 
         protected RenderTexture _targets;
 
@@ -47,7 +47,7 @@ namespace Crest
             InitData();
         }
 
-        protected RenderTexture CreateLodDataTextures(RenderTextureDescriptor desc, string name, bool needToReadWriteTextureData)
+        protected RenderTexture CreateLodDataTextures(RenderTextureDescriptor desc, string name, bool needToReadWriteTextureData, bool useArrayCountMultiplier = true)
         {
             RenderTexture result = new RenderTexture(desc);
             result.wrapMode = TextureWrapMode.Clamp;
@@ -57,7 +57,7 @@ namespace Crest
             result.useMipMap = false;
             result.name = name;
             result.dimension = TextureDimension.Tex2DArray;
-            result.volumeDepth = OceanRenderer.Instance.CurrentLodCount * DepthMultiplier;
+            result.volumeDepth = OceanRenderer.Instance.CurrentLodCount * (useArrayCountMultiplier ? ArrayCountMultiplier : 1);
             result.enableRandomWrite = needToReadWriteTextureData;
             result.Create();
             return result;

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgr.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgr.cs
@@ -27,7 +27,7 @@ namespace Crest
 
         protected abstract bool NeedToReadWriteTextureData { get; }
 
-        protected virtual int DepthMultiplier { get { return 1; }}
+        public virtual int DepthMultiplier { get { return 1; }}
 
         protected RenderTexture _targets;
 
@@ -57,7 +57,6 @@ namespace Crest
             result.useMipMap = false;
             result.name = name;
             result.dimension = TextureDimension.Tex2DArray;
-            // TODO(TRC): Fix this hack!
             result.volumeDepth = OceanRenderer.Instance.CurrentLodCount * DepthMultiplier;
             result.enableRandomWrite = needToReadWriteTextureData;
             result.Create();

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrAnimWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrAnimWaves.cs
@@ -21,8 +21,20 @@ namespace Crest
     {
         public override string SimName { get { return "AnimatedWaves"; } }
         // shape format. i tried RGB111110Float but error becomes visible. one option would be to use a UNORM setup.
-        public override RenderTextureFormat TextureFormat { get { return RenderTextureFormat.ARGBHalf; } }
+        public override RenderTextureFormat TextureFormat { get {
+            if(_UAVWeirdness)
+            {
+                return RenderTextureFormat.RHalf;
+            }
+            else
+            {
+                return RenderTextureFormat.ARGBHalf;
+            }
+        } }
         protected override bool NeedToReadWriteTextureData { get { return true; } }
+
+        // TODO(TRC): Find a better name for this variable and add a comment explaining what it is and what it does.
+        bool _UAVWeirdness = true;
 
         [Tooltip("Read shape textures back to the CPU for collision purposes.")]
         public bool _readbackShapeForCollision = true;

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrAnimWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrAnimWaves.cs
@@ -24,7 +24,7 @@ namespace Crest
         public override RenderTextureFormat TextureFormat { get {
             if(_UAVWeirdness)
             {
-                return RenderTextureFormat.RHalf;
+                return RenderTextureFormat.RFloat;
             }
             else
             {
@@ -34,6 +34,7 @@ namespace Crest
         protected override bool NeedToReadWriteTextureData { get { return true; } }
 
         // TODO(TRC): Find a better name for this variable and add a comment explaining what it is and what it does.
+        // the why: https://docs.microsoft.com/en-us/windows/win32/direct3d12/typed-unordered-access-view-loads
         bool _UAVWeirdness = true;
 
         [Tooltip("Read shape textures back to the CPU for collision purposes.")]

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrAnimWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrAnimWaves.cs
@@ -26,20 +26,14 @@ namespace Crest
         /// </summary>
         static readonly bool s_WorkaroundUAVLimitation = true;
         public override int ArrayCountMultiplier => s_WorkaroundUAVLimitation ? 4 : 1;
-        public override string SimName { get { return "AnimatedWaves"; } }
-        // shape format. i tried RGB111110Float but error becomes visible. one option would be to use a UNORM setup.
-        public override RenderTextureFormat TextureFormat { get {
-            if(_UAVWeirdness)
-            {
-                return RenderTextureFormat.RFloat;
-            }
-            else
-            {
-                return RenderTextureFormat.ARGBHalf;
-            }
-        } }
-        protected override bool NeedToReadWriteTextureData { get { return true; } }
 
+        public override string SimName { get { return "AnimatedWaves"; } }
+
+        // Shape texture format. I tried RGB111110Float but error becomes visible. One option would be to use a UNORM setup.
+        // For UAV issue, 32 bit single channel.
+        public override RenderTextureFormat TextureFormat => s_WorkaroundUAVLimitation ? RenderTextureFormat.RFloat : RenderTextureFormat.ARGBHalf;
+
+        protected override bool NeedToReadWriteTextureData { get { return true; } }
 
         [Tooltip("Read shape textures back to the CPU for collision purposes.")]
         public bool _readbackShapeForCollision = true;

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrAnimWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrAnimWaves.cs
@@ -24,7 +24,7 @@ namespace Crest
         public override RenderTextureFormat TextureFormat { get {
             if(_UAVWeirdness)
             {
-                return RenderTextureFormat.RFloat;
+                return RenderTextureFormat.ARGBHalf;
             }
             else
             {
@@ -36,6 +36,7 @@ namespace Crest
         // TODO(TRC): Find a better name for this variable and add a comment explaining what it is and what it does.
         // the why: https://docs.microsoft.com/en-us/windows/win32/direct3d12/typed-unordered-access-view-loads
         bool _UAVWeirdness = true;
+        protected override int DepthMultiplier { get { if(_UAVWeirdness) { return 4; } else { return 1; }}}
 
         [Tooltip("Read shape textures back to the CPU for collision purposes.")]
         public bool _readbackShapeForCollision = true;

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrAnimWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrAnimWaves.cs
@@ -24,7 +24,7 @@ namespace Crest
         public override RenderTextureFormat TextureFormat { get {
             if(_UAVWeirdness)
             {
-                return RenderTextureFormat.ARGBHalf;
+                return RenderTextureFormat.RFloat;
             }
             else
             {
@@ -36,7 +36,7 @@ namespace Crest
         // TODO(TRC): Find a better name for this variable and add a comment explaining what it is and what it does.
         // the why: https://docs.microsoft.com/en-us/windows/win32/direct3d12/typed-unordered-access-view-loads
         bool _UAVWeirdness = true;
-        protected override int DepthMultiplier { get { if(_UAVWeirdness) { return 4; } else { return 1; }}}
+        public override int DepthMultiplier { get { if(_UAVWeirdness) { return 4; } else { return 1; }}}
 
         [Tooltip("Read shape textures back to the CPU for collision purposes.")]
         public bool _readbackShapeForCollision = true;

--- a/crest/Assets/Crest/Crest/Shaders/Ocean.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Ocean.shader
@@ -286,7 +286,7 @@ Shader "Crest/Ocean"
 
 					#if !_DEBUGDISABLESHAPETEXTURES_ON
 					half sss = 0.;
-					SampleDisplacements(_LD_TexArray_AnimatedWaves, uv_slice_smallerLod, wt_smallerLod, o.worldPos, sss);
+					SampleDisplacementAnimatedWaves(uv_slice_smallerLod, wt_smallerLod, o.worldPos, sss);
 					#endif
 
 					#if _FOAM_ON
@@ -303,7 +303,7 @@ Shader "Crest/Ocean"
 
 					#if !_DEBUGDISABLESHAPETEXTURES_ON
 					half sss = 0.;
-					SampleDisplacements(_LD_TexArray_AnimatedWaves, uv_slice_biggerLod, wt_biggerLod, o.worldPos, sss);
+					SampleDisplacementAnimatedWaves(uv_slice_biggerLod, wt_biggerLod, o.worldPos, sss);
 					#endif
 
 					#if _FOAM_ON
@@ -430,8 +430,8 @@ Shader "Crest/Ocean"
 				float3 dummy = 0.;
 				half3 n_geom = half3(0.0, 1.0, 0.0);
 				half sss = 0.;
-				if (wt_smallerLod > 0.001) SampleDisplacementsNormals(_LD_TexArray_AnimatedWaves, uv_slice_smallerLod, wt_smallerLod, _LD_Params[_LD_SliceIndex].w, _LD_Params[_LD_SliceIndex].x, dummy, n_geom.xz, sss);
-				if (wt_biggerLod > 0.001) SampleDisplacementsNormals(_LD_TexArray_AnimatedWaves, uv_slice_biggerLod, wt_biggerLod, _LD_Params[_LD_SliceIndex + 1].w, _LD_Params[_LD_SliceIndex + 1].x, dummy, n_geom.xz, sss);
+				if (wt_smallerLod > 0.001) SampleNormalsAnimatedWaves(uv_slice_smallerLod, wt_smallerLod, _LD_Params[_LD_SliceIndex].w, _LD_Params[_LD_SliceIndex].x, dummy, n_geom.xz, sss);
+				if (wt_biggerLod > 0.001) SampleNormalsAnimatedWaves(uv_slice_biggerLod, wt_biggerLod, _LD_Params[_LD_SliceIndex + 1].w, _LD_Params[_LD_SliceIndex + 1].x, dummy, n_geom.xz, sss);
 				n_geom = normalize(n_geom);
 
 				if (underwater) n_geom = -n_geom;

--- a/crest/Assets/Crest/Crest/Shaders/OceanEmission.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanEmission.hlsl
@@ -139,7 +139,7 @@ void ApplyCaustics(in const half3 i_view, in const half3 i_lightDir, in const fl
 	half sss = 0.;
 	// this gives height at displaced position, not exactly at query position.. but it helps. i cant pass this from vert shader
 	// because i dont know it at scene pos.
-	SampleDisplacements(_LD_TexArray_AnimatedWaves, scenePosUV, 1.0, disp, sss);
+	SampleDisplacementAnimatedWaves(scenePosUV, 1.0, disp, sss);
 	half waterHeight = _OceanCenterPosWorld.y + disp.y;
 	half sceneDepth = waterHeight - scenePos.y;
 	// Compute mip index manually, with bias based on sea floor depth. We compute it manually because if it is computed automatically it produces ugly patches

--- a/crest/Assets/Crest/Crest/Shaders/OceanLODData.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanLODData.hlsl
@@ -14,7 +14,7 @@
 
 // TODO(TRC): Come up with a better name for this and find a way to make it
 // toggleable at runtime in a better way
-#define UAV_WEIRDNESS 1
+#define WORKAROUND_UAV_LIMITATION 1
 
 // 'Current' target/source slice index
 const float _LD_SliceIndex;
@@ -104,14 +104,16 @@ float2 IDtoUV(in float2 i_id, in float i_width, in float i_height)
 
 half4 SampleLodLevelAnimatedWaves(in float3 uv_slice, in float mips)
 {
-#if UAV_WEIRDNESS
-	// TODO(TRC): Make this not hardcoded.
-	float3 numLods = float3(0.0, 0.0, 7.0);
+#if WORKAROUND_UAV_LIMITATION
+	float w, h, d;
+	_LD_TexArray_AnimatedWaves.GetDimensions(w, h, d);
+
+	float3 numLods = float3(0.0, 0.0, d / 4.0);
 	half4 data;
-	data.r = _LD_TexArray_AnimatedWaves.SampleLevel(LODData_linear_clamp_sampler, uv_slice, mips);
-	data.g = _LD_TexArray_AnimatedWaves.SampleLevel(LODData_linear_clamp_sampler, uv_slice + numLods, mips);
-	data.b = _LD_TexArray_AnimatedWaves.SampleLevel(LODData_linear_clamp_sampler, uv_slice + (numLods * 2.0), mips);
-	data.a = _LD_TexArray_AnimatedWaves.SampleLevel(LODData_linear_clamp_sampler, uv_slice + (numLods * 3.0), mips);
+	data.x = _LD_TexArray_AnimatedWaves.SampleLevel(LODData_linear_clamp_sampler, uv_slice, mips).x;
+	data.y = _LD_TexArray_AnimatedWaves.SampleLevel(LODData_linear_clamp_sampler, uv_slice + numLods, mips).x;
+	data.z = _LD_TexArray_AnimatedWaves.SampleLevel(LODData_linear_clamp_sampler, uv_slice + (numLods * 2.0), mips).x;
+	data.w = _LD_TexArray_AnimatedWaves.SampleLevel(LODData_linear_clamp_sampler, uv_slice + (numLods * 3.0), mips).x;
 	return data;
 #else
 	return _LD_TexArray_AnimatedWaves.SampleLevel(LODData_linear_clamp_sampler, uv_slice, mips);

--- a/crest/Assets/Crest/Crest/Shaders/OceanLODData.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanLODData.hlsl
@@ -12,6 +12,10 @@
 #define THREAD_GROUP_SIZE_X 8
 #define THREAD_GROUP_SIZE_Y 8
 
+// TODO(TRC): Come up with a better name for this and find a way to make it
+// toggleable at runtime in a better way
+#define UAV_WEIRDNESS 1
+
 // 'Current' target/source slice index
 const float _LD_SliceIndex;
 
@@ -100,7 +104,18 @@ float2 IDtoUV(in float2 i_id, in float i_width, in float i_height)
 
 half4 SampleLodLevelAnimatedWaves(in float3 uv_slice, in float mips)
 {
+#if UAV_WEIRDNESS
+	// TODO(TRC): Make this not hardcoded.
+	float3 numLods = float3(0.0, 0.0, 7.0);
+	half4 data;
+	data.r = _LD_TexArray_AnimatedWaves.SampleLevel(LODData_linear_clamp_sampler, uv_slice, mips);
+	data.g = _LD_TexArray_AnimatedWaves.SampleLevel(LODData_linear_clamp_sampler, uv_slice + numLods, mips);
+	data.b = _LD_TexArray_AnimatedWaves.SampleLevel(LODData_linear_clamp_sampler, uv_slice + (numLods * 2.0), mips);
+	data.a = _LD_TexArray_AnimatedWaves.SampleLevel(LODData_linear_clamp_sampler, uv_slice + (numLods * 3.0), mips);
+	return data;
+#else
 	return _LD_TexArray_AnimatedWaves.SampleLevel(LODData_linear_clamp_sampler, uv_slice, mips);
+#endif
 }
 
 half4 SampleLodAnimatedWaves(in float3 uv_slice)

--- a/crest/Assets/Crest/Crest/Shaders/OceanSurfaceAlpha.shader
+++ b/crest/Assets/Crest/Crest/Shaders/OceanSurfaceAlpha.shader
@@ -77,8 +77,8 @@ Shader "Crest/Ocean Surface Alpha"
 				const float2 wxz = worldPos.xz;
 				half foam = 0.0;
 				half sss = 0.;
-				SampleDisplacements(_LD_TexArray_AnimatedWaves, WorldToUV(wxz), wt_smallerLod, worldPos, sss);
-				SampleDisplacements(_LD_TexArray_AnimatedWaves, WorldToUV_BiggerLod(wxz), wt_biggerLod, worldPos, sss);
+				SampleDisplacementAnimatedWaves(WorldToUV(wxz), wt_smallerLod, worldPos, sss);
+				SampleDisplacementAnimatedWaves(WorldToUV_BiggerLod(wxz), wt_biggerLod, worldPos, sss);
 
 				// move to sea level
 				worldPos.y += _OceanCenterPosWorld.y;

--- a/crest/Assets/Crest/Crest/Shaders/Resources/ShapeCombine.compute
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/ShapeCombine.compute
@@ -29,8 +29,7 @@ void Flow(out float2 offsets, out float2 weights)
 	weights.y = 1.0 - weights.x;
 }
 
-void SampleDisplacementsCompute(
-	in RWTexture2DArray<float4> i_dispSampler,
+void SampleDisplacementAnimatedWavesCompute(
 	in float i_width, in float i_height, in float3 i_uv_slice,
 	in float i_wt, inout float3 io_worldPos, inout float io_sss
 ) {
@@ -52,10 +51,10 @@ void SampleDisplacementsCompute(
 	const float2 pixelCoordCentersBotLeft = floor(pixelCoordCenters);
 	const float2 pixelCoordCentersFrac = frac(pixelCoordCenters);
 
-	const float4 dataBotLeft = i_dispSampler[float3(pixelCoordCentersBotLeft, i_uv_slice.z)];
-	const float4 dataBotRight = i_dispSampler[float3(pixelCoordCentersBotLeft + float2(1.0, 0.0), i_uv_slice.z)];
-	const float4 dataTopLeft = i_dispSampler[float3(pixelCoordCentersBotLeft + float2(0.0, 1.0), i_uv_slice.z)];
-	const float4 dataTopRight = i_dispSampler[float3(pixelCoordCentersBotLeft + float2(1.0, 1.0), i_uv_slice.z)];
+	const float4 dataBotLeft = _LD_TexArray_AnimatedWaves_Compute[float3(pixelCoordCentersBotLeft, i_uv_slice.z)];
+	const float4 dataBotRight = _LD_TexArray_AnimatedWaves_Compute[float3(pixelCoordCentersBotLeft + float2(1.0, 0.0), i_uv_slice.z)];
+	const float4 dataTopLeft = _LD_TexArray_AnimatedWaves_Compute[float3(pixelCoordCentersBotLeft + float2(0.0, 1.0), i_uv_slice.z)];
+	const float4 dataTopRight = _LD_TexArray_AnimatedWaves_Compute[float3(pixelCoordCentersBotLeft + float2(1.0, 1.0), i_uv_slice.z)];
 
 	const float4 dataLerped = lerp(
 		lerp(dataBotLeft, dataBotRight, pixelCoordCentersFrac.x),
@@ -105,7 +104,7 @@ void ShapeCombineBase (uint3 id)
 // C# Script determines whether this enabled or not by selecting appropriate
 // kernel for each LOD.
 #if !_DISABLE_COMBINE
-	SampleDisplacementsCompute(_LD_TexArray_AnimatedWaves_Compute, width, height, uv_nextLod, 1.0, result, sss);
+	SampleDisplacementAnimatedWavesCompute(width, height, uv_nextLod, 1.0, result, sss);
 #endif
 
 #if _DYNAMIC_WAVE_SIM_ON

--- a/crest/Assets/Crest/Crest/Shaders/Resources/ShapeCombine.compute
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/ShapeCombine.compute
@@ -17,6 +17,8 @@ float _HorizDisplace;
 float _DisplaceClamp;
 float _CrestTime;
 
+
+Texture2DArray _LD_TexArray_WaveBuffer;
 RWTexture2DArray<float4> _LD_TexArray_AnimatedWaves_Compute;
 
 void Flow(out float2 offsets, out float2 weights)
@@ -27,6 +29,14 @@ void Flow(out float2 offsets, out float2 weights)
 	weights.x = offsets.x / half_period;
 	if (weights.x > 1.0) weights.x = 2.0 - weights.x;
 	weights.y = 1.0 - weights.x;
+}
+
+// Sampling functions
+void SampleDisplacementWaveBuffer(in float3 i_uv_slice, in float i_wt, inout float3 io_worldPos, inout float io_sss)
+{
+	const half4 data = _LD_TexArray_WaveBuffer.SampleLevel(LODData_linear_clamp_sampler, i_uv_slice, 0.0);
+	io_worldPos += i_wt * data.xyz;
+	io_sss += i_wt * data.a;
 }
 
 void SampleDisplacementAnimatedWavesCompute(
@@ -93,8 +103,8 @@ void ShapeCombineBase (uint3 id)
 
 	float3 uv_thisLod_flow_0 = WorldToUV(worldPosXZ - offsets[0] * flow);
 	float3 uv_thisLod_flow_1 = WorldToUV(worldPosXZ - offsets[1] * flow);
-	SampleDisplacements(_LD_TexArray_WaveBuffer, uv_thisLod_flow_0, weights[0], result, sss);
-	SampleDisplacements(_LD_TexArray_WaveBuffer, uv_thisLod_flow_1, weights[1], result, sss);
+	SampleDisplacementWaveBuffer(uv_thisLod_flow_0, weights[0], result, sss);
+	SampleDisplacementWaveBuffer(uv_thisLod_flow_1, weights[1], result, sss);
 #else
 	float4 data =_LD_TexArray_WaveBuffer.SampleLevel(LODData_linear_clamp_sampler, uv_thisLod, 0.0);
 	result += data.xyz;

--- a/crest/Assets/Crest/Crest/Shaders/Resources/ShapeCombine.compute
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/ShapeCombine.compute
@@ -19,7 +19,12 @@ float _CrestTime;
 
 
 Texture2DArray _LD_TexArray_WaveBuffer;
+
+#if UAV_WEIRDNESS
+RWTexture2DArray<float> _LD_TexArray_AnimatedWaves_Compute;
+#else
 RWTexture2DArray<float4> _LD_TexArray_AnimatedWaves_Compute;
+#endif
 
 void Flow(out float2 offsets, out float2 weights)
 {
@@ -38,6 +43,37 @@ void SampleDisplacementWaveBuffer(in float3 i_uv_slice, in float i_wt, inout flo
 	io_worldPos += i_wt * data.xyz;
 	io_sss += i_wt * data.a;
 }
+
+half4 SampleAnimatedWavesCompute(in uint3 coords)
+{
+#if UAV_WEIRDNESS
+	// TODO(TRC): Make this not hardcoded.
+	uint3 numLods = uint3(0, 0, 7);
+	half4 data;
+	data.r = _LD_TexArray_AnimatedWaves_Compute[coords];
+	data.g = _LD_TexArray_AnimatedWaves_Compute[coords + numLods];
+	data.b = _LD_TexArray_AnimatedWaves_Compute[coords + (numLods * 2)];
+	data.a = _LD_TexArray_AnimatedWaves_Compute[coords + (numLods * 3)];
+	return data;
+#else
+	return _LD_TexArray_AnimatedWaves_Compute[coords];
+#endif
+}
+
+void SetValueAnimatedWavesCompute(in uint3 coords, in half4 value)
+{
+#if UAV_WEIRDNESS
+// TODO(TRC): Make this not hardcoded.
+	uint3 numLods = uint3(0, 0, 7);
+	_LD_TexArray_AnimatedWaves_Compute[coords] = value.r;
+	_LD_TexArray_AnimatedWaves_Compute[coords + numLods] = value.g;
+	_LD_TexArray_AnimatedWaves_Compute[coords + (numLods * 2)] = value.b;
+	_LD_TexArray_AnimatedWaves_Compute[coords + (numLods * 3)] = value.a;
+#else
+	_LD_TexArray_AnimatedWaves_Compute[coords] = value;
+#endif
+}
+
 
 void SampleDisplacementAnimatedWavesCompute(
 	in float i_width, in float i_height, in float3 i_uv_slice,
@@ -61,10 +97,10 @@ void SampleDisplacementAnimatedWavesCompute(
 	const float2 pixelCoordCentersBotLeft = floor(pixelCoordCenters);
 	const float2 pixelCoordCentersFrac = frac(pixelCoordCenters);
 
-	const float4 dataBotLeft = _LD_TexArray_AnimatedWaves_Compute[float3(pixelCoordCentersBotLeft, i_uv_slice.z)];
-	const float4 dataBotRight = _LD_TexArray_AnimatedWaves_Compute[float3(pixelCoordCentersBotLeft + float2(1.0, 0.0), i_uv_slice.z)];
-	const float4 dataTopLeft = _LD_TexArray_AnimatedWaves_Compute[float3(pixelCoordCentersBotLeft + float2(0.0, 1.0), i_uv_slice.z)];
-	const float4 dataTopRight = _LD_TexArray_AnimatedWaves_Compute[float3(pixelCoordCentersBotLeft + float2(1.0, 1.0), i_uv_slice.z)];
+	const float4 dataBotLeft = SampleAnimatedWavesCompute(float3(pixelCoordCentersBotLeft, i_uv_slice.z));
+	const float4 dataBotRight = SampleAnimatedWavesCompute(float3(pixelCoordCentersBotLeft + float2(1.0, 0.0), i_uv_slice.z));
+	const float4 dataTopLeft = SampleAnimatedWavesCompute(float3(pixelCoordCentersBotLeft + float2(0.0, 1.0), i_uv_slice.z));
+	const float4 dataTopRight = SampleAnimatedWavesCompute(float3(pixelCoordCentersBotLeft + float2(1.0, 1.0), i_uv_slice.z));
 
 	const float4 dataLerped = lerp(
 		lerp(dataBotLeft, dataBotRight, pixelCoordCentersFrac.x),
@@ -144,7 +180,7 @@ void ShapeCombineBase (uint3 id)
 	}
 #endif // _DYNAMIC_WAVE_SIM_
 
-	_LD_TexArray_AnimatedWaves_Compute[uint3(id.xy, _LD_SliceIndex)] = half4(result, sss);
+	SetValueAnimatedWavesCompute(uint3(id.xy, _LD_SliceIndex), half4(result, sss));
 }
 
 

--- a/crest/Assets/Crest/Crest/Shaders/Resources/ShapeCombine.compute
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/ShapeCombine.compute
@@ -20,7 +20,7 @@ float _CrestTime;
 
 Texture2DArray _LD_TexArray_WaveBuffer;
 
-#if UAV_WEIRDNESS
+#if WORKAROUND_UAV_LIMITATION
 RWTexture2DArray<float> _LD_TexArray_AnimatedWaves_Compute;
 #else
 RWTexture2DArray<float4> _LD_TexArray_AnimatedWaves_Compute;
@@ -46,14 +46,16 @@ void SampleDisplacementWaveBuffer(in float3 i_uv_slice, in float i_wt, inout flo
 
 half4 SampleAnimatedWavesCompute(in uint3 coords)
 {
-#if UAV_WEIRDNESS
-	// TODO(TRC): Make this not hardcoded.
-	uint3 numLods = uint3(0, 0, 7);
+#if WORKAROUND_UAV_LIMITATION
+	uint w, h, d;
+	_LD_TexArray_AnimatedWaves_Compute.GetDimensions(w, h, d);
+
+	uint3 numLods = uint3(0, 0, d / 4);
 	half4 data;
-	data.r = _LD_TexArray_AnimatedWaves_Compute[coords];
-	data.g = _LD_TexArray_AnimatedWaves_Compute[coords + numLods];
-	data.b = _LD_TexArray_AnimatedWaves_Compute[coords + (numLods * 2)];
-	data.a = _LD_TexArray_AnimatedWaves_Compute[coords + (numLods * 3)];
+	data.x = _LD_TexArray_AnimatedWaves_Compute[coords];
+	data.y = _LD_TexArray_AnimatedWaves_Compute[coords + numLods];
+	data.z = _LD_TexArray_AnimatedWaves_Compute[coords + (numLods * 2)];
+	data.w = _LD_TexArray_AnimatedWaves_Compute[coords + (numLods * 3)];
 	return data;
 #else
 	return _LD_TexArray_AnimatedWaves_Compute[coords];
@@ -62,13 +64,15 @@ half4 SampleAnimatedWavesCompute(in uint3 coords)
 
 void SetValueAnimatedWavesCompute(in uint3 coords, in half4 value)
 {
-#if UAV_WEIRDNESS
-// TODO(TRC): Make this not hardcoded.
-	uint3 numLods = uint3(0, 0, 7);
-	_LD_TexArray_AnimatedWaves_Compute[coords] = value.r;
-	_LD_TexArray_AnimatedWaves_Compute[coords + numLods] = value.g;
-	_LD_TexArray_AnimatedWaves_Compute[coords + (numLods * 2)] = value.b;
-	_LD_TexArray_AnimatedWaves_Compute[coords + (numLods * 3)] = value.a;
+#if WORKAROUND_UAV_LIMITATION
+	uint w, h, d;
+	_LD_TexArray_AnimatedWaves_Compute.GetDimensions(w, h, d);
+
+	uint3 numLods = uint3(0, 0, d / 4);
+	_LD_TexArray_AnimatedWaves_Compute[coords] = value.x;
+	_LD_TexArray_AnimatedWaves_Compute[coords + numLods] = value.y;
+	_LD_TexArray_AnimatedWaves_Compute[coords + (numLods * 2)] = value.z;
+	_LD_TexArray_AnimatedWaves_Compute[coords + (numLods * 3)] = value.w;
 #else
 	_LD_TexArray_AnimatedWaves_Compute[coords] = value;
 #endif
@@ -112,7 +116,7 @@ void SampleDisplacementAnimatedWavesCompute(
 	io_sss += dataLerped.a;
 }
 
-void ShapeCombineBase (uint3 id)
+void ShapeCombineBase(uint3 id)
 {
 	float width; float height; float depth;
 	{
@@ -142,13 +146,13 @@ void ShapeCombineBase (uint3 id)
 	SampleDisplacementWaveBuffer(uv_thisLod_flow_0, weights[0], result, sss);
 	SampleDisplacementWaveBuffer(uv_thisLod_flow_1, weights[1], result, sss);
 #else
-	float4 data =_LD_TexArray_WaveBuffer.SampleLevel(LODData_linear_clamp_sampler, uv_thisLod, 0.0);
+	float4 data = _LD_TexArray_WaveBuffer.SampleLevel(LODData_linear_clamp_sampler, uv_thisLod, 0.0);
 	result += data.xyz;
 	sss = data.a;
 #endif
 
-// C# Script determines whether this enabled or not by selecting appropriate
-// kernel for each LOD.
+	// C# Script determines whether this enabled or not by selecting appropriate
+	// kernel for each LOD.
 #if !_DISABLE_COMBINE
 	SampleDisplacementAnimatedWavesCompute(width, height, uv_nextLod, 1.0, result, sss);
 #endif
@@ -184,11 +188,11 @@ void ShapeCombineBase (uint3 id)
 }
 
 
-[numthreads(THREAD_GROUP_SIZE_X,THREAD_GROUP_SIZE_Y,1)] void ShapeCombine(uint3 id : SV_DispatchThreadID) { ShapeCombineBase(id); }
-[numthreads(THREAD_GROUP_SIZE_X,THREAD_GROUP_SIZE_Y,1)] void ShapeCombine_DISABLE_COMBINE(uint3 id : SV_DispatchThreadID) { ShapeCombineBase(id); }
-[numthreads(THREAD_GROUP_SIZE_X,THREAD_GROUP_SIZE_Y,1)] void ShapeCombine_FLOW_ON(uint3 id : SV_DispatchThreadID) { ShapeCombineBase(id); }
-[numthreads(THREAD_GROUP_SIZE_X,THREAD_GROUP_SIZE_Y,1)] void ShapeCombine_FLOW_ON_DISABLE_COMBINE(uint3 id : SV_DispatchThreadID) { ShapeCombineBase(id); }
-[numthreads(THREAD_GROUP_SIZE_X,THREAD_GROUP_SIZE_Y,1)] void ShapeCombine_DYNAMIC_WAVE_SIM_ON(uint3 id : SV_DispatchThreadID) { ShapeCombineBase(id); }
-[numthreads(THREAD_GROUP_SIZE_X,THREAD_GROUP_SIZE_Y,1)] void ShapeCombine_DYNAMIC_WAVE_SIM_ON_DISABLE_COMBINE(uint3 id : SV_DispatchThreadID) { ShapeCombineBase(id); }
-[numthreads(THREAD_GROUP_SIZE_X,THREAD_GROUP_SIZE_Y,1)] void ShapeCombine_FLOW_ON_DYNAMIC_WAVE_SIM_ON(uint3 id : SV_DispatchThreadID) { ShapeCombineBase(id); }
-[numthreads(THREAD_GROUP_SIZE_X,THREAD_GROUP_SIZE_Y,1)] void ShapeCombine_FLOW_ON_DYNAMIC_WAVE_SIM_ON_DISABLE_COMBINE(uint3 id : SV_DispatchThreadID) { ShapeCombineBase(id); }
+[numthreads(THREAD_GROUP_SIZE_X, THREAD_GROUP_SIZE_Y, 1)] void ShapeCombine(uint3 id : SV_DispatchThreadID) { ShapeCombineBase(id); }
+[numthreads(THREAD_GROUP_SIZE_X, THREAD_GROUP_SIZE_Y, 1)] void ShapeCombine_DISABLE_COMBINE(uint3 id : SV_DispatchThreadID) { ShapeCombineBase(id); }
+[numthreads(THREAD_GROUP_SIZE_X, THREAD_GROUP_SIZE_Y, 1)] void ShapeCombine_FLOW_ON(uint3 id : SV_DispatchThreadID) { ShapeCombineBase(id); }
+[numthreads(THREAD_GROUP_SIZE_X, THREAD_GROUP_SIZE_Y, 1)] void ShapeCombine_FLOW_ON_DISABLE_COMBINE(uint3 id : SV_DispatchThreadID) { ShapeCombineBase(id); }
+[numthreads(THREAD_GROUP_SIZE_X, THREAD_GROUP_SIZE_Y, 1)] void ShapeCombine_DYNAMIC_WAVE_SIM_ON(uint3 id : SV_DispatchThreadID) { ShapeCombineBase(id); }
+[numthreads(THREAD_GROUP_SIZE_X, THREAD_GROUP_SIZE_Y, 1)] void ShapeCombine_DYNAMIC_WAVE_SIM_ON_DISABLE_COMBINE(uint3 id : SV_DispatchThreadID) { ShapeCombineBase(id); }
+[numthreads(THREAD_GROUP_SIZE_X, THREAD_GROUP_SIZE_Y, 1)] void ShapeCombine_FLOW_ON_DYNAMIC_WAVE_SIM_ON(uint3 id : SV_DispatchThreadID) { ShapeCombineBase(id); }
+[numthreads(THREAD_GROUP_SIZE_X, THREAD_GROUP_SIZE_Y, 1)] void ShapeCombine_FLOW_ON_DYNAMIC_WAVE_SIM_ON_DISABLE_COMBINE(uint3 id : SV_DispatchThreadID) { ShapeCombineBase(id); }

--- a/crest/Assets/Crest/Crest/Shaders/Resources/UpdateFoam.compute
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/UpdateFoam.compute
@@ -64,9 +64,9 @@ void UpdateFoam(uint3 id : SV_DispatchThreadID)
 
 	// sample displacement texture and generate foam from it
 	const float3 dd = float3(_LD_Params[sliceIndex].w, 0.0, _LD_Params[sliceIndex].x);
-	half3 s = SampleLod(_LD_TexArray_AnimatedWaves, uv_slice).xyz;
-	half3 sx = SampleLodLevel(_LD_TexArray_AnimatedWaves, uv_slice + float3(dd.xy, 0), dd.y).xyz;
-	half3 sz = SampleLodLevel(_LD_TexArray_AnimatedWaves, uv_slice + float3(dd.yx, 0), dd.y).xyz;
+	half3 s = SampleLodAnimatedWaves(uv_slice).xyz;
+	half3 sx = SampleLodLevelAnimatedWaves(uv_slice + float3(dd.xy, 0), dd.y).xyz;
+	half3 sz = SampleLodLevelAnimatedWaves(uv_slice + float3(dd.yx, 0), dd.y).xyz;
 	float3 disp = s.xyz;
 	float3 disp_x = dd.zyy + sx.xyz;
 	float3 disp_z = dd.yyz + sz.xyz;

--- a/crest/Assets/Crest/Crest/Shaders/Underwater/UnderwaterCurtain.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Underwater/UnderwaterCurtain.shader
@@ -182,7 +182,7 @@ Shader "Crest/Underwater Curtain"
 				float3 surfaceAboveCamPosWorld = 0.0;
 				half sss = 0.;
 				const float3 uv_slice = WorldToUV(_WorldSpaceCameraPos.xz);
-				SampleDisplacements(_LD_TexArray_AnimatedWaves, uv_slice, 1.0, surfaceAboveCamPosWorld, sss);
+				SampleDisplacementAnimatedWaves(uv_slice, 1.0, surfaceAboveCamPosWorld, sss);
 				surfaceAboveCamPosWorld.y += _OceanCenterPosWorld.y;
 
 				// depth and shadow are computed in ScatterColour when underwater==true, using the LOD1 texture.

--- a/crest/Assets/Crest/Crest/Shaders/Underwater/UnderwaterShared.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/Underwater/UnderwaterShared.hlsl
@@ -20,7 +20,7 @@ float IntersectRayWithWaterSurface(const float3 pos, const float3 dir)
 		// Sample displacement textures, add results to current world pos / normal / foam
 		disp = float3(sampleXZ.x, _OceanCenterPosWorld.y, sampleXZ.y);
 		half sss = 0.;
-		SampleDisplacements(_LD_TexArray_AnimatedWaves, WorldToUV(sampleXZ), 1.0, disp, sss);
+		SampleDisplacementAnimatedWaves(WorldToUV(sampleXZ), 1.0, disp, sss);
 		float3 nearestPointOnRay = pos + dir * dot(disp - pos, dir);
 		const float2 error = disp.xz - nearestPointOnRay.xz;
 		sampleXZ -= error;


### PR DESCRIPTION
The second attempt to fix #279, but with less drastic changes.

https://docs.microsoft.com/en-us/windows/win32/direct3d12/typed-unordered-access-view-loads

As explained above *reading* from typed UAVs that aren't floats, uints or ints is unsupported in DX11 versions below DX11.3 - this was a problem as merging LODs required reading from an ARGBHalf typed UAV resource.

This change introduces the option of using a single float texture array slice for each displacement dimension - allowing older hardware to be supported. This does currently come with the following two caveats:

- It doubles the memory used (with an increase in associated bandwidth requirements) of animated waves when the fix is enabled.
- It won't work with GPU readbacks, however, this should no longer be an issue once #279 has been worked on.

We are going to wait and see if it fixes the issues people have been having, and if so we will get this merged.

It's worth noting that packing two halfs into a single in texture could be an option to save on memory requirements - but would add a lot of complexity and take time to complete. This workaround should work fine for now.

Tasks:
- [ ] Look into detecting if typed UAVs are supported on a given piece of hardware at runtime. (Could just check if DX11.2 or below?)
- [ ] Disable the workaround by default.
- [ ] Find a way to print a warning if waves don't show? (Or throw it in validation somehow).
- [ ] Investigate the best way to toggle WORKAROUND_UAV_LIMITATION in the shaders (is there a way to do this in code?). (Marked `TODO(TRC)`)