### PR TITLE
Minor fixes

### DIFF
--- a/crest/Assets/Crest/Crest-Examples/Whirlpool/Materials/Ocean-Flow.mat
+++ b/crest/Assets/Crest/Crest-Examples/Whirlpool/Materials/Ocean-Flow.mat
@@ -131,7 +131,6 @@ Material:
     - _Specular: 1
     - _StartLevel: 0.157
     - _SubSurfaceBase: 0.24
-    - _SubSurfaceCrestColour: 1
     - _SubSurfaceDepthMax: 9.4
     - _SubSurfaceDepthPower: 2.57
     - _SubSurfaceHeightLerp: 1
@@ -171,7 +170,6 @@ Material:
     - _SkyTowardsSun: {r: 2.6390157, g: 1.8217498, b: 0.9236555, a: 1}
     - _SubSurface: {r: 0, g: 0.48, b: 0.36, a: 1}
     - _SubSurfaceColour: {r: 0.10196078, g: 0.57254905, b: 0.5256646, a: 1}
-    - _SubSurfaceCrestColour: {r: 0.42, g: 0.69, b: 0.52, a: 1}
     - _SubSurfaceShallowCol: {r: 0.552, g: 1, b: 1, a: 1}
     - _SubSurfaceShallowColShadow: {r: 0.14417942, g: 0.2264151, b: 0.21173015, a: 1}
     - _SubSurfaceShallowColour: {r: 0.41999996, g: 0.75, b: 0.69, a: 1}

--- a/crest/Assets/Crest/Crest/Materials/Ocean-Underwater.mat
+++ b/crest/Assets/Crest/Crest/Materials/Ocean-Underwater.mat
@@ -136,7 +136,6 @@ Material:
     - _StartLevel: 0.157
     - _StencilFunction: 0
     - _SubSurfaceBase: 1.04
-    - _SubSurfaceCrestColour: 1
     - _SubSurfaceDepthMax: 9.4
     - _SubSurfaceDepthPower: 2.57
     - _SubSurfaceHeightLerp: 1
@@ -176,7 +175,6 @@ Material:
     - _SkyTowardsSun: {r: 2.6390157, g: 1.8217498, b: 0.9236555, a: 1}
     - _SubSurface: {r: 0, g: 0.48, b: 0.36, a: 1}
     - _SubSurfaceColour: {r: 0.10196078, g: 0.57254905, b: 0.5256646, a: 1}
-    - _SubSurfaceCrestColour: {r: 0.42, g: 0.69, b: 0.52, a: 1}
     - _SubSurfaceShallowCol: {r: 0.552, g: 1, b: 1, a: 1}
     - _SubSurfaceShallowColShadow: {r: 0.14417942, g: 0.2264151, b: 0.21173015, a: 1}
     - _SubSurfaceShallowColour: {r: 0.41999996, g: 0.75, b: 0.69, a: 1}

--- a/crest/Assets/Crest/Crest/Materials/Ocean.mat
+++ b/crest/Assets/Crest/Crest/Materials/Ocean.mat
@@ -135,7 +135,6 @@ Material:
     - _StartLevel: 0.157
     - _StencilFunction: 0
     - _SubSurfaceBase: 0.67
-    - _SubSurfaceCrestColour: 1
     - _SubSurfaceDepthMax: 9.4
     - _SubSurfaceDepthPower: 2.57
     - _SubSurfaceHeightLerp: 1
@@ -175,7 +174,6 @@ Material:
     - _SkyTowardsSun: {r: 2.6390157, g: 1.8217498, b: 0.9236555, a: 1}
     - _SubSurface: {r: 0, g: 0.48, b: 0.36, a: 1}
     - _SubSurfaceColour: {r: 0.10196078, g: 0.57254905, b: 0.5256646, a: 1}
-    - _SubSurfaceCrestColour: {r: 0.42, g: 0.69, b: 0.52, a: 1}
     - _SubSurfaceShallowCol: {r: 0.552, g: 1, b: 1, a: 1}
     - _SubSurfaceShallowColShadow: {r: 0.14417942, g: 0.2264151, b: 0.21173015, a: 1}
     - _SubSurfaceShallowColour: {r: 0.41999996, g: 0.75, b: 0.69, a: 1}

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgr.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgr.cs
@@ -107,9 +107,9 @@ namespace Crest
         }
 
         // Avoid heap allocations instead BindData
-        private Vector4[] _BindData_paramIdPosScales = new Vector4[MAX_LOD_COUNT];
+        private Vector4[] _BindData_paramIdPosScales = new Vector4[MAX_LOD_COUNT + 1];
         // Used in child
-        protected Vector4[] _BindData_paramIdOceans = new Vector4[MAX_LOD_COUNT];
+        protected Vector4[] _BindData_paramIdOceans = new Vector4[MAX_LOD_COUNT + 1];
         protected virtual void BindData(IPropertyWrapper properties, Texture applyData, bool blendOut, ref LodTransform.RenderData[] renderData, bool sourceLod = false)
         {
             if (applyData)

--- a/crest/Assets/Crest/Crest/Scripts/OceanBuilder.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanBuilder.cs
@@ -226,7 +226,7 @@ namespace Crest
 
 #if PROFILE_CONSTRUCTION
             sw.Stop();
-            Debug.Log( "Finished generating " + parms._lodCount.ToString() + " LODs, time: " + (1000.0*sw.Elapsed.TotalSeconds).ToString(".000") + "ms" );
+            Debug.Log( "Finished generating " + lodCount.ToString() + " LODs, time: " + (1000.0*sw.Elapsed.TotalSeconds).ToString(".000") + "ms" );
 #endif
         }
 

--- a/crest/Assets/Crest/Crest/Shaders/OceanEmission.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanEmission.hlsl
@@ -20,7 +20,6 @@ uniform half3 _SubSurfaceColour;
 uniform half _SubSurfaceBase;
 uniform half _SubSurfaceSun;
 uniform half _SubSurfaceSunFallOff;
-uniform half3 _SubSurfaceCrestColour;
 #endif // _SUBSURFACESCATTERING_ON
 
 #if _SUBSURFACESHALLOWCOLOUR_ON


### PR DESCRIPTION
Sorry if having a few small fixes in a single PR is an issue. It was just the most efficient way. I can redo as separate PRs if desired.

Incomplete refactor: `parms` was years ago
`IndexOutOfRangeException` was due to "slice index + 1" so adding an extra element is correct I believe
`_SubSurfaceCrestColour` was from the now removed height lerp subsurface colouring

