### PR TITLE
Ping pong combine

### DIFF
--- a/crest/Assets/Crest/Crest-Examples/Shared/Scripts/OceanDebugGUI.cs
+++ b/crest/Assets/Crest/Crest-Examples/Shared/Scripts/OceanDebugGUI.cs
@@ -90,6 +90,7 @@ public class OceanDebugGUI : MonoBehaviour
 
 #if UNITY_EDITOR
             LodDataMgrAnimWaves._shapeCombinePass = GUI.Toggle(new Rect(x, y, w, h), LodDataMgrAnimWaves._shapeCombinePass, "Shape combine pass"); y += h;
+            LodDataMgrAnimWaves._shapeCombinePassPingPong = GUI.Toggle(new Rect(x, y, w, h), LodDataMgrAnimWaves._shapeCombinePassPingPong, "Combine pass ping pong"); y += h;
 #endif
 
             LodDataMgrShadow.s_processData = GUI.Toggle(new Rect(x, y, w, h), LodDataMgrShadow.s_processData, "Process Shadows"); y += h;

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrAnimWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrAnimWaves.cs
@@ -243,16 +243,16 @@ namespace Crest
                 }
 
                 // TODO - uncomment these..
-                //// dynamic waves
-                //if (OceanRenderer.Instance._lodDataDynWaves)
-                //{
-                //    OceanRenderer.Instance._lodDataDynWaves.BindCopySettings(_combineMaterial[lodIdx]);
-                //    OceanRenderer.Instance._lodDataDynWaves.BindResultData(lodIdx, 0, _combineMaterial[lodIdx]);
-                //}
-                //else
-                //{
-                //    LodDataMgrDynWaves.BindNull(0, _combineMaterial[lodIdx]);
-                //}
+                // dynamic waves
+                if (OceanRenderer.Instance._lodDataDynWaves)
+                {
+                    OceanRenderer.Instance._lodDataDynWaves.BindCopySettings(_combineMaterial[lodIdx]);
+                    OceanRenderer.Instance._lodDataDynWaves.BindResultData(_combineMaterial[lodIdx]);
+                }
+                else
+                {
+                    LodDataMgrDynWaves.BindNull(_combineMaterial[lodIdx]);
+                }
 
                 //// flow
                 //if (OceanRenderer.Instance._lodDataFlow)

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrAnimWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrAnimWaves.cs
@@ -228,6 +228,7 @@ namespace Crest
         void CombinePassPingPong(CommandBuffer buf)
         {
             var lodCount = OceanRenderer.Instance.CurrentLodCount;
+            const int shaderPassCombineIntoAux = 0, shaderPassCopyResultBack = 1;
 
             // combine waves
             for (int lodIdx = lodCount - 1; lodIdx >= 0; lodIdx--)
@@ -268,14 +269,14 @@ namespace Crest
 
                 _combineMaterial[lodIdx].SetFloat(OceanRenderer.sp_LD_SliceIndex, lodIdx);
 
-                // Combine into aux buffer
-                // TODO - do this with drawprocedural like below?
-                buf.Blit(null, _combineBuffer, _combineMaterial[lodIdx].material, 0);
+                // Combine this LOD's waves with waves from the LODs above into auxiliary combine buffer
+                buf.SetRenderTarget(_combineBuffer);
+                buf.DrawProcedural(Matrix4x4.identity, _combineMaterial[lodIdx].material, shaderPassCombineIntoAux, MeshTopology.Triangles, 3);
 
-                // Copy back to lod texture array
+                // Copy combine buffer back to lod texture array
                 buf.SetRenderTarget(_targets, 0, CubemapFace.Unknown, lodIdx);
                 _combineMaterial[lodIdx].SetTexture(Shader.PropertyToID("_CombineBuffer"), _combineBuffer);
-                buf.DrawProcedural(Matrix4x4.identity, _combineMaterial[lodIdx].material, 1, MeshTopology.Triangles, 3);
+                buf.DrawProcedural(Matrix4x4.identity, _combineMaterial[lodIdx].material, shaderPassCopyResultBack, MeshTopology.Triangles, 3);
             }
         }
 

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrAnimWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrAnimWaves.cs
@@ -254,15 +254,15 @@ namespace Crest
                     LodDataMgrDynWaves.BindNull(_combineMaterial[lodIdx]);
                 }
 
-                //// flow
-                //if (OceanRenderer.Instance._lodDataFlow)
-                //{
-                //    OceanRenderer.Instance._lodDataFlow.BindResultData(lodIdx, 0, _combineMaterial[lodIdx]);
-                //}
-                //else
-                //{
-                //    LodDataMgrFlow.BindNull(0, _combineMaterial[lodIdx]);
-                //}
+                // flow
+                if (OceanRenderer.Instance._lodDataFlow)
+                {
+                    OceanRenderer.Instance._lodDataFlow.BindResultData(_combineMaterial[lodIdx]);
+                }
+                else
+                {
+                    LodDataMgrFlow.BindNull(_combineMaterial[lodIdx]);
+                }
 
                 _combineMaterial[lodIdx].SetFloat(OceanRenderer.sp_LD_SliceIndex, lodIdx);
 

--- a/crest/Assets/Crest/Crest/Shaders/OceanLODData.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanLODData.hlsl
@@ -42,7 +42,6 @@ const float4 _LD_Params_Source[MAX_LOD_COUNT + 1];
 const float3 _LD_Pos_Scale_Source[MAX_LOD_COUNT + 1];
 
 SamplerState LODData_linear_clamp_sampler;
-SamplerState LODData_point_clamp_sampler;
 
 // Bias ocean floor depth so that default (0) values in texture are not interpreted as shallow and generating foam everywhere
 #define CREST_OCEAN_DEPTH_BASELINE 1000.0

--- a/crest/Assets/Crest/Crest/Shaders/OceanLODData.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanLODData.hlsl
@@ -42,6 +42,7 @@ const float4 _LD_Params_Source[MAX_LOD_COUNT + 1];
 const float3 _LD_Pos_Scale_Source[MAX_LOD_COUNT + 1];
 
 SamplerState LODData_linear_clamp_sampler;
+SamplerState LODData_point_clamp_sampler;
 
 // Bias ocean floor depth so that default (0) values in texture are not interpreted as shallow and generating foam everywhere
 #define CREST_OCEAN_DEPTH_BASELINE 1000.0

--- a/crest/Assets/Crest/Crest/Shaders/Resources/ShapeCombine.compute
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/ShapeCombine.compute
@@ -2,6 +2,10 @@
 
 // This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
 
+// Compute shader to perform combine of displacements. Reads and writes to texture array which saves
+// needing to do ping pong of render targets. Unfortunately reading/writing float4s is not supported
+// on pre-DX11.3 hardware (aka typed UAV loads), so this path is not the default, for now..
+
 #pragma kernel ShapeCombine
 #pragma kernel ShapeCombine_DISABLE_COMBINE _DISABLE_COMBINE
 #pragma kernel ShapeCombine_FLOW_ON _FLOW_ON

--- a/crest/Assets/Crest/Crest/Shaders/Resources/ShapeCombine.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/ShapeCombine.shader
@@ -2,6 +2,9 @@
 
 // This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
 
+// Shaders to perform combine as a ping pong process - combine happens into an auxiliary buffer, which is then copied
+// back into the texture array.
+
 Shader "Hidden/Crest/Simulation/Combine Animated Wave LODs"
 {
 	SubShader

--- a/crest/Assets/Crest/Crest/Shaders/Resources/ShapeCombine.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/ShapeCombine.shader
@@ -69,17 +69,23 @@ Shader "Hidden/Crest/Simulation/Combine Animated Wave LODs"
 				const float3 uv_nextLod = WorldToUV_BiggerLod(worldPosXZ);
 
 				float3 result = 0.0;
+				float sss = 0.0;
 
-				// TODO(huw) - get flow and dynamic waves turned on, by fixing up the below and also binding them in LodDataMgrAnimWaves.cs
-				// NOTE the below
-
-				// this lods waves
 #if _FLOW_ON
-				// TODO
+				float2 flow = 0.0;
+				SampleFlow(_LD_TexArray_Flow, uv_thisLod, 1.0, flow);
+
+				float2 offsets, weights;
+				Flow(offsets, weights);
+
+				float3 uv_thisLod_flow_0 = WorldToUV(worldPosXZ - offsets[0] * flow);
+				float3 uv_thisLod_flow_1 = WorldToUV(worldPosXZ - offsets[1] * flow);
+				SampleDisplacements(_LD_TexArray_WaveBuffer, uv_thisLod_flow_0, weights[0], result, sss);
+				SampleDisplacements(_LD_TexArray_WaveBuffer, uv_thisLod_flow_1, weights[1], result, sss);
 #else
 				float4 data = _LD_TexArray_WaveBuffer.SampleLevel(LODData_linear_clamp_sampler, uv_thisLod, 0.0);
 				result += data.xyz;
-				float sss = data.w;
+				sss = data.w;
 #endif
 
 				float w, h, d;

--- a/crest/Assets/Crest/Crest/Shaders/Resources/ShapeCombine.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/ShapeCombine.shader
@@ -77,7 +77,7 @@ Shader "Hidden/Crest/Simulation/Combine Animated Wave LODs"
 #if _FLOW_ON
 				// TODO
 #else
-				float4 data = _LD_TexArray_WaveBuffer.SampleLevel(LODData_linear_clamp_sampler, uv_thisLod, 0.0);
+				float4 data = _LD_TexArray_WaveBuffer.SampleLevel(LODData_point_clamp_sampler, uv_thisLod, 0.0);
 				result += data.xyz;
 				float sss = data.w;
 #endif
@@ -88,7 +88,7 @@ Shader "Hidden/Crest/Simulation/Combine Animated Wave LODs"
 				// waves to combine down from the next lod up the chain
 				if (_LD_SliceIndex < d - 1.0)
 				{
-					float4 dataNextLod = _LD_TexArray_AnimatedWaves.SampleLevel(LODData_linear_clamp_sampler, uv_nextLod, 0.0);
+					float4 dataNextLod = _LD_TexArray_AnimatedWaves.SampleLevel(LODData_point_clamp_sampler, uv_nextLod, 0.0);
 					result += dataNextLod.xyz;
 					sss += dataNextLod.w;
 				}

--- a/crest/Assets/Crest/Crest/Shaders/Resources/ShapeCombine.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/ShapeCombine.shader
@@ -167,7 +167,7 @@ Shader "Hidden/Crest/Simulation/Combine Animated Wave LODs"
 			
 			half4 Frag(Varyings input) : SV_Target
 			{
-				return _CombineBuffer.SampleLevel(LODData_linear_clamp_sampler, input.uv, 0.0);
+				return _CombineBuffer.SampleLevel(LODData_point_clamp_sampler, input.uv, 0.0);
 			}
 			ENDCG
 		}

--- a/crest/Assets/Crest/Crest/Shaders/Resources/ShapeCombine.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/ShapeCombine.shader
@@ -77,7 +77,7 @@ Shader "Hidden/Crest/Simulation/Combine Animated Wave LODs"
 #if _FLOW_ON
 				// TODO
 #else
-				float4 data = _LD_TexArray_WaveBuffer.SampleLevel(LODData_point_clamp_sampler, uv_thisLod, 0.0);
+				float4 data = _LD_TexArray_WaveBuffer.SampleLevel(LODData_linear_clamp_sampler, uv_thisLod, 0.0);
 				result += data.xyz;
 				float sss = data.w;
 #endif
@@ -88,7 +88,7 @@ Shader "Hidden/Crest/Simulation/Combine Animated Wave LODs"
 				// waves to combine down from the next lod up the chain
 				if (_LD_SliceIndex < d - 1.0)
 				{
-					float4 dataNextLod = _LD_TexArray_AnimatedWaves.SampleLevel(LODData_point_clamp_sampler, uv_nextLod, 0.0);
+					float4 dataNextLod = _LD_TexArray_AnimatedWaves.SampleLevel(LODData_linear_clamp_sampler, uv_nextLod, 0.0);
 					result += dataNextLod.xyz;
 					sss += dataNextLod.w;
 				}

--- a/crest/Assets/Crest/Crest/Shaders/Resources/ShapeCombine.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/ShapeCombine.shader
@@ -23,6 +23,7 @@ Shader "Hidden/Crest/Simulation/Combine Animated Wave LODs"
 
 			#include "UnityCG.cginc"
 			#include "../OceanLODData.hlsl"
+			#include "../FullScreenTriangle.hlsl"
 
 			float _HorizDisplace;
 			float _DisplaceClamp;
@@ -30,8 +31,7 @@ Shader "Hidden/Crest/Simulation/Combine Animated Wave LODs"
 
 			struct Attributes
 			{
-				float3 positionOS : POSITION;
-				float2 uv : TEXCOORD0;
+				uint VertexID : SV_VertexID;
 			};
 
 			struct Varyings
@@ -43,11 +43,11 @@ Shader "Hidden/Crest/Simulation/Combine Animated Wave LODs"
 			Varyings Vert(Attributes input)
 			{
 				Varyings o;
-				o.positionCS = UnityObjectToClipPos(input.positionOS);
-				o.uv = input.uv;
+				o.positionCS = GetFullScreenTriangleVertexPosition(input.VertexID);
+				o.uv = GetFullScreenTriangleTexCoord(input.VertexID);
 				return o;
 			}
-			
+
 			void Flow(out float2 offsets, out float2 weights)
 			{
 				const float period = 3.0 * _LD_Params[_LD_SliceIndex].x;

--- a/crest/Assets/Crest/Crest/Shaders/Resources/ShapeCombine.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/ShapeCombine.shader
@@ -1,0 +1,147 @@
+﻿// Crest Ocean System
+
+// This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
+
+Shader "Hidden/Crest/Simulation/Combine Animated Wave LODs"
+{
+	SubShader
+	{
+		// No culling or depth
+		Cull Off
+		ZWrite Off
+		ZTest Always
+		Blend Off
+
+		Pass
+		{
+			CGPROGRAM
+			#pragma vertex Vert
+			#pragma fragment Frag
+			
+			#pragma multi_compile __ _DYNAMIC_WAVE_SIM_ON
+			#pragma multi_compile __ _FLOW_ON
+
+			#include "UnityCG.cginc"
+			#include "../OceanLODData.hlsl"
+
+			float _HorizDisplace;
+			float _DisplaceClamp;
+			float _CrestTime;
+
+			struct Attributes
+			{
+				float3 positionOS : POSITION;
+				float2 uv : TEXCOORD0;
+			};
+
+			struct Varyings
+			{
+				float4 positionCS : SV_POSITION;
+				float2 uv : TEXCOORD0;
+			};
+
+			Varyings Vert(Attributes input)
+			{
+				Varyings o;
+				o.positionCS = UnityObjectToClipPos(input.positionOS);
+				o.uv = input.uv;
+				return o;
+			}
+			
+			void Flow(out float2 offsets, out float2 weights)
+			{
+				const float period = 3.0 * _LD_Params[_LD_SliceIndex].x;
+				const float half_period = period / 2.0;
+				offsets = fmod(float2(_CrestTime, _CrestTime + half_period), period);
+				weights.x = offsets.x / half_period;
+				if (weights.x > 1.0) weights.x = 2.0 - weights.x;
+				weights.y = 1.0 - weights.x;
+			}
+
+			half4 Frag(Varyings input) : SV_Target
+			{
+				float3 uv_thisLod = float3(input.uv, _LD_SliceIndex);
+
+				// go from uv out to world for the current shape texture
+				const float2 worldPosXZ = UVToWorld(input.uv);
+
+				// sample the shape 1 texture at this world pos
+				const float3 uv_nextLod = WorldToUV_BiggerLod(worldPosXZ);
+
+				float3 result = 0.0;
+
+				// TODO(huw) - get flow and dynamic waves turned on, by fixing up the below and also binding them in LodDataMgrAnimWaves.cs
+				// NOTE the below
+
+				// this lods waves
+#if _FLOW_ON
+				// TODO
+#else
+				float4 data = _LD_TexArray_WaveBuffer.SampleLevel(LODData_linear_clamp_sampler, uv_thisLod, 0.0);
+				result += data.xyz;
+				float sss = data.w;
+#endif
+
+				float w, h, d;
+				_LD_TexArray_AnimatedWaves.GetDimensions(w, h, d);
+
+				// waves to combine down from the next lod up the chain
+				if (_LD_SliceIndex < d - 1.0)
+				{
+					float4 dataNextLod = _LD_TexArray_AnimatedWaves.SampleLevel(LODData_linear_clamp_sampler, uv_nextLod, 0.0);
+					result += dataNextLod.xyz;
+					sss += dataNextLod.w;
+				}
+
+#if _DYNAMIC_WAVE_SIM_ON
+				// TODO
+#endif // _DYNAMIC_WAVE_SIM_ON
+
+				return half4(result, sss);
+			}
+			ENDCG
+		}
+
+
+
+		// Copy back to lod texture array
+		Pass
+		{
+			CGPROGRAM
+			#pragma vertex Vert
+			#pragma fragment Frag
+
+			#include "UnityCG.cginc"
+			#include "../OceanLODData.hlsl"
+			#include "../FullScreenTriangle.hlsl"
+
+			Texture2D _CombineBuffer;
+
+			struct Attributes
+			{
+				uint VertexID : SV_VertexID;
+			};
+
+			struct Varyings
+			{
+				float4 positionCS : SV_POSITION;
+				float2 uv : TEXCOORD0;
+			};
+
+			Varyings Vert(Attributes input)
+			{
+				Varyings o;
+				o.positionCS = GetFullScreenTriangleVertexPosition(input.VertexID);
+				o.uv = GetFullScreenTriangleTexCoord(input.VertexID);
+				return o;
+			}
+			
+			half4 Frag(Varyings input) : SV_Target
+			{
+				return _CombineBuffer.SampleLevel(LODData_linear_clamp_sampler, input.uv, 0.0);
+			}
+			ENDCG
+		}
+
+	}
+}

--- a/crest/Assets/Crest/Crest/Shaders/Resources/ShapeCombine.shader.meta
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/ShapeCombine.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 5c7b540557038e64b88626fddf91e123
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Another variation of a fix for #279 . I think this might be a 'winner' (or at least the best loser) - doesnt add complexity to the code beyond the minimum (a new combine code path).

Adds a few texture copies, but avoids a few downsides of #340 .

I've lazily left both code paths in the runtime. This has an overhead of loading an additional shader, and allocating an additional widthXheightX1 texture. To fix this we could move a bunch of stuff into defines potentially. Might be a good idea to deploy it as a dynamic switch which might help with debugging and then bake it into a define later perhaps? Or just leave it dynamic.