### PR TITLE
Reduce depth precision to half

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
@@ -13,7 +13,7 @@ namespace Crest
     public class LodDataMgrSeaFloorDepth : LodDataMgr
     {
         public override string SimName { get { return "SeaFloorDepth"; } }
-        public override RenderTextureFormat TextureFormat { get { return RenderTextureFormat.RFloat; } }
+        public override RenderTextureFormat TextureFormat { get { return RenderTextureFormat.RHalf; } }
         protected override bool NeedToReadWriteTextureData { get { return false; } }
 
         public override SimSettingsBase CreateDefaultSettings() { return null; }
@@ -37,7 +37,7 @@ namespace Crest
             for (int lodIdx = OceanRenderer.Instance.CurrentLodCount - 1; lodIdx >= 0; lodIdx--)
             {
                 buf.SetRenderTarget(_targets, 0, CubemapFace.Unknown, lodIdx);
-                buf.ClearRenderTarget(false, true, Color.white * 1000f);
+                buf.ClearRenderTarget(false, true, Color.red * 1000f);
                 buf.SetGlobalInt(sp_LD_SliceIndex, lodIdx);
                 SubmitDraws(lodIdx, buf);
             }

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/OceanDepthsCache.shader
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/OceanDepthsCache.shader
@@ -18,6 +18,7 @@ Shader "Crest/Inputs/Depth/Cached Depths"
 			// To confuse matters further, ocean depth is now more like 'sea floor altitude' - a height above a deep water value,
 			// so values are increasing in Y and we need to take the MAX of all depths.
 			BlendOp Min
+			ColorMask R
 
 			CGPROGRAM
 			#pragma vertex Vert


### PR DESCRIPTION
I think this should be ok. Half precision didn't work in the past because the depth used to represent 'height' so had bad precision at shallow depths, and the artifacts were obvious. Now that its properly water depth it seems to work fine.

Add a couple of minor extras to explicitly target the R channel.

I tested in main which has a fairly large variation in sea floor depts and it seems fine to me.

@daleeidd @moosichu let me know if you have thoughts!
