### PR TITLE
Vary material roughness in distance

### DIFF
--- a/crest/Assets/Crest/Crest/Materials/Ocean-Underwater.mat
+++ b/crest/Assets/Crest/Crest/Materials/Ocean-Underwater.mat
@@ -10,8 +10,9 @@ Material:
   m_Name: Ocean-Underwater
   m_Shader: {fileID: 4800000, guid: 668aecf91371c8b4997e42c0c7b19527, type: 3}
   m_ShaderKeywords: _APPLYNORMALMAPPING_ON _CAUSTICS_ON _COMPUTEDIRECTIONALLIGHT_ON
-    _DEBUGMULTIPLYBYLIGHT0COLOR_ON _FOAM3DLIGHTING_ON _FOAM_ON _SHADOWS_ON _SUBSURFACEHEIGHTLERP_ON
-    _SUBSURFACESCATTERING_ON _SUBSURFACESHALLOWCOLOUR_ON _TRANSPARENCY_ON _UNDERWATER_ON
+    _DEBUGMULTIPLYBYLIGHT0COLOR_ON _DIRECTIONALLIGHTVARYROUGHNESS_ON _FOAM3DLIGHTING_ON
+    _FOAM_ON _SHADOWS_ON _SUBSURFACEHEIGHTLERP_ON _SUBSURFACESCATTERING_ON _SUBSURFACESHALLOWCOLOUR_ON
+    _TRANSPARENCY_ON _UNDERWATER_ON
   m_LightmapFlags: 5
   m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 0
@@ -102,7 +103,10 @@ Material:
     - _DebugVisualiseFlow: 0
     - _DebugVisualiseShapeSample: 0
     - _DirectionalLightBoost: 7
-    - _DirectionalLightFallOff: 275
+    - _DirectionalLightFallOff: 188
+    - _DirectionalLightFallOffFar: 42
+    - _DirectionalLightFarDistance: 137
+    - _DirectionalLightVaryRoughness: 1
     - _Flow: 0
     - _Foam: 1
     - _Foam3DLighting: 1

--- a/crest/Assets/Crest/Crest/Materials/Ocean.mat
+++ b/crest/Assets/Crest/Crest/Materials/Ocean.mat
@@ -104,6 +104,9 @@ Material:
     - _DebugVisualiseShapeSample: 0
     - _DirectionalLightBoost: 7
     - _DirectionalLightFallOff: 275
+    - _DirectionalLightFallOffFar: 42
+    - _DirectionalLightFarDistance: 137
+    - _DirectionalLightVaryRoughness: 0
     - _Flow: 0
     - _Foam: 1
     - _Foam3DLighting: 1

--- a/crest/Assets/Crest/Crest/Shaders/Ocean.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Ocean.shader
@@ -86,6 +86,9 @@ Shader "Crest/Ocean"
 		[Header(Add Directional Light)]
 		[Toggle] _ComputeDirectionalLight("Enable", Float) = 1
 		_DirectionalLightFallOff("Fall-Off", Range(1.0, 4096.0)) = 275.0
+		[Toggle] _DirectionalLightVaryRoughness("Vary Fall-Off Over Distance", Float) = 0
+		_DirectionalLightFarDistance("Far Distance", Float) = 137.0
+		_DirectionalLightFallOffFar("Fall-Off At Far Distance", Range(1.0, 4096.0)) = 42.0
 		_DirectionalLightBoost("Boost", Range(0.0, 512.0)) = 7.0
 
 		[Header(Foam)]
@@ -197,6 +200,7 @@ Shader "Crest/Ocean"
 
 			#pragma shader_feature _APPLYNORMALMAPPING_ON
 			#pragma shader_feature _COMPUTEDIRECTIONALLIGHT_ON
+			#pragma shader_feature _DIRECTIONALLIGHTVARYROUGHNESS_ON
 			#pragma shader_feature _SUBSURFACESCATTERING_ON
 			#pragma shader_feature _SUBSURFACESHALLOWCOLOUR_ON
 			#pragma shader_feature _TRANSPARENCY_ON
@@ -470,7 +474,7 @@ Shader "Crest/Ocean"
 				else
 				#endif
 				{
-					ApplyReflectionSky(view, n_pixel, lightDir, shadow.y, input.foam_screenPosXYW.yzzw, reflAlpha, col);
+					ApplyReflectionSky(view, n_pixel, lightDir, shadow.y, input.foam_screenPosXYW.yzzw, pixelZ, reflAlpha, col);
 				}
 
 				// Override final result with white foam - bubbles on surface


### PR DESCRIPTION
Used to put too-fine surface detail into material. Gives widening of specular response in distance.

Detail moves from surface shape, to normal map, to microfacets

https://hal.inria.fr/inria-00443630/file/article-1.pdf
