### PR TITLE
Performance optimization, disable shadows when rendering planar reflection.

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Reflection/OceanPlanarReflection.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Reflection/OceanPlanarReflection.cs
@@ -71,6 +71,7 @@ namespace Crest
     {
         [SerializeField] LayerMask _reflectionLayers = 1;
         [SerializeField] bool _disablePixelLights = true;
+        [SerializeField] bool _disableShadows = false;
         [SerializeField] int _textureSize = 256;
         [SerializeField] float _clipPlaneOffset = 0.07f;
         [SerializeField] bool _hdr = true;
@@ -159,6 +160,13 @@ namespace Crest
                 QualitySettings.pixelLightCount = 0;
             }
 
+            // Optionally disable shadows for reflection/refraction
+            ShadowQuality oldShadowQuality = QualitySettings.shadows;
+            if (_disableShadows)
+            {
+                QualitySettings.shadows = ShadowQuality.Disable;
+            }
+
             UpdateCameraModes();
 
             // Reflect camera around reflection plane
@@ -184,9 +192,6 @@ namespace Crest
             bool oldCulling = GL.invertCulling;
             GL.invertCulling = !oldCulling;
 
-            ShadowQuality oldShadows = QualitySettings.shadows;
-            QualitySettings.shadows = ShadowQuality.Disable;
-
             _camReflections.transform.position = newpos;
             Vector3 euler = _camViewpoint.transform.eulerAngles;
             _camReflections.transform.eulerAngles = new Vector3(-euler.x, euler.y, euler.z);
@@ -196,8 +201,13 @@ namespace Crest
 
             _camReflections.Render();
 
-            QualitySettings.shadows = oldShadows;
             GL.invertCulling = oldCulling;
+
+            // Restore shadows
+            if (_disableShadows)
+            {
+                QualitySettings.shadows = oldShadowQuality;
+            }
 
             // Restore pixel light count
             if (_disablePixelLights)

--- a/crest/Assets/Crest/Crest/Scripts/Reflection/OceanPlanarReflection.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Reflection/OceanPlanarReflection.cs
@@ -184,6 +184,9 @@ namespace Crest
             bool oldCulling = GL.invertCulling;
             GL.invertCulling = !oldCulling;
 
+            ShadowQuality oldShadows = QualitySettings.shadows;
+            QualitySettings.shadows = ShadowQuality.Disable;
+
             _camReflections.transform.position = newpos;
             Vector3 euler = _camViewpoint.transform.eulerAngles;
             _camReflections.transform.eulerAngles = new Vector3(-euler.x, euler.y, euler.z);
@@ -193,6 +196,7 @@ namespace Crest
 
             _camReflections.Render();
 
+            QualitySettings.shadows = oldShadows;
             GL.invertCulling = oldCulling;
 
             // Restore pixel light count


### PR DESCRIPTION
Disable rendering shadows into the planar reflection. This cut the planar reflection render time in half for my project, from about 2.2ms to 1.2ms.