### PR TITLE
Unify depth cache validation

### DIFF
--- a/crest/Assets/Crest/Crest-Examples/Main/Scenes/main.unity
+++ b/crest/Assets/Crest/Crest-Examples/Main/Scenes/main.unity
@@ -474,6 +474,7 @@ MonoBehaviour:
   _minTexelsPerWave: 3
   _minScale: 4
   _maxScale: 256
+  _dropDetailHeightBasedOnWaves: 0.2
   _lodDataResolution: 384
   _geometryDownSampleFactor: 4
   _lodCount: 7
@@ -967,13 +968,17 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5be4155a909a5ef47bdaaf1422602735, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _populateOnStartup: 1
+  _type: 0
+  _refreshMode: 0
   _geometryToRenderIntoCache: []
   _layerNames:
   - Terrain
   _resolution: 384
   _cameraMaxTerrainHeight: 100
   _forceAlwaysUpdateDebug: 0
+  _savedCache: {fileID: 0}
+  _checkTerrainDrawInstancedOption: 1
+  _runValidationOnStart: 1
 --- !u!4 &1899543707
 Transform:
   m_ObjectHideFlags: 0
@@ -983,7 +988,7 @@ Transform:
   m_GameObject: {fileID: 1899543705}
   m_LocalRotation: {x: -0, y: 0.27672777, z: -0, w: 0.96094835}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 540, y: 540, z: 540}
+  m_LocalScale: {x: 540, y: 1, z: 540}
   m_Children: []
   m_Father: {fileID: 1591410378}
   m_RootOrder: 1

--- a/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
@@ -296,7 +296,7 @@ namespace Crest
                 Debug.LogWarning("Validation: Ocean depth cache transform scale is small and will capture a small area of the world. The scale sets the size of the area that will be cached, and this cache is set to render a very small area. Click this message to highlight the cache in question.", this);
             }
 
-            if (transform.lossyScale.y < 0.001 || transform.localScale.y < 0.01)
+            if (transform.lossyScale.y < 0.001f || transform.localScale.y < 0.01f)
             {
                 Debug.LogError($"Validation: Ocean depth cache scale Y should be set to 1.0. Its current scale in the hierarchy is {transform.lossyScale.y}.", this);
             }
@@ -310,11 +310,6 @@ namespace Crest
             if (rend != null)
             {
                 Debug.LogWarning("Validation: It is not expected that a depth cache object has a Renderer component in its hierarchy. The cache is typically attached to an empty GameObject. Click this message to highlight the Renderer. Please refer to the example content.", rend);
-            }
-
-            if (_forceAlwaysUpdateDebug)
-            {
-                Debug.LogWarning($"Validation: Note that the 'Force Always Update Debug' option is enabled on depth cache {gameObject.name} which will trigger the depth cache to populate every frame.", this);
             }
         }
 #endif
@@ -346,7 +341,7 @@ namespace Crest
             {
                 // Only expose the following if real-time cache type
                 EditorGUILayout.PropertyField(serializedObject.FindProperty("_refreshMode"));
-                EditorGUILayout.PropertyField(serializedObject.FindProperty("_geometryToRenderIntoCache"));
+                EditorGUILayout.PropertyField(serializedObject.FindProperty("_geometryToRenderIntoCache"), true);
                 EditorGUILayout.PropertyField(serializedObject.FindProperty("_layerNames"), true);
                 EditorGUILayout.PropertyField(serializedObject.FindProperty("_resolution"));
                 EditorGUILayout.PropertyField(serializedObject.FindProperty("_cameraMaxTerrainHeight"));

--- a/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
@@ -296,6 +296,11 @@ namespace Crest
                 Debug.LogWarning("Validation: Ocean depth cache transform scale is small and will capture a small area of the world. The scale sets the size of the area that will be cached, and this cache is set to render a very small area. Click this message to highlight the cache in question.", this);
             }
 
+            if (transform.lossyScale.y < 0.001 || transform.localScale.y < 0.01)
+            {
+                Debug.LogError($"Validation: Ocean depth cache scale Y should be set to 1.0. Its current scale in the hierarchy is {transform.lossyScale.y}.", this);
+            }
+
             if (Mathf.Abs(transform.position.y - ocean.transform.position.y) > 0.00001f)
             {
                 Debug.LogWarning("Validation: It is recommended that the cache is placed at the same height (y component of position) as the ocean, i.e. at the sea level. If the cache is created before the ocean is present, the cache height will inform the sea level. Click this message to highlight the cache in question.", this);

--- a/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
@@ -65,6 +65,11 @@ namespace Crest
         bool _checkTerrainDrawInstancedOption = true;
 #pragma warning restore 414
 
+#pragma warning disable 414
+        [Tooltip("Editor only: run validation checks on Start() to check for issues."), SerializeField]
+        bool _runValidationOnStart = true;
+#pragma warning restore 414
+
         RenderTexture _cacheTexture;
         public RenderTexture CacheTexture => _cacheTexture;
 
@@ -73,12 +78,12 @@ namespace Crest
 
         void Start()
         {
-            if (_layerNames == null || _layerNames.Length < 1)
+#if UNITY_EDITOR
+            if (_runValidationOnStart)
             {
-                Debug.LogError("At least one layer name to render into the cache must be provided.", this);
-                enabled = false;
-                return;
+                Validate(OceanRenderer.Instance);
             }
+#endif
 
             if (_type == OceanDepthCacheType.Baked && _drawCacheQuad == null)
             {
@@ -87,16 +92,6 @@ namespace Crest
             else if (_type == OceanDepthCacheType.Realtime && _refreshMode == OceanDepthCacheRefreshMode.OnStart)
             {
                 PopulateCache();
-            }
-
-            if (transform.lossyScale.magnitude < 5f)
-            {
-                Debug.LogWarning("Ocean depth cache transform scale is small and will capture a small area of the world. Is this intended?", this);
-            }
-
-            if (_forceAlwaysUpdateDebug)
-            {
-                Debug.LogWarning("Note: Force Always Update Debug option is enabled on depth cache " + gameObject.name, this);
             }
         }
 
@@ -309,7 +304,12 @@ namespace Crest
             var rend = GetComponentInChildren<Renderer>();
             if (rend != null)
             {
-                Debug.LogWarning("Validation: It is not expected that a depth cache object has a renderer component in its hierarchy. The cache is typically attached to an empty GameObject. Please refer to the example content.", rend);
+                Debug.LogWarning("Validation: It is not expected that a depth cache object has a Renderer component in its hierarchy. The cache is typically attached to an empty GameObject. Click this message to highlight the Renderer. Please refer to the example content.", rend);
+            }
+
+            if (_forceAlwaysUpdateDebug)
+            {
+                Debug.LogWarning($"Validation: Note that the 'Force Always Update Debug' option is enabled on depth cache {gameObject.name} which will trigger the depth cache to populate every frame.", this);
             }
         }
 #endif


### PR DESCRIPTION
Status: ready for review by commit. @moosichu / @daleeidd let me know if you are up for taking a look.

The validation code on the ocean depth cache was split into two places.

This change unifies it into one place and has an option to perform the validation on Start() (in addition to the 'Validate' button in the OceanRenderer inspector) which defaults to true. This way people get the full validation by default and can disable it if desired.

Added a validation error for the depth cache Y scale being 0, which breaks the cache population.
