### PR TITLE
Spectrum power lerp should check disabled flag

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Shapes/OceanWaveSpectrum.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/OceanWaveSpectrum.cs
@@ -84,10 +84,8 @@ namespace Crest
                 return 0f;
             }
 
-            if (_powerDisabled[index])
-            {
-                return 0f;
-            }
+            // Get the first power for interpolation if available
+            var thisPower = !_powerDisabled[index] ? _powerLog[index] : MIN_POWER_LOG;
 
             // Get the next power for interpolation if available
             var nextIndex = index + 1;
@@ -109,7 +107,7 @@ namespace Crest
             var alpha = (wavelength - lower) / lower;
 
             // Power
-            var pow = hasNextIndex ? Mathf.Lerp(_powerLog[index], nextPower, alpha) : _powerLog[index];
+            var pow = hasNextIndex ? Mathf.Lerp(thisPower, nextPower, alpha) : _powerLog[index];
 
             var a_2 = 2f * Mathf.Pow(10f, pow) * domega;
 

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/OceanWaveSpectrum.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/OceanWaveSpectrum.cs
@@ -89,6 +89,11 @@ namespace Crest
                 return 0f;
             }
 
+            // Get the next power for interpolation if available
+            var nextIndex = index + 1;
+            var hasNextIndex = nextIndex < _powerLog.Length;
+            var nextPower = hasNextIndex && !_powerDisabled[nextIndex] ? _powerLog[nextIndex] : MIN_POWER_LOG;
+
             // The amplitude calculation follows this nice paper from Frechot:
             // https://hal.archives-ouvertes.fr/file/index/docid/307938/filename/frechot_realistic_simulation_of_ocean_surface_using_wave_spectra.pdf
             var wl_lo = Mathf.Pow(2f, Mathf.Floor(wl_pow2));
@@ -104,7 +109,7 @@ namespace Crest
             var alpha = (wavelength - lower) / lower;
 
             // Power
-            var pow = Mathf.Lerp(_powerLog[index], _powerLog[Mathf.Min(index + 1, _powerLog.Length - 1)], alpha);
+            var pow = hasNextIndex ? Mathf.Lerp(_powerLog[index], nextPower, alpha) : _powerLog[index];
 
             var a_2 = 2f * Mathf.Pow(10f, pow) * domega;
 


### PR DESCRIPTION
Resolves: #351

The aim is to reduce confusion when authoring or debugging since before
the fix the disabled slider would still affect the spectrum. Option 4
out of the following options was chosen:

1. Leave as is. This is expected behaviour
2. Find the next highest power that is enabled
3. Skip interpolation
4. Use the minimum power