### PR TITLE
Ocean Debug GUI housekeeping

### DIFF
--- a/crest/Assets/Crest/Crest-Examples/Shared/Scripts/OceanDebugGUI.cs
+++ b/crest/Assets/Crest/Crest-Examples/Shared/Scripts/OceanDebugGUI.cs
@@ -167,7 +167,8 @@ public class OceanDebugGUI : MonoBehaviour
 
         // Draw bottom panel for toggles
         GUI.color = _guiColor;
-        GUI.DrawTexture(new Rect(_leftPanelWidth, Screen.height - _bottomPanelHeight, Screen.width, _bottomPanelHeight), Texture2D.whiteTexture);
+        GUI.DrawTexture(new Rect(_guiVisible ? _leftPanelWidth : 0, Screen.height - _bottomPanelHeight, Screen.width,
+            _bottomPanelHeight), Texture2D.whiteTexture);
         GUI.color = Color.white;
 
         // draw sim data

--- a/crest/Assets/Crest/Crest-Examples/Shared/Shaders/Debug/TextureArray.shader
+++ b/crest/Assets/Crest/Crest-Examples/Shared/Shaders/Debug/TextureArray.shader
@@ -15,33 +15,38 @@ Shader "Hidden/Crest/Debug/TextureArray"
 		Pass
 		{
 			CGPROGRAM
-			#pragma vertex vert
-			#pragma fragment frag
+			#pragma vertex Vert
+			#pragma fragment Frag
 			#pragma require 2darray
 
 			#include "UnityCG.cginc"
 
-			struct v2f
+			struct Attributes
 			{
+				float4 positionOS : POSITION;
+				float2 uv : TEXCOORD0;
+			};
+
+			struct Varyings
+			{
+				float4 positionCS : SV_POSITION;
 				float3 uv : TEXCOORD0;
-				float4 vertex : SV_POSITION;
 			};
 
 			UNITY_DECLARE_TEX2DARRAY(_MainTex);
 			uint _Depth;
 
-			v2f vert (float4 vertex : POSITION, float3 uv : TEXCOORD0)
+			Varyings Vert(Attributes input)
 			{
-				v2f o;
-				o.vertex = mul(UNITY_MATRIX_P, vertex);
-				o.uv = float3(uv.xy, _Depth);
+				Varyings o;
+				o.positionCS = UnityObjectToClipPos(input.positionOS);
+				o.uv = float3(input.uv.xy, _Depth);
 				return o;
 			}
 
-			half4 frag (v2f i) : SV_TARGET
+			half4 Frag(Varyings input) : SV_TARGET
 			{
-				// Brighten textures so they match previous solution (4)
-				return UNITY_SAMPLE_TEX2DARRAY(_MainTex, i.uv) * 4;
+				return UNITY_SAMPLE_TEX2DARRAY(_MainTex, input.uv);
 			}
 			ENDCG
 		}


### PR DESCRIPTION
TextureArray shader
- Use code style similar to other shaders
- Use unity_ColorSpaceDouble to brighten textures
- Use newer UnityObjectToClipPos
- UV only needs to be float2

OceanDebugGUI
- Make bottom bar full width if sidebar hidden