### PR TITLE
Baked depth cache improvements

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
@@ -4,6 +4,7 @@
 
 // This is the original version that uses an auxillary camera and works with Unity's GPU terrain - issue 152.
 
+using System;
 using UnityEditor;
 using UnityEngine;
 
@@ -310,7 +311,8 @@ namespace Crest
                 byte[] bytes;
                 bytes = tex.EncodeToEXR(Texture2D.EXRFlags.OutputAsFloat);
 
-                string path = dc._savedCache ? AssetDatabase.GetAssetPath(dc._savedCache) : $"Assets/{target.name}.exr";
+                string path = dc._savedCache ? 
+                    AssetDatabase.GetAssetPath(dc._savedCache) : $"Assets/OceanDepthCache_{Guid.NewGuid()}.exr";
                 System.IO.File.WriteAllBytes(path, bytes);
                 AssetDatabase.ImportAsset(path);
 

--- a/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
@@ -386,7 +386,7 @@ namespace Crest
                 ti.alphaIsTransparency = false;
                 ti.SaveAndReimport();
 
-                Debug.Log("Saved to " + path);
+                Debug.Log("Cache saved to " + path, AssetDatabase.LoadAssetAtPath<UnityEngine.Object>(path));
             }
         }
     }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
@@ -38,7 +38,11 @@ namespace Crest
         bool _forceAlwaysUpdateDebug = false;
 #pragma warning restore 414
 
-        public Texture2D _savedCache;
+        [Tooltip("Baked depth cache. Baking button available in play mode."), SerializeField]
+#pragma warning disable 649
+        Texture2D _savedCache;
+#pragma warning restore 649
+        public Texture2D SavedCache => _savedCache;
 
         [Tooltip("Check for any terrains that have the 'Draw Instanced' option enabled. Such instanced terrains will not populate into the depth cache and therefore will not contribute to shorelines and shallow water. This option must be disabled on the terrain when the depth cache is populated (but can be enabled afterwards)."), SerializeField]
 #pragma warning disable 414
@@ -311,8 +315,8 @@ namespace Crest
                 byte[] bytes;
                 bytes = tex.EncodeToEXR(Texture2D.EXRFlags.OutputAsFloat);
 
-                string path = dc._savedCache ? 
-                    AssetDatabase.GetAssetPath(dc._savedCache) : $"Assets/OceanDepthCache_{Guid.NewGuid()}.exr";
+                string path = dc.SavedCache ? 
+                    AssetDatabase.GetAssetPath(dc.SavedCache) : $"Assets/OceanDepthCache_{Guid.NewGuid()}.exr";
                 System.IO.File.WriteAllBytes(path, bytes);
                 AssetDatabase.ImportAsset(path);
 

--- a/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
@@ -313,7 +313,14 @@ namespace Crest
 
         public override void OnInspectorGUI()
         {
-            // First expose cache type and refresh mode
+            // We won't just use default inspector because we want to show some of the params conditionally based on cache type
+
+            // First show standard 'Script' field
+            GUI.enabled = false;
+            EditorGUILayout.PropertyField(serializedObject.FindProperty("m_Script"));
+            GUI.enabled = true;
+
+            // Next expose cache type and refresh mode
 
             var typeProp = serializedObject.FindProperty("_type");
             EditorGUILayout.PropertyField(typeProp);

--- a/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
@@ -80,26 +80,11 @@ namespace Crest
                 return;
             }
 
-            if (_drawCacheQuad == null)
+            if (_type == OceanDepthCacheType.Baked && _drawCacheQuad == null)
             {
-                _drawCacheQuad = GameObject.CreatePrimitive(PrimitiveType.Quad);
-                Destroy(_drawCacheQuad.GetComponent<Collider>());
-                _drawCacheQuad.name = "DepthCache_" + gameObject.name;
-                _drawCacheQuad.transform.SetParent(transform, false);
-                _drawCacheQuad.transform.localEulerAngles = 90f * Vector3.right;
-                _drawCacheQuad.AddComponent<RegisterSeaFloorDepthInput>();
-                var qr = _drawCacheQuad.GetComponent<Renderer>();
-                qr.material = new Material(Shader.Find(LodDataMgrSeaFloorDepth.ShaderName));
-
-                if (_type == OceanDepthCacheType.Baked)
-                {
-                    qr.material.mainTexture = _savedCache;
-                }
-
-                qr.enabled = false;
+                DrawCacheQuad();
             }
-
-            if (_type == OceanDepthCacheType.Realtime && _refreshMode == OceanDepthCacheRefreshMode.OnStart)
+            else if (_type == OceanDepthCacheType.Realtime && _refreshMode == OceanDepthCacheRefreshMode.OnStart)
             {
                 PopulateCache();
             }
@@ -230,8 +215,30 @@ namespace Crest
             Shader.SetGlobalVector("_OceanCenterPosWorld", centerPoint);
             _camDepthCache.RenderWithShader(Shader.Find("Crest/Inputs/Depth/Ocean Depth From Geometry"), null);
 
+            DrawCacheQuad();
+        }
+
+        void DrawCacheQuad()
+        {
+            _drawCacheQuad = GameObject.CreatePrimitive(PrimitiveType.Quad);
+            Destroy(_drawCacheQuad.GetComponent<Collider>());
+            _drawCacheQuad.name = "DepthCache_" + gameObject.name;
+            _drawCacheQuad.transform.SetParent(transform, false);
+            _drawCacheQuad.transform.localEulerAngles = 90f * Vector3.right;
+            _drawCacheQuad.AddComponent<RegisterSeaFloorDepthInput>();
             var qr = _drawCacheQuad.GetComponent<Renderer>();
-            qr.material.mainTexture = _cacheTexture;
+            qr.material = new Material(Shader.Find(LodDataMgrSeaFloorDepth.ShaderName));
+
+            if (_type == OceanDepthCacheType.Baked)
+            {
+                qr.material.mainTexture = _savedCache;
+            }
+            else
+            {
+                qr.material.mainTexture = _cacheTexture;
+            }
+
+            qr.enabled = false;
         }
 
 #if UNITY_EDITOR

--- a/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
@@ -346,7 +346,15 @@ namespace Crest
             var playing = EditorApplication.isPlaying;
 
             var dc = target as OceanDepthCache;
-            var isBakeable = cacheType == OceanDepthCache.OceanDepthCacheType.Realtime;
+            var isOnDemand = cacheType == OceanDepthCache.OceanDepthCacheType.Realtime &&
+                dc.RefreshMode == OceanDepthCache.OceanDepthCacheRefreshMode.OnDemand;
+            var isBakeable = cacheType == OceanDepthCache.OceanDepthCacheType.Realtime &&
+                (!isOnDemand || dc.CacheTexture != null);
+
+            if (playing && isOnDemand && GUILayout.Button("Populate cache"))
+            {
+                dc.PopulateCache();
+            }
 
             if (playing && isBakeable && GUILayout.Button("Save cache to file"))
             {

--- a/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
@@ -159,7 +159,7 @@ namespace Crest
             }
 
 #if UNITY_EDITOR
-            if (_checkTerrainDrawInstancedOption)
+            if (_type == OceanDepthCacheType.Realtime && _checkTerrainDrawInstancedOption)
             {
                 // This issue only affects the built-in render pipeline. Issue 158: https://github.com/crest-ocean/crest/issues/158
 


### PR DESCRIPTION
Continues on from issue #364

Overwriting is for quality of life. Otherwise, you would have to remove the texture property, bake, replace and finally delete the old texture. It can track path changes so users can rename GUID name if desired. GUIDs are used to avoid conflicts.