### PR TITLE
Add pixel light support

### DIFF
--- a/crest/Assets/Crest/Crest/Shaders/Ocean.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Ocean.shader
@@ -525,6 +525,7 @@ Shader "Crest/Ocean"
 			// Temporary. Prevents doubling of some effects leading to artefacts.
 			// But this pass should be distilled so that only the light is applied instead.
 			// Doesn't work very well with foam lighting
+			// Blend SrcAlpha One
 			BlendOp Max
 			// Culling user defined - can be inverted for under water
 			Cull [_CullMode]
@@ -851,6 +852,7 @@ Shader "Crest/Ocean"
 				#endif
 				#endif
 
+				// return half4(col, lightCol.a);
 				return half4(col, 1.);
 			}
 

--- a/crest/Assets/Crest/Crest/Shaders/Ocean.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Ocean.shader
@@ -176,11 +176,6 @@ Shader "Crest/Ocean"
 
 	SubShader
 	{
-		// ForwardBase - tell unity we're going to render water in forward manner and we're going to do lighting and it will set the appropriate uniforms
-		// Geometry+510 - unity treats anything after Geometry+500 as transparent, and will render it in a forward manner and copy out the gbuffer data
-		//     and do post processing before running it. Discussion of this in issue #53.
-		Tags { "LightMode"="ForwardBase" "Queue"="Geometry+510" "IgnoreProjector"="True" "RenderType"="Opaque" }
-
 		GrabPass
 		{
 			"_BackgroundTexture"
@@ -188,6 +183,346 @@ Shader "Crest/Ocean"
 
 		Pass
 		{
+			// ForwardBase - tell unity we're going to render water in forward manner and we're going to do lighting and it will set the appropriate uniforms
+			// Geometry+510 - unity treats anything after Geometry+500 as transparent, and will render it in a forward manner and copy out the gbuffer data
+			//     and do post processing before running it. Discussion of this in issue #53.
+			Tags { "LightMode"="ForwardBase" "Queue"="Geometry+510" "IgnoreProjector"="True" "RenderType"="Opaque" }
+			// Culling user defined - can be inverted for under water
+			Cull [_CullMode]
+
+			CGPROGRAM
+			#pragma vertex Vert
+			#pragma fragment Frag
+			// for VFACE
+			#pragma target 3.0
+			#pragma multi_compile_fog
+
+			#pragma shader_feature _APPLYNORMALMAPPING_ON
+			#pragma shader_feature _COMPUTEDIRECTIONALLIGHT_ON
+			#pragma shader_feature _DIRECTIONALLIGHTVARYROUGHNESS_ON
+			#pragma shader_feature _SUBSURFACESCATTERING_ON
+			#pragma shader_feature _SUBSURFACESHALLOWCOLOUR_ON
+			#pragma shader_feature _TRANSPARENCY_ON
+			#pragma shader_feature _CAUSTICS_ON
+			#pragma shader_feature _FOAM_ON
+			#pragma shader_feature _FOAM3DLIGHTING_ON
+			#pragma shader_feature _PLANARREFLECTIONS_ON
+			#pragma shader_feature _OVERRIDEREFLECTIONCUBEMAP_ON
+
+			#pragma shader_feature _PROCEDURALSKY_ON
+			#pragma shader_feature _UNDERWATER_ON
+			#pragma shader_feature _FLOW_ON
+			#pragma shader_feature _SHADOWS_ON
+
+			#pragma shader_feature _DEBUGDISABLESHAPETEXTURES_ON
+			#pragma shader_feature _DEBUGVISUALISESHAPESAMPLE_ON
+			#pragma shader_feature _DEBUGVISUALISEFLOW_ON
+			#pragma shader_feature _DEBUGDISABLESMOOTHLOD_ON
+			#pragma shader_feature _COMPILESHADERWITHDEBUGINFO_ON
+
+			#if _COMPILESHADERWITHDEBUGINFO_ON
+			#pragma enable_d3d11_debug_symbols
+			#endif
+
+			#include "UnityCG.cginc"
+			#include "Lighting.cginc"
+
+			struct Attributes
+			{
+				// The old unity macros require this name and type.
+				float4 vertex : POSITION;
+			};
+
+			struct Varyings
+			{
+				float4 positionCS : SV_POSITION;
+				half4 flow_shadow : TEXCOORD1;
+				half4 foam_screenPosXYW : TEXCOORD4;
+				float4 lodAlpha_worldXZUndisplaced_oceanDepth : TEXCOORD5;
+				float3 worldPos : TEXCOORD7;
+				#if _DEBUGVISUALISESHAPESAMPLE_ON
+				half3 debugtint : TEXCOORD8;
+				#endif
+				half4 grabPos : TEXCOORD9;
+
+				UNITY_FOG_COORDS(3)
+			};
+
+			#include "OceanHelpers.hlsl"
+
+			float _CrestTime;
+
+			// MeshScaleLerp, FarNormalsWeight, LODIndex (debug)
+			float3 _InstanceData;
+
+			// Argument name is v because some macros like COMPUTE_EYEDEPTH require it.
+			Varyings Vert(Attributes v)
+			{
+				Varyings o;
+
+				// Move to world space
+				o.worldPos = mul(unity_ObjectToWorld, float4(v.vertex.xyz, 1.0));
+
+				// Vertex snapping and lod transition
+				float lodAlpha;
+				SnapAndTransitionVertLayout(_InstanceData.x, o.worldPos, lodAlpha);
+				o.lodAlpha_worldXZUndisplaced_oceanDepth.x = lodAlpha;
+				o.lodAlpha_worldXZUndisplaced_oceanDepth.yz = o.worldPos.xz;
+
+				// sample shape textures - always lerp between 2 LOD scales, so sample two textures
+				o.flow_shadow = half4(0., 0., 0., 0.);
+				o.foam_screenPosXYW.x = 0.;
+
+				o.lodAlpha_worldXZUndisplaced_oceanDepth.w = CREST_OCEAN_DEPTH_BASELINE;
+				// Sample shape textures - always lerp between 2 LOD scales, so sample two textures
+
+				// Calculate sample weights. params.z allows shape to be faded out (used on last lod to support pop-less scale transitions)
+				const float wt_smallerLod = (1. - lodAlpha) * _LD_Params[_LD_SliceIndex].z;
+				const float wt_biggerLod = (1. - wt_smallerLod) * _LD_Params[_LD_SliceIndex + 1].z;
+				// Sample displacement textures, add results to current world pos / normal / foam
+				const float2 positionWS_XZ_before = o.worldPos.xz;
+
+				// Data that needs to be sampled at the undisplaced position
+				if (wt_smallerLod > 0.001)
+				{
+					const float3 uv_slice_smallerLod = WorldToUV(positionWS_XZ_before);
+
+					#if !_DEBUGDISABLESHAPETEXTURES_ON
+					half sss = 0.;
+					SampleDisplacements(_LD_TexArray_AnimatedWaves, uv_slice_smallerLod, wt_smallerLod, o.worldPos, sss);
+					#endif
+
+					#if _FOAM_ON
+					SampleFoam(_LD_TexArray_Foam, uv_slice_smallerLod, wt_smallerLod, o.foam_screenPosXYW.x);
+					#endif
+
+					#if _FLOW_ON
+					SampleFlow(_LD_TexArray_Flow, uv_slice_smallerLod, wt_smallerLod, o.flow_shadow.xy);
+					#endif
+				}
+				if (wt_biggerLod > 0.001)
+				{
+					const float3 uv_slice_biggerLod = WorldToUV_BiggerLod(positionWS_XZ_before);
+
+					#if !_DEBUGDISABLESHAPETEXTURES_ON
+					half sss = 0.;
+					SampleDisplacements(_LD_TexArray_AnimatedWaves, uv_slice_biggerLod, wt_biggerLod, o.worldPos, sss);
+					#endif
+
+					#if _FOAM_ON
+					SampleFoam(_LD_TexArray_Foam, uv_slice_biggerLod, wt_biggerLod, o.foam_screenPosXYW.x);
+					#endif
+
+					#if _FLOW_ON
+					SampleFlow(_LD_TexArray_Flow, uv_slice_biggerLod, wt_biggerLod, o.flow_shadow.xy);
+					#endif
+				}
+
+				// Data that needs to be sampled at the displaced position
+				if (wt_smallerLod > 0.001)
+				{
+					const float3 uv_slice_smallerLodDisp = WorldToUV(o.worldPos.xz);
+
+					#if _SUBSURFACESHALLOWCOLOUR_ON
+					SampleSeaDepth(_LD_TexArray_SeaFloorDepth, uv_slice_smallerLodDisp, wt_smallerLod, o.lodAlpha_worldXZUndisplaced_oceanDepth.w);
+					#endif
+
+					#if _SHADOWS_ON
+					SampleShadow(_LD_TexArray_Shadow, uv_slice_smallerLodDisp, wt_smallerLod, o.flow_shadow.zw);
+					#endif
+				}
+				if (wt_biggerLod > 0.001)
+				{
+					const float3 uv_slice_biggerLodDisp = WorldToUV_BiggerLod(o.worldPos.xz);
+
+					#if _SUBSURFACESHALLOWCOLOUR_ON
+					SampleSeaDepth(_LD_TexArray_SeaFloorDepth, uv_slice_biggerLodDisp, wt_biggerLod, o.lodAlpha_worldXZUndisplaced_oceanDepth.w);
+					#endif
+
+					#if _SHADOWS_ON
+					SampleShadow(_LD_TexArray_Shadow, uv_slice_biggerLodDisp, wt_biggerLod, o.flow_shadow.zw);
+					#endif
+				}
+
+				// Foam can saturate
+				o.foam_screenPosXYW.x = saturate(o.foam_screenPosXYW.x);
+
+				// debug tinting to see which shape textures are used
+				#if _DEBUGVISUALISESHAPESAMPLE_ON
+				#define TINT_COUNT (uint)7
+				half3 tintCols[TINT_COUNT]; tintCols[0] = half3(1., 0., 0.); tintCols[1] = half3(1., 1., 0.); tintCols[2] = half3(1., 0., 1.); tintCols[3] = half3(0., 1., 1.); tintCols[4] = half3(0., 0., 1.); tintCols[5] = half3(1., 0., 1.); tintCols[6] = half3(.5, .5, 1.);
+				o.debugtint = wt_smallerLod * tintCols[_LD_LodIdx_0 % TINT_COUNT] + wt_biggerLod * tintCols[_LD_LodIdx_1 % TINT_COUNT];
+				#endif
+
+				// view-projection
+				o.positionCS = mul(UNITY_MATRIX_VP, float4(o.worldPos, 1.));
+
+				UNITY_TRANSFER_FOG(o, o.positionCS);
+
+				// unfortunate hoop jumping - this is inputs for refraction. depending on whether HDR is on or off, the grabbed scene
+				// colours may or may not come from the backbuffer, which means they may or may not be flipped in y. use these macros
+				// to get the right results, every time.
+				o.grabPos = ComputeGrabScreenPos(o.positionCS);
+				o.foam_screenPosXYW.yzw = ComputeScreenPos(o.positionCS).xyw;
+				return o;
+			}
+
+			// frag shader uniforms
+
+			#include "OceanFoam.hlsl"
+			#include "OceanEmission.hlsl"
+			#include "OceanReflection.hlsl"
+			uniform sampler2D _Normals;
+			#include "OceanNormalMapping.hlsl"
+
+			uniform sampler2D _CameraDepthTexture;
+
+			// Hack - due to SV_IsFrontFace occasionally coming through as true for backfaces,
+			// add a param here that forces ocean to be in undrwater state. I think the root
+			// cause here might be imprecision or numerical issues at ocean tile boundaries, although
+			// i'm not sure why cracks are not visible in this case.
+			uniform float _ForceUnderwater;
+
+			float3 WorldSpaceLightDir(float3 worldPos)
+			{
+				float3 lightDir = _WorldSpaceLightPos0.xyz;
+				if (_WorldSpaceLightPos0.w > 0.)
+				{
+					// non-directional light - this is a position, not a direction
+					lightDir = normalize(lightDir - worldPos.xyz);
+				}
+				return lightDir;
+			}
+
+			bool IsUnderwater(const float facing)
+			{
+#if !_UNDERWATER_ON
+				return false;
+#endif
+				const bool backface = facing < 0.0;
+				return backface || _ForceUnderwater > 0.0;
+			}
+
+			half4 Frag(const Varyings input, const float facing : VFACE) : SV_Target
+			{
+				const bool underwater = IsUnderwater(facing);
+				const float lodAlpha = input.lodAlpha_worldXZUndisplaced_oceanDepth.x;
+
+				half3 view = normalize(_WorldSpaceCameraPos - input.worldPos);
+
+				// water surface depth, and underlying scene opaque surface depth
+				float pixelZ = LinearEyeDepth(input.positionCS.z);
+				half3 screenPos = input.foam_screenPosXYW.yzw;
+				half2 uvDepth = screenPos.xy / screenPos.z;
+				float sceneZ01 = tex2D(_CameraDepthTexture, uvDepth).x;
+				float sceneZ = LinearEyeDepth(sceneZ01);
+
+				float3 lightDir = WorldSpaceLightDir(input.worldPos);
+				// Soft shadow, hard shadow
+				fixed2 shadow = (fixed2)1.0
+				#if _SHADOWS_ON
+					- input.flow_shadow.zw
+				#endif
+					;
+
+				// Normal - geom + normal mapping. Subsurface scattering.
+				const float3 uv_slice_smallerLod = WorldToUV(input.lodAlpha_worldXZUndisplaced_oceanDepth.yz);
+				const float3 uv_slice_biggerLod = WorldToUV_BiggerLod(input.lodAlpha_worldXZUndisplaced_oceanDepth.yz);
+				const float wt_smallerLod = (1. - lodAlpha) * _LD_Params[_LD_SliceIndex].z;
+				const float wt_biggerLod = (1. - wt_smallerLod) * _LD_Params[_LD_SliceIndex + 1].z;
+				float3 dummy = 0.;
+				half3 n_geom = half3(0.0, 1.0, 0.0);
+				half sss = 0.;
+				if (wt_smallerLod > 0.001) SampleDisplacementsNormals(_LD_TexArray_AnimatedWaves, uv_slice_smallerLod, wt_smallerLod, _LD_Params[_LD_SliceIndex].w, _LD_Params[_LD_SliceIndex].x, dummy, n_geom.xz, sss);
+				if (wt_biggerLod > 0.001) SampleDisplacementsNormals(_LD_TexArray_AnimatedWaves, uv_slice_biggerLod, wt_biggerLod, _LD_Params[_LD_SliceIndex + 1].w, _LD_Params[_LD_SliceIndex + 1].x, dummy, n_geom.xz, sss);
+				n_geom = normalize(n_geom);
+
+				if (underwater) n_geom = -n_geom;
+				half3 n_pixel = n_geom;
+				#if _APPLYNORMALMAPPING_ON
+				#if _FLOW_ON
+				ApplyNormalMapsWithFlow(input.lodAlpha_worldXZUndisplaced_oceanDepth.yz, input.flow_shadow.xy, lodAlpha, n_pixel);
+				#else
+				n_pixel.xz += (underwater ? -1. : 1.) * SampleNormalMaps(input.lodAlpha_worldXZUndisplaced_oceanDepth.yz, lodAlpha);
+				n_pixel = normalize(n_pixel);
+				#endif
+				#endif
+
+				// Foam - underwater bubbles and whitefoam
+				half3 bubbleCol = (half3)0.;
+				#if _FOAM_ON
+				half4 whiteFoamCol;
+				#if !_FLOW_ON
+				ComputeFoam(input.foam_screenPosXYW.x, input.lodAlpha_worldXZUndisplaced_oceanDepth.yz, input.worldPos.xz, n_pixel, pixelZ, sceneZ, view, lightDir, shadow.y, lodAlpha, bubbleCol, whiteFoamCol);
+				#else
+				ComputeFoamWithFlow(input.flow_shadow.xy, input.foam_screenPosXYW.x, input.lodAlpha_worldXZUndisplaced_oceanDepth.yz, input.worldPos.xz, n_pixel, pixelZ, sceneZ, view, lightDir, shadow.y, lodAlpha, bubbleCol, whiteFoamCol);
+				#endif // _FLOW_ON
+				#endif // _FOAM_ON
+
+				// Compute color of ocean - in-scattered light + refracted scene
+				half3 scatterCol = ScatterColour(input.lodAlpha_worldXZUndisplaced_oceanDepth.w, _WorldSpaceCameraPos, lightDir, view, shadow.x, underwater, true, sss);
+				half3 col = OceanEmission(view, n_pixel, lightDir, input.grabPos, pixelZ, uvDepth, sceneZ, sceneZ01, bubbleCol, _Normals, _CameraDepthTexture, underwater, scatterCol);
+
+				// Light that reflects off water surface
+
+				// Soften reflection at intersections with objects/surfaces
+				#if _TRANSPARENCY_ON
+				float reflAlpha = saturate((sceneZ - pixelZ) / 0.2);
+				#else
+				// This addresses the problem where screenspace depth doesnt work in VR, and so neither will this. In VR people currently
+				// disable transparency, so this will always be 1.0.
+				float reflAlpha = 1.0;
+				#endif
+				
+				#if _UNDERWATER_ON
+				if (underwater)
+				{
+					ApplyReflectionUnderwater(view, n_pixel, lightDir, shadow.y, input.foam_screenPosXYW.yzzw, scatterCol, reflAlpha, col);
+				}
+				else
+				#endif
+				{
+					ApplyReflectionSky(view, n_pixel, lightDir, shadow.y, input.foam_screenPosXYW.yzzw, pixelZ, reflAlpha, col);
+				}
+
+				// Override final result with white foam - bubbles on surface
+				#if _FOAM_ON
+				col = lerp(col, whiteFoamCol.rgb, whiteFoamCol.a);
+				#endif
+
+				// Fog
+				if (!underwater)
+				{
+					// Above water - do atmospheric fog. If you are using a third party sky package such as Azure, replace this with their stuff!
+					UNITY_APPLY_FOG(input.fogCoord, col);
+				}
+				else
+				{
+					// underwater - do depth fog
+					col = lerp(col, scatterCol, saturate(1. - exp(-_DepthFogDensity.xyz * pixelZ)));
+				}
+
+				#if _DEBUGVISUALISESHAPESAMPLE_ON
+				col = lerp(col.rgb, input.debugtint, 0.5);
+				#endif
+				#if _DEBUGVISUALISEFLOW_ON
+				#if _FLOW_ON
+				col.rg = lerp(col.rg, input.flow_shadow.xy, 0.5);
+				#endif
+				#endif
+
+				return half4(col, 1.);
+			}
+
+			ENDCG
+		}
+
+		Pass
+		{
+			// ForwardBase - tell unity we're going to render water in forward manner and we're going to do lighting and it will set the appropriate uniforms
+			// Geometry+510 - unity treats anything after Geometry+500 as transparent, and will render it in a forward manner and copy out the gbuffer data
+			//     and do post processing before running it. Discussion of this in issue #53.
+			Tags { "LightMode"="ForwardBase" "Queue"="Geometry+510" "IgnoreProjector"="True" "RenderType"="Opaque" }
 			// Culling user defined - can be inverted for under water
 			Cull [_CullMode]
 

--- a/crest/Assets/Crest/Crest/Shaders/OceanEmission.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanEmission.hlsl
@@ -49,7 +49,7 @@ uniform half3 _DiffuseShadow;
 half3 ScatterColour(
 	in const half i_surfaceOceanDepth, in const float3 i_cameraPos,
 	in const half3 i_lightDir, in const half3 i_view, in const fixed i_shadow,
-	in const bool i_underwater, in const bool i_outscatterLight, half sss)
+	in const bool i_underwater, in const bool i_outscatterLight, half sss, half4 lightCol)
 {
 	half depth;
 	half shadow = 1.0;
@@ -113,7 +113,7 @@ half3 ScatterColour(
 
 		// Approximate subsurface scattering - add light when surface faces viewer. Use geometry normal - don't need high freqs.
 		half towardsSun = pow(max(0., dot(i_lightDir, -i_view)), _SubSurfaceSunFallOff);
-		half3 subsurface = (_SubSurfaceBase + _SubSurfaceSun * towardsSun) * _SubSurfaceColour.rgb * _LightColor0 * shadow;
+		half3 subsurface = (_SubSurfaceBase + _SubSurfaceSun * towardsSun) * _SubSurfaceColour.rgb * lightCol * shadow;
 		if (!i_underwater)
 			subsurface *= (1.0 - v * v) * sss;
 		col += subsurface;

--- a/crest/Assets/Crest/Crest/Shaders/OceanFoam.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanFoam.hlsl
@@ -48,7 +48,7 @@ half BubbleFoamTexture(float2 i_worldXZ, float2 i_worldXZUndisplaced, half3 i_n,
 	return ft;
 }
 
-void ComputeFoam(half i_foam, float2 i_worldXZUndisplaced, float2 i_worldXZ, half3 i_n, float i_pixelZ, float i_sceneZ, half3 i_view, float3 i_lightDir, half i_shadow, half lodVal, out half3 o_bubbleCol, out half4 o_whiteFoamCol)
+void ComputeFoam(half i_foam, float2 i_worldXZUndisplaced, float2 i_worldXZ, half3 i_n, float i_pixelZ, float i_sceneZ, half3 i_view, float3 i_lightDir, half i_shadow, half lodVal, out half3 o_bubbleCol, out half4 o_whiteFoamCol, half4 lightCol)
 {
 	half foamAmount = i_foam;
 
@@ -73,17 +73,17 @@ void ComputeFoam(half i_foam, float2 i_worldXZUndisplaced, float2 i_worldXZ, hal
 	half3 fN = normalize(i_n + _WaveFoamNormalStrength * half3(-dfdx, 0., -dfdz));
 	// do simple NdL and phong lighting
 	half foamNdL = max(0., dot(fN, i_lightDir));
-	o_whiteFoamCol.rgb = _FoamWhiteColor.rgb * (AmbientLight() + _WaveFoamLightScale * _LightColor0 * foamNdL * i_shadow);
+	o_whiteFoamCol.rgb = _FoamWhiteColor.rgb * (AmbientLight() + _WaveFoamLightScale * lightCol * foamNdL * i_shadow);
 	half3 refl = reflect(-i_view, fN);
-	o_whiteFoamCol.rgb += pow(max(0., dot(refl, i_lightDir)), _WaveFoamSpecularFallOff) * _WaveFoamSpecularBoost * _LightColor0 * i_shadow;
+	o_whiteFoamCol.rgb += pow(max(0., dot(refl, i_lightDir)), _WaveFoamSpecularFallOff) * _WaveFoamSpecularBoost * lightCol * i_shadow;
 #else // _FOAM3DLIGHTING_ON
-	o_whiteFoamCol.rgb = _FoamWhiteColor.rgb * (AmbientLight() + _WaveFoamLightScale * _LightColor0 * i_shadow);
+	o_whiteFoamCol.rgb = _FoamWhiteColor.rgb * (AmbientLight() + _WaveFoamLightScale * lightCol * i_shadow);
 #endif // _FOAM3DLIGHTING_ON
 
 	o_whiteFoamCol.a = _FoamWhiteColor.a * whiteFoam;
 }
 
-void ComputeFoamWithFlow(half2 flow, half i_foam, float2 i_worldXZUndisplaced, float2 i_worldXZ, half3 i_n, float i_pixelZ, float i_sceneZ, half3 i_view, float3 i_lightDir, half i_shadow, half lodVal, out half3 o_bubbleCol, out half4 o_whiteFoamCol)
+void ComputeFoamWithFlow(half2 flow, half i_foam, float2 i_worldXZUndisplaced, float2 i_worldXZ, half3 i_n, float i_pixelZ, float i_sceneZ, half3 i_view, float3 i_lightDir, half i_shadow, half lodVal, out half3 o_bubbleCol, out half4 o_whiteFoamCol, half4 lightCol)
 {
 	const float half_period = 1;
 	const float period = half_period * 2;
@@ -101,8 +101,8 @@ void ComputeFoamWithFlow(half2 flow, half i_foam, float2 i_worldXZUndisplaced, f
 	half3 o_bubbleCol2 = half3(0, 0, 0);
 	half4 o_whiteFoamCol2 = half4(0, 0, 0, 0);
 
-	ComputeFoam(i_foam, i_worldXZUndisplaced - (flow * sample1_offset), i_worldXZ, i_n, i_pixelZ, i_sceneZ, i_view, i_lightDir, i_shadow, lodVal, o_bubbleCol1, o_whiteFoamCol1);
-	ComputeFoam(i_foam, i_worldXZUndisplaced - (flow * sample2_offset), i_worldXZ, i_n, i_pixelZ, i_sceneZ, i_view, i_lightDir, i_shadow, lodVal, o_bubbleCol2, o_whiteFoamCol2);
+	ComputeFoam(i_foam, i_worldXZUndisplaced - (flow * sample1_offset), i_worldXZ, i_n, i_pixelZ, i_sceneZ, i_view, i_lightDir, i_shadow, lodVal, o_bubbleCol1, o_whiteFoamCol1, lightCol);
+	ComputeFoam(i_foam, i_worldXZUndisplaced - (flow * sample2_offset), i_worldXZ, i_n, i_pixelZ, i_sceneZ, i_view, i_lightDir, i_shadow, lodVal, o_bubbleCol2, o_whiteFoamCol2, lightCol);
 	o_bubbleCol = (sample1_weight * o_bubbleCol1) + (sample2_weight * o_bubbleCol2);
 	o_whiteFoamCol = (sample1_weight * o_whiteFoamCol1) + (sample2_weight * o_whiteFoamCol2);
 }

--- a/crest/Assets/Crest/Crest/Shaders/OceanReflection.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanReflection.hlsl
@@ -61,7 +61,7 @@ float CalculateFresnelReflectionCoefficient(float cosTheta)
 	return R_theta;
 }
 
-void ApplyReflectionSky(in const half3 i_view, in const half3 i_n_pixel, in const half3 i_lightDir, in const half i_shadow, in const half4 i_screenPos, in const float i_pixelZ, in const half i_weight, inout half3 io_col)
+void ApplyReflectionSky(in const half3 i_view, in const half3 i_n_pixel, in const half3 i_lightDir, in const half i_shadow, in const half4 i_screenPos, in const float i_pixelZ, in const half i_weight, inout half3 io_col, half4 lightCol)
 {
 	// Reflection
 	half3 refl = reflect(-i_view, i_n_pixel);
@@ -104,7 +104,7 @@ void ApplyReflectionSky(in const half3 i_view, in const half3 i_n_pixel, in cons
 	half fallOff = _DirectionalLightFallOff;
 #endif
 
-	skyColour += pow(max(0., dot(refl, i_lightDir)), fallOff) * _DirectionalLightBoost * _LightColor0 * i_shadow;
+	skyColour += pow(max(0., dot(refl, i_lightDir)), fallOff) * _DirectionalLightBoost * lightCol * i_shadow;
 #endif
 
 	// Fresnel

--- a/crest/Assets/Crest/Crest/Shaders/Underwater/UnderwaterCurtain.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Underwater/UnderwaterCurtain.shader
@@ -191,7 +191,7 @@ Shader "Crest/Underwater Curtain"
 				const float depth = 0.0;
 				const half shadow = 1.0;
 
-				const half3 scatterCol = ScatterColour(depth, _WorldSpaceCameraPos, lightDir, view, shadow, true, true, sss);
+				const half3 scatterCol = ScatterColour(depth, _WorldSpaceCameraPos, lightDir, view, shadow, true, true, sss, _LightColor0);
 
 				half3 sceneColour = tex2D(_BackgroundTexture, input.grabPos.xy / input.grabPos.w).rgb;
 


### PR DESCRIPTION
This will help address #357
There is also vertex light support with #382

Experimental support for pixel lights. Pixel lights can be point, spot or directional lights which are set to _Important_ or in some cases _Automatic_.

![Red Pixel](https://user-images.githubusercontent.com/5249806/71513585-0eded200-28ef-11ea-901d-98b5a8a1cb17.jpg)
Point Light

![Green Pixel](https://user-images.githubusercontent.com/5249806/71513588-11d9c280-28ef-11ea-87b4-ad8a6da7ea3d.jpg)
Spot Light

## About

This is a very rough PR. It will need a lot of work.

### Pass and Blending
Adds another pass and uses `BlendOp Max`. This prevents the more egregious artefacts. Improving the extra pass is a better way to go. Distilling the pass to only perform the necessary work for the light itself is the ideal.

### Performance
Only the tiles which are affected by the light will require additional passes. Performance will depend on how many lights and their coverage. Performance can be improved by removing unnecessary work.

## Issues

Plenty. I haven't properly worked through everything so some features are broken or misused.

### Technical Debt
In its current form, technical debt is pretty high.

### Directional Light
Based on light direction rather than camera to light for spot lights.
