### PR TITLE
Adaptor to dynamically batch one-at-a-time height queries

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Collision/DWPAdaptor.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Collision/DWPAdaptor.cs
@@ -1,0 +1,57 @@
+﻿// Crest Ocean System
+
+// This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
+
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Crest
+{
+    /// <summary>
+    /// Tries to dynamically batch height query points on the fly. 
+    /// </summary>
+    public class DWPAdaptor
+    {
+        class QueryToken { }
+        List<QueryToken> _tokens = new List<QueryToken>();
+
+        int _queryCount = 0;
+
+        SamplingData _samplingData = new SamplingData();
+
+        Vector3[] _queryScratch = new Vector3[] { Vector3.zero };
+        float[] _resultsScratch = new float[] { 0f };
+
+        [Tooltip("Width of object (for a 2m x 4m boat, set this to 2). The larger this value, the more filtered/smooth the wave response will be."), SerializeField]
+        float _minSpatialLength = 0f;
+
+        public DWPAdaptor()
+        {
+            _samplingData._minSpatialLength = _minSpatialLength;
+        }
+
+        public float GetWaterHeight(Vector3 position)
+        {
+            _queryCount++;
+
+            // Create token object for the query if needed
+            if (_tokens.Count < _queryCount)
+            {
+                _tokens.Add(new QueryToken());
+            }
+
+            _queryScratch[0] = position;
+            var result = OceanRenderer.Instance.CollisionProvider.Query(
+                _tokens[_queryCount - 1].GetHashCode(), _samplingData, _queryScratch, _resultsScratch, null, null
+                );
+
+            return _resultsScratch[0];
+        }
+
+        // Must be called after queries are made
+        public void Update()
+        {
+            _queryCount = 0;
+        }
+    }
+}

--- a/crest/Assets/Crest/Crest/Scripts/Collision/DWPAdaptor.cs.meta
+++ b/crest/Assets/Crest/Crest/Scripts/Collision/DWPAdaptor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fbb3d1ac6ea4a6d45a6b78083c18c8b7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/crest/Assets/Crest/Crest/Scripts/Collision/QueryBase.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Collision/QueryBase.cs
@@ -26,7 +26,6 @@ namespace Crest
         protected abstract string QueryKernelName { get; }
 
         const int s_maxRequests = 4;
-        const int s_maxGuids = 64;
 
         protected virtual ComputeShader ShaderProcessQueries => _shaderProcessQueries;
         ComputeShader _shaderProcessQueries;
@@ -221,12 +220,6 @@ namespace Crest
 
             if (!segmentRetrieved)
             {
-                if (_segmentRegistrarRingBuffer.Current._segments.Count >= s_maxGuids)
-                {
-                    Debug.LogError("Too many guids registered with CollProviderCompute. Increase s_maxGuids.", this);
-                    return false;
-                }
-
                 segment.x = _segmentRegistrarRingBuffer.Current._numQueries;
                 segment.y = segment.x + countTotal - 1;
                 _segmentRegistrarRingBuffer.Current._segments.Add(i_ownerHash, segment);


### PR DESCRIPTION
Usage - create an adaptor in the code where one-at-a-time queries need to be serviced:

`DWPAdaptor _adaptor = new DWPAdaptor();`

Execute queries to get heights:

`float waterHeight = _adaptor.GetWaterHeight(position);`

When done writing queries for a frame, call the update function:

`_adaptor.Update();`

This could be called from Update() of a monobehaviour (if queries will come through during FixedUpdate), or from LateUpdate. It is probably not critical when exactly it's called, as long as it's called exactly once per frame and in a consistent way.

This is intended specifically to proxy non-batched queries into the system. We don't recommend this for general purpose use - for example if a single height needs to be queried, use `SampleHeightHelper` which is simpler, more direct and more efficient.