### PR TITLE
Added Unity PBS Reflection Probe Sampling

### DIFF
--- a/crest/Assets/Crest/Crest/Shaders/Ocean.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Ocean.shader
@@ -55,6 +55,8 @@ Shader "Crest/Ocean"
 		[Header(Reflection Environment)]
 		// Strength of specular lighting response
 		_Specular("Specular", Range(0.0, 1.0)) = 1.0
+		// Controls blurriness of reflection
+		_Roughness("Roughness", Range(0.0, 1.0)) = 0.0
 		// Controls harshness of Fresnel behaviour
 		_FresnelPower("Fresnel Power", Range(1.0, 20.0)) = 5.0
 		// Index of refraction of air. Can be increased to almost 1.333 to increase visibility up through water surface.

--- a/crest/Assets/Crest/Crest/Shaders/OceanReflection.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanReflection.hlsl
@@ -92,7 +92,7 @@ void ApplyReflectionSky(in const half3 i_view, in const half3 i_n_pixel, in cons
 	UNITY_BRANCH
 	if (interpolator < 0.99999) 
 	{
-		float3 probe1 = Unity_GlossyEnvironment(UNITY_PASS_TEXCUBE_SAMPLER(unity_SpecCube1, unity_SpecCube0), unity_SpecCube0_HDR, envData);
+		float3 probe1 = Unity_GlossyEnvironment(UNITY_PASS_TEXCUBE_SAMPLER(unity_SpecCube1, unity_SpecCube0), unity_SpecCube1_HDR, envData);
 		skyColour = lerp(probe1, probe0, interpolator);
 	}
 	else 

--- a/crest/Assets/Crest/Crest/Shaders/OceanReflection.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanReflection.hlsl
@@ -39,6 +39,7 @@ samplerCUBE _ReflectionCubemapOverride;
 #endif // _OVERRIDEREFLECTIONCUBEMAP_ON
 
 uniform half _Specular;
+uniform half _Roughness;
 uniform half _FresnelPower;
 uniform float  _RefractiveIndexOfAir;
 uniform float  _RefractiveIndexOfWater;
@@ -83,7 +84,7 @@ void ApplyReflectionSky(in const half3 i_view, in const half3 i_n_pixel, in cons
 	skyColour = val.rgb;
 #else
 	Unity_GlossyEnvironmentData envData;
-	envData.roughness = 1.0f - _Specular;
+	envData.roughness = _Roughness;
 	envData.reflUVW = refl;
 	float3 probe0 = Unity_GlossyEnvironment(UNITY_PASS_TEXCUBE(unity_SpecCube0), unity_SpecCube0_HDR, envData);
 	#if UNITY_SPECCUBE_BLENDING

--- a/crest/Assets/Crest/Crest/Shaders/OceanReflection.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanReflection.hlsl
@@ -87,20 +87,20 @@ void ApplyReflectionSky(in const half3 i_view, in const half3 i_n_pixel, in cons
 	envData.reflUVW = refl;
 	float3 probe0 = Unity_GlossyEnvironment(UNITY_PASS_TEXCUBE(unity_SpecCube0), unity_SpecCube0_HDR, envData);
 	#if UNITY_SPECCUBE_BLENDING
-		float interpolator = unity_SpecCube0_BoxMin.w;
-		// Branch optimization recommended by: https://catlikecoding.com/unity/tutorials/rendering/part-8/
-		UNITY_BRANCH
-		if (interpolator < 0.99999) 
-		{
-			float3 probe1 = Unity_GlossyEnvironment(UNITY_PASS_TEXCUBE_SAMPLER(unity_SpecCube1, unity_SpecCube0), unity_SpecCube0_HDR, envData);
-			skyColour = lerp(probe1, probe0, interpolator);
-		}
-		else 
-		{
-			skyColour = probe0;
-		}
-	#else
+	float interpolator = unity_SpecCube0_BoxMin.w;
+	// Branch optimization recommended by: https://catlikecoding.com/unity/tutorials/rendering/part-8/
+	UNITY_BRANCH
+	if (interpolator < 0.99999) 
+	{
+		float3 probe1 = Unity_GlossyEnvironment(UNITY_PASS_TEXCUBE_SAMPLER(unity_SpecCube1, unity_SpecCube0), unity_SpecCube0_HDR, envData);
+		skyColour = lerp(probe1, probe0, interpolator);
+	}
+	else 
+	{
 		skyColour = probe0;
+	}
+	#else
+	skyColour = probe0;
 	#endif
 #endif
 


### PR DESCRIPTION
Not sure this is desireable, but if it is this may be helpful in reflections.

Commit Description:
This probe sampling code is based on the Unity PBS standard shader and interpolation code suggested by https://catlikecoding.com/unity/tutorials/rendering/part-8/.

It should blend probes, which I think was not taking place before, and also it should make reflection smoothness depend on the Ocean specular parameter.