### PR TITLE
Ocean Debug GUI optimisations

### DIFF
--- a/crest/Assets/Crest/Crest-Examples/Shared/Scripts/OceanDebugGUI.cs
+++ b/crest/Assets/Crest/Crest-Examples/Shared/Scripts/OceanDebugGUI.cs
@@ -11,6 +11,8 @@ public class OceanDebugGUI : MonoBehaviour
     [SerializeField] bool _showSimTargets = false;
     [SerializeField] bool _guiVisible = true;
     static float _leftPanelWidth = 180f;
+    static float _bottomPanelHeight = 25f;
+    static Color _guiColor = Color.black * 0.7f;
     ShapeGerstnerBatched[] _gerstners;
 
     static Dictionary<System.Type, bool> _drawTargets = new Dictionary<System.Type, bool>();
@@ -59,7 +61,7 @@ public class OceanDebugGUI : MonoBehaviour
             float x = 5f, y = 0f;
             float w = _leftPanelWidth - 2f * x, h = 25f;
 
-            GUI.color = Color.black * 0.7f;
+            GUI.color = _guiColor;
             GUI.DrawTexture(new Rect(0, 0, w + 2f * x, Screen.height), Texture2D.whiteTexture);
             GUI.color = Color.white;
 
@@ -163,6 +165,11 @@ public class OceanDebugGUI : MonoBehaviour
     {
         if (OceanRenderer.Instance == null) return;
 
+        // Draw bottom panel for toggles
+        GUI.color = _guiColor;
+        GUI.DrawTexture(new Rect(_leftPanelWidth, Screen.height - _bottomPanelHeight, Screen.width, _bottomPanelHeight), Texture2D.whiteTexture);
+        GUI.color = Color.white;
+
         // draw sim data
         float column = 1f;
 
@@ -188,30 +195,35 @@ public class OceanDebugGUI : MonoBehaviour
             _simNames.Add(type, type.Name.Substring(10));
         }
 
+        float togglesBegin = Screen.height - _bottomPanelHeight;
         float b = 7f;
-        float h = Screen.height / (float)lodData.DataTexture.volumeDepth;
+        float h = togglesBegin / (float)lodData.DataTexture.volumeDepth;
         float w = h + b;
         float x = Screen.width - w * offset + b * (offset - 1f);
 
-        // Only use Graphics.DrawTexture in EventType.Repaint events if called in OnGUI
-        if (_drawTargets[type] && Event.current.type.Equals(EventType.Repaint))
+        if (_drawTargets[type])
         {
-            for (int idx = 0; idx < lodData.DataTexture.volumeDepth; idx++)
+            GUI.color = _guiColor;
+            GUI.DrawTexture(new Rect(x, 0, offset == 1f ? w : w - b, Screen.height - _bottomPanelHeight), Texture2D.whiteTexture);
+            GUI.color = Color.white;
+
+            // Only use Graphics.DrawTexture in EventType.Repaint events if called in OnGUI
+            if (Event.current.type.Equals(EventType.Repaint))
             {
-                float y = idx * h;
-                if (offset == 1f) w += b;
+                for (int idx = 0; idx < lodData.DataTexture.volumeDepth; idx++)
+                {
+                    float y = idx * h;
+                    if (offset == 1f) w += b;
 
-                GUI.color = Color.black * 0.7f;
-                GUI.DrawTexture(new Rect(x, y, w - b, h), Texture2D.whiteTexture);
-                GUI.color = Color.white;
-
-                // Render specific slice of 2D texture array
-                textureArrayMaterial.SetInt("_Depth", idx);
-                Graphics.DrawTexture(new Rect(x + b, y + b / 2f, h - b, h - b), lodData.DataTexture, textureArrayMaterial);
+                    // Render specific slice of 2D texture array
+                    textureArrayMaterial.SetInt("_Depth", idx);
+                    Graphics.DrawTexture(new Rect(x + b, y + b / 2f, h - b, h - b), lodData.DataTexture, textureArrayMaterial);
+                }
             }
         }
 
-        _drawTargets[type] = GUI.Toggle(new Rect(x + b, Screen.height - 25f, w - 2f * b, 25f), _drawTargets[type], _simNames[type]);
+
+        _drawTargets[type] = GUI.Toggle(new Rect(x + b, togglesBegin, w - 2f * b, _bottomPanelHeight), _drawTargets[type], _simNames[type]);
 
         offset++;
     }

--- a/crest/Assets/Crest/Crest-Examples/Shared/Scripts/OceanDebugGUI.cs
+++ b/crest/Assets/Crest/Crest-Examples/Shared/Scripts/OceanDebugGUI.cs
@@ -10,13 +10,13 @@ public class OceanDebugGUI : MonoBehaviour
 {
     [SerializeField] bool _showSimTargets = false;
     [SerializeField] bool _guiVisible = true;
-    static float _leftPanelWidth = 180f;
-    static float _bottomPanelHeight = 25f;
-    static Color _guiColor = Color.black * 0.7f;
+    readonly static float _leftPanelWidth = 180f;
+    readonly static float _bottomPanelHeight = 25f;
+    readonly static Color _guiColor = Color.black * 0.7f;
     ShapeGerstnerBatched[] _gerstners;
 
-    static Dictionary<System.Type, bool> _drawTargets = new Dictionary<System.Type, bool>();
-    static Dictionary<System.Type, string> _simNames = new Dictionary<System.Type, string>();
+    readonly static Dictionary<System.Type, bool> _drawTargets = new Dictionary<System.Type, bool>();
+    readonly static Dictionary<System.Type, string> _simNames = new Dictionary<System.Type, string>();
 
     static Material textureArrayMaterial;
 

--- a/crest/Assets/Crest/Crest-Examples/Shared/Shaders.meta
+++ b/crest/Assets/Crest/Crest-Examples/Shared/Shaders.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7d5a7ad66395d4cba8838f2f00e39e49
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/crest/Assets/Crest/Crest-Examples/Shared/Shaders/Debug.meta
+++ b/crest/Assets/Crest/Crest-Examples/Shared/Shaders/Debug.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8faa2b06c02e446f781937aa730e78de
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/crest/Assets/Crest/Crest-Examples/Shared/Shaders/Debug/TextureArray.shader
+++ b/crest/Assets/Crest/Crest-Examples/Shared/Shaders/Debug/TextureArray.shader
@@ -1,0 +1,49 @@
+﻿// Crest Ocean System
+
+// This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
+
+// Renders a specific slice of a 2D Texture Array
+// https://docs.unity3d.com/Manual/SL-TextureArrays.html
+Shader "Hidden/Crest/Debug/TextureArray"
+{
+	SubShader
+	{
+		Tags { "RenderType"="Opaque" }
+		Cull Off
+		ZWrite Off
+
+		Pass
+		{
+			CGPROGRAM
+			#pragma vertex vert
+			#pragma fragment frag
+			#pragma require 2darray
+
+			#include "UnityCG.cginc"
+
+			struct v2f
+			{
+				float3 uv : TEXCOORD0;
+				float4 vertex : SV_POSITION;
+			};
+
+			UNITY_DECLARE_TEX2DARRAY(_MainTex);
+			uint _Depth;
+
+			v2f vert (float4 vertex : POSITION, float3 uv : TEXCOORD0)
+			{
+				v2f o;
+				o.vertex = mul(UNITY_MATRIX_P, vertex);
+				o.uv = float3(uv.xy, _Depth);
+				return o;
+			}
+
+			half4 frag (v2f i) : SV_TARGET
+			{
+				// Brighten textures so they match previous solution (4)
+				return UNITY_SAMPLE_TEX2DARRAY(_MainTex, i.uv) * 4;
+			}
+			ENDCG
+		}
+	}
+}

--- a/crest/Assets/Crest/Crest-Examples/Shared/Shaders/Debug/TextureArray.shader.meta
+++ b/crest/Assets/Crest/Crest-Examples/Shared/Shaders/Debug/TextureArray.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 29dad847f745e944a98a415e92bdb4d3
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Resolves #277. Not my first issue, but I am very green when it comes to these things so I thought I would give it a try. Followed the following:
https://docs.unity3d.com/Manual/SL-TextureArrays.html

I went with the simplest approach which is a shader to render a specific depth of the texture array. I placed it under `Crest-Examples` since that is where the `OceanDebugGUI` lives.

I made some other optimisations and a minor design change. If you want to use the old layout, then I can easily change it back (but still have it optimised).

Before:
![Before](https://user-images.githubusercontent.com/5249806/71140932-ca0bc900-2266-11ea-850c-b03db8e48d54.png)

After:
![After](https://user-images.githubusercontent.com/5249806/71140942-d132d700-2266-11ea-8e60-1a2482844650.png)

Tested on MacOS with 2018.4 and 2019.2