### PR TITLE
Support no domain reload

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/BuildCommandBuffer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/BuildCommandBuffer.cs
@@ -18,6 +18,15 @@ namespace Crest
         /// Used to validate update order
         /// </summary>
         public static int _lastUpdateFrame = -1;
+
+#if UNITY_2019_3_OR_NEWER
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+#endif
+        static void InitStatics()
+        {
+            // Init here from 2019.3 onwards
+            _lastUpdateFrame = -1;
+        }
     }
 
     /// <summary>

--- a/crest/Assets/Crest/Crest/Scripts/Collision/CollProviderNull.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Collision/CollProviderNull.cs
@@ -74,6 +74,6 @@ namespace Crest
             return true;
         }
 
-        public static readonly CollProviderNull Instance = new CollProviderNull();
+        public readonly static CollProviderNull Instance = new CollProviderNull();
     }
 }

--- a/crest/Assets/Crest/Crest/Scripts/Collision/QueryBase.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Collision/QueryBase.cs
@@ -38,7 +38,7 @@ namespace Crest
         const int s_computeGroupSize = 64;
         public static bool s_useComputeCollQueries = true;
 
-        int sp_queryPositions_minGridSizes = Shader.PropertyToID("_QueryPositions_MinGridSizes");
+        readonly int sp_queryPositions_minGridSizes = Shader.PropertyToID("_QueryPositions_MinGridSizes");
 
         const float s_finiteDiffDx = 0.1f;
 

--- a/crest/Assets/Crest/Crest/Scripts/Collision/QueryBase.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Collision/QueryBase.cs
@@ -38,7 +38,7 @@ namespace Crest
         const int s_computeGroupSize = 64;
         public static bool s_useComputeCollQueries = true;
 
-        readonly static int sp_queryPositions_minGridSizes = Shader.PropertyToID("_QueryPositions_MinGridSizes");
+        int sp_queryPositions_minGridSizes = Shader.PropertyToID("_QueryPositions_MinGridSizes");
 
         const float s_finiteDiffDx = 0.1f;
 

--- a/crest/Assets/Crest/Crest/Scripts/Collision/QueryDisplacements.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Collision/QueryDisplacements.cs
@@ -11,8 +11,8 @@ namespace Crest
     /// </summary>
     public class QueryDisplacements : QueryBase, ICollProvider
     {
-        readonly static int sp_LD_TexArray_AnimatedWaves = Shader.PropertyToID("_LD_TexArray_AnimatedWaves");
-        readonly static int sp_ResultDisplacements = Shader.PropertyToID("_ResultDisplacements");
+        int sp_LD_TexArray_AnimatedWaves = Shader.PropertyToID("_LD_TexArray_AnimatedWaves");
+        int sp_ResultDisplacements = Shader.PropertyToID("_ResultDisplacements");
 
         protected override string QueryShaderName => "QueryDisplacements";
         protected override string QueryKernelName => "CSMain";
@@ -61,6 +61,15 @@ namespace Crest
             }
 
             return result;
+        }
+
+#if UNITY_2019_3_OR_NEWER
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+#endif
+        static void InitStatics()
+        {
+            // Init here from 2019.3 onwards
+            Instance = null;
         }
     }
 }

--- a/crest/Assets/Crest/Crest/Scripts/Collision/QueryDisplacements.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Collision/QueryDisplacements.cs
@@ -11,8 +11,8 @@ namespace Crest
     /// </summary>
     public class QueryDisplacements : QueryBase, ICollProvider
     {
-        int sp_LD_TexArray_AnimatedWaves = Shader.PropertyToID("_LD_TexArray_AnimatedWaves");
-        int sp_ResultDisplacements = Shader.PropertyToID("_ResultDisplacements");
+        readonly int sp_LD_TexArray_AnimatedWaves = Shader.PropertyToID("_LD_TexArray_AnimatedWaves");
+        readonly int sp_ResultDisplacements = Shader.PropertyToID("_ResultDisplacements");
 
         protected override string QueryShaderName => "QueryDisplacements";
         protected override string QueryKernelName => "CSMain";

--- a/crest/Assets/Crest/Crest/Scripts/Collision/QueryFlow.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Collision/QueryFlow.cs
@@ -11,8 +11,8 @@ namespace Crest
     /// </summary>
     public class QueryFlow : QueryBase
     {
-        int sp_LD_TexArray_Flow = Shader.PropertyToID("_LD_TexArray_Flow");
-        int sp_ResultFlows = Shader.PropertyToID("_ResultFlows");
+        readonly int sp_LD_TexArray_Flow = Shader.PropertyToID("_LD_TexArray_Flow");
+        readonly int sp_ResultFlows = Shader.PropertyToID("_ResultFlows");
 
         protected override string QueryShaderName => "QueryFlow";
         protected override string QueryKernelName => "CSMain";

--- a/crest/Assets/Crest/Crest/Scripts/Collision/QueryFlow.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Collision/QueryFlow.cs
@@ -11,8 +11,8 @@ namespace Crest
     /// </summary>
     public class QueryFlow : QueryBase
     {
-        readonly static int sp_LD_TexArray_Flow = Shader.PropertyToID("_LD_TexArray_Flow");
-        readonly static int sp_ResultFlows = Shader.PropertyToID("_ResultFlows");
+        int sp_LD_TexArray_Flow = Shader.PropertyToID("_LD_TexArray_Flow");
+        int sp_ResultFlows = Shader.PropertyToID("_ResultFlows");
 
         protected override string QueryShaderName => "QueryFlow";
         protected override string QueryKernelName => "CSMain";
@@ -44,6 +44,15 @@ namespace Crest
         public int Query(int i_ownerHash, float i_minSpatialLength, Vector3[] i_queryPoints, Vector3[] o_resultFlows)
         {
             return Query(i_ownerHash, i_minSpatialLength, i_queryPoints, o_resultFlows, null, null);
+        }
+
+#if UNITY_2019_3_OR_NEWER
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+#endif
+        static void InitStatics()
+        {
+            // Init here from 2019.3 onwards
+            Instance = null;
         }
     }
 }

--- a/crest/Assets/Crest/Crest/Scripts/Collision/VisualiseCollisionArea.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Collision/VisualiseCollisionArea.cs
@@ -12,7 +12,7 @@ namespace Crest
 
         float[] _resultHeights = new float[s_steps * s_steps];
 
-        static float s_radius = 5f;
+        readonly float s_radius = 5f;
         static readonly int s_steps = 10;
 
         Vector3[] _samplePositions = new Vector3[s_steps * s_steps];

--- a/crest/Assets/Crest/Crest/Scripts/Collision/VisualiseCollisionArea.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Collision/VisualiseCollisionArea.cs
@@ -12,7 +12,7 @@ namespace Crest
 
         float[] _resultHeights = new float[s_steps * s_steps];
 
-        readonly float s_radius = 5f;
+        static readonly float s_radius = 5f;
         static readonly int s_steps = 10;
 
         Vector3[] _samplePositions = new Vector3[s_steps * s_steps];

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/OceanDebugGUI.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/OceanDebugGUI.cs
@@ -17,8 +17,8 @@ namespace Crest
         readonly static Color _guiColor = Color.black * 0.7f;
         ShapeGerstnerBatched[] _gerstners;
 
-        static Dictionary<System.Type, bool> s_drawTargets = new Dictionary<System.Type, bool>();
-        static Dictionary<System.Type, string> s_simNames = new Dictionary<System.Type, string>();
+        static readonly Dictionary<System.Type, bool> s_drawTargets = new Dictionary<System.Type, bool>();
+        static readonly Dictionary<System.Type, string> s_simNames = new Dictionary<System.Type, string>();
 
         static Material s_textureArrayMaterial = null;
 
@@ -223,8 +223,8 @@ namespace Crest
         static void InitStatics()
         {
             // Init here from 2019.3 onwards
-            s_drawTargets = new Dictionary<System.Type, bool>();
-            s_simNames = new Dictionary<System.Type, string>();
+            s_drawTargets.Clear();
+            s_simNames.Clear();
             s_textureArrayMaterial = null;
         }
     }

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/OceanDebugGUI.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/OceanDebugGUI.cs
@@ -17,16 +17,16 @@ namespace Crest
         readonly static Color _guiColor = Color.black * 0.7f;
         ShapeGerstnerBatched[] _gerstners;
 
-        readonly static Dictionary<System.Type, bool> _drawTargets = new Dictionary<System.Type, bool>();
-        readonly static Dictionary<System.Type, string> _simNames = new Dictionary<System.Type, string>();
+        static Dictionary<System.Type, bool> s_drawTargets = new Dictionary<System.Type, bool>();
+        static Dictionary<System.Type, string> s_simNames = new Dictionary<System.Type, string>();
 
-        static Material textureArrayMaterial;
+        static Material s_textureArrayMaterial = null;
 
         void Awake()
         {
-            if (textureArrayMaterial == null)
+            if (s_textureArrayMaterial == null)
             {
-                textureArrayMaterial = new Material(Shader.Find("Hidden/Crest/Debug/TextureArray"));
+                s_textureArrayMaterial = new Material(Shader.Find("Hidden/Crest/Debug/TextureArray"));
             }
         }
 
@@ -170,13 +170,13 @@ namespace Crest
             if (lodData == null) return;
 
             var type = typeof(SimType);
-            if (!_drawTargets.ContainsKey(type))
+            if (!s_drawTargets.ContainsKey(type))
             {
-                _drawTargets.Add(type, showByDefault);
+                s_drawTargets.Add(type, showByDefault);
             }
-            if (!_simNames.ContainsKey(type))
+            if (!s_simNames.ContainsKey(type))
             {
-                _simNames.Add(type, type.Name.Substring(10));
+                s_simNames.Add(type, type.Name.Substring(10));
             }
 
             float togglesBegin = Screen.height - _bottomPanelHeight;
@@ -185,7 +185,7 @@ namespace Crest
             float w = h + b;
             float x = Screen.width - w * offset + b * (offset - 1f);
 
-            if (_drawTargets[type])
+            if (s_drawTargets[type])
             {
                 GUI.color = _guiColor;
                 GUI.DrawTexture(new Rect(x, 0, offset == 1f ? w : w - b, Screen.height - _bottomPanelHeight), Texture2D.whiteTexture);
@@ -200,14 +200,14 @@ namespace Crest
                         if (offset == 1f) w += b;
 
                         // Render specific slice of 2D texture array
-                        textureArrayMaterial.SetInt("_Depth", idx);
-                        Graphics.DrawTexture(new Rect(x + b, y + b / 2f, h - b, h - b), lodData.DataTexture, textureArrayMaterial);
+                        s_textureArrayMaterial.SetInt("_Depth", idx);
+                        Graphics.DrawTexture(new Rect(x + b, y + b / 2f, h - b, h - b), lodData.DataTexture, s_textureArrayMaterial);
                     }
                 }
             }
 
 
-            _drawTargets[type] = GUI.Toggle(new Rect(x + b, togglesBegin, w - 2f * b, _bottomPanelHeight), _drawTargets[type], _simNames[type]);
+            s_drawTargets[type] = GUI.Toggle(new Rect(x + b, togglesBegin, w - 2f * b, _bottomPanelHeight), s_drawTargets[type], s_simNames[type]);
 
             offset++;
         }
@@ -215,6 +215,17 @@ namespace Crest
         void ToggleGUI()
         {
             _guiVisible = !_guiVisible;
+        }
+
+#if UNITY_2019_3_OR_NEWER
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+#endif
+        static void InitStatics()
+        {
+            // Init here from 2019.3 onwards
+            s_drawTargets = new Dictionary<System.Type, bool>();
+            s_simNames = new Dictionary<System.Type, string>();
+            s_textureArrayMaterial = null;
         }
     }
 }

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/TextureArrayHelpers.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/TextureArrayHelpers.cs
@@ -8,33 +8,16 @@ namespace Crest
 {
     public static class TextureArrayHelpers
     {
-        private const string ClearToBlackShaderName = "ClearToBlack";
+        private const string CLEAR_TO_BLACK_SHADER_NAME = "ClearToBlack";
+        private const int SMALL_TEXTURE_DIM = 4;
+
         private static int krnl_ClearToBlack = -1;
-        private static ComputeShader ClearToBlackShader;
+        private static ComputeShader s_clearToBlackShader = null;
         private static int sp_LD_TexArray_Target = Shader.PropertyToID("_LD_TexArray_Target");
 
         static TextureArrayHelpers()
         {
-            if (BlackTextureArray == null)
-            {
-                BlackTextureArray = new Texture2DArray(
-                    Texture2D.blackTexture.width, Texture2D.blackTexture.height,
-                    OceanRenderer.Instance.CurrentLodCount,
-                    Texture2D.blackTexture.format,
-                    false,
-                    false
-                );
-
-                for (int textureArrayIndex = 0; textureArrayIndex < OceanRenderer.Instance.CurrentLodCount; textureArrayIndex++)
-                {
-                    Graphics.CopyTexture(Texture2D.blackTexture, 0, 0, BlackTextureArray, textureArrayIndex, 0);
-                }
-
-                BlackTextureArray.name = "Black Texture2DArray";
-            }
-
-            ClearToBlackShader = Resources.Load<ComputeShader>(ClearToBlackShaderName);
-            krnl_ClearToBlack = ClearToBlackShader.FindKernel(ClearToBlackShaderName);
+            InitStatics();
         }
 
         // This is used as alternative to Texture2D.blackTexture, as using that
@@ -45,13 +28,43 @@ namespace Crest
         // implemented a custom version to clear to black
         public static void ClearToBlack(RenderTexture dst)
         {
-            ClearToBlackShader.SetTexture(krnl_ClearToBlack, sp_LD_TexArray_Target, dst);
-            ClearToBlackShader.Dispatch(
+            s_clearToBlackShader.SetTexture(krnl_ClearToBlack, sp_LD_TexArray_Target, dst);
+            s_clearToBlackShader.Dispatch(
                 krnl_ClearToBlack,
                 OceanRenderer.Instance.LodDataResolution / PropertyWrapperCompute.THREAD_GROUP_SIZE_X,
                 OceanRenderer.Instance.LodDataResolution / PropertyWrapperCompute.THREAD_GROUP_SIZE_Y,
                 dst.volumeDepth
             );
+        }
+
+#if UNITY_2019_3_OR_NEWER
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+#endif
+        static void InitStatics()
+        {
+            // Init here from 2019.3 onwards
+            sp_LD_TexArray_Target = Shader.PropertyToID("_LD_TexArray_Target");
+
+            if (BlackTextureArray == null)
+            {
+                BlackTextureArray = new Texture2DArray(
+                    SMALL_TEXTURE_DIM, SMALL_TEXTURE_DIM,
+                    LodDataMgr.MAX_LOD_COUNT,
+                    Texture2D.blackTexture.format,
+                    false,
+                    false
+                );
+
+                for (int textureArrayIndex = 0; textureArrayIndex < LodDataMgr.MAX_LOD_COUNT; textureArrayIndex++)
+                {
+                    Graphics.CopyTexture(Texture2D.blackTexture, 0, 0, BlackTextureArray, textureArrayIndex, 0);
+                }
+
+                BlackTextureArray.name = "Black Texture2DArray";
+            }
+
+            s_clearToBlackShader = Resources.Load<ComputeShader>(CLEAR_TO_BLACK_SHADER_NAME);
+            krnl_ClearToBlack = s_clearToBlackShader.FindKernel(CLEAR_TO_BLACK_SHADER_NAME);
         }
     }
 }

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/UnderwaterEffect.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/UnderwaterEffect.cs
@@ -34,7 +34,7 @@ namespace Crest
         PropertyWrapperMPB _mpb;
         Renderer _rend;
 
-        static readonly int sp_HeightOffset = Shader.PropertyToID("_HeightOffset");
+        int sp_HeightOffset = Shader.PropertyToID("_HeightOffset");
 
         SampleHeightHelper _sampleWaterHeight = new SampleHeightHelper();
 

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/UnderwaterEffect.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/UnderwaterEffect.cs
@@ -34,7 +34,7 @@ namespace Crest
         PropertyWrapperMPB _mpb;
         Renderer _rend;
 
-        int sp_HeightOffset = Shader.PropertyToID("_HeightOffset");
+        readonly int sp_HeightOffset = Shader.PropertyToID("_HeightOffset");
 
         SampleHeightHelper _sampleWaterHeight = new SampleHeightHelper();
 

--- a/crest/Assets/Crest/Crest/Scripts/Interaction/SphereWaterInteraction.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Interaction/SphereWaterInteraction.cs
@@ -47,10 +47,10 @@ namespace Crest
         Renderer _renderer;
         MaterialPropertyBlock _mpb;
 
-        readonly static int sp_velocity = Shader.PropertyToID("_Velocity");
-        readonly static int sp_weight = Shader.PropertyToID("_Weight");
-        readonly static int sp_simDeltaTime = Shader.PropertyToID("_SimDeltaTime");
-        readonly static int sp_radius = Shader.PropertyToID("_Radius");
+        static int sp_velocity = Shader.PropertyToID("_Velocity");
+        static int sp_weight = Shader.PropertyToID("_Weight");
+        static int sp_simDeltaTime = Shader.PropertyToID("_SimDeltaTime");
+        static int sp_radius = Shader.PropertyToID("_Radius");
 
         private void Start()
         {
@@ -248,6 +248,18 @@ namespace Crest
         {
             Gizmos.color = new Color(0f, 1f, 0f, 0.5f);
             Gizmos.DrawWireSphere(transform.position, Radius);
+        }
+
+#if UNITY_2019_3_OR_NEWER
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+#endif
+        static void InitStatics()
+        {
+            // Init here from 2019.3 onwards
+            sp_velocity = Shader.PropertyToID("_Velocity");
+            sp_weight = Shader.PropertyToID("_Weight");
+            sp_simDeltaTime = Shader.PropertyToID("_SimDeltaTime");
+            sp_radius = Shader.PropertyToID("_Radius");
         }
     }
 }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgr.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgr.cs
@@ -221,5 +221,15 @@ namespace Crest
             }
             public int GetId(bool sourceLod) { return sourceLod ? _paramId_Source : _paramId; }
         }
+
+#if UNITY_2019_3_OR_NEWER
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+#endif
+        static void InitStatics()
+        {
+            // Init here from 2019.3 onwards
+            sp_LD_SliceIndex = Shader.PropertyToID("_LD_SliceIndex");
+            sp_LODChange = Shader.PropertyToID("_LODChange");
+        }
     }
 }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrAnimWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrAnimWaves.cs
@@ -56,8 +56,8 @@ namespace Crest
         PropertyWrapperCompute _combineProperties;
         PropertyWrapperMaterial[] _combineMaterial;
 
-        int sp_LD_TexArray_AnimatedWaves_Compute = Shader.PropertyToID("_LD_TexArray_AnimatedWaves_Compute");
-        int sp_LD_TexArray_WaveBuffer = Shader.PropertyToID("_LD_TexArray_WaveBuffer");
+        readonly int sp_LD_TexArray_AnimatedWaves_Compute = Shader.PropertyToID("_LD_TexArray_AnimatedWaves_Compute");
+        readonly int sp_LD_TexArray_WaveBuffer = Shader.PropertyToID("_LD_TexArray_WaveBuffer");
         const string s_textureArrayName = "_LD_TexArray_AnimatedWaves";
 
         public override void UseSettings(SimSettingsBase settings) { OceanRenderer.Instance._simSettingsAnimatedWaves = settings as SimSettingsAnimatedWaves; }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrAnimWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrAnimWaves.cs
@@ -56,8 +56,8 @@ namespace Crest
         PropertyWrapperCompute _combineProperties;
         PropertyWrapperMaterial[] _combineMaterial;
 
-        readonly static int sp_LD_TexArray_AnimatedWaves_Compute = Shader.PropertyToID("_LD_TexArray_AnimatedWaves_Compute");
-        readonly static int sp_LD_TexArray_WaveBuffer = Shader.PropertyToID("_LD_TexArray_WaveBuffer");
+        int sp_LD_TexArray_AnimatedWaves_Compute = Shader.PropertyToID("_LD_TexArray_AnimatedWaves_Compute");
+        int sp_LD_TexArray_WaveBuffer = Shader.PropertyToID("_LD_TexArray_WaveBuffer");
         const string s_textureArrayName = "_LD_TexArray_AnimatedWaves";
 
         public override void UseSettings(SimSettingsBase settings) { OceanRenderer.Instance._simSettingsAnimatedWaves = settings as SimSettingsAnimatedWaves; }
@@ -423,8 +423,8 @@ namespace Crest
             return -1;
         }
 
-        private static TextureArrayParamIds textureArrayParamIds = new TextureArrayParamIds(s_textureArrayName);
-        public static int ParamIdSampler(bool sourceLod = false) { return textureArrayParamIds.GetId(sourceLod); }
+        private static TextureArrayParamIds s_textureArrayParamIds = new TextureArrayParamIds(s_textureArrayName);
+        public static int ParamIdSampler(bool sourceLod = false) { return s_textureArrayParamIds.GetId(sourceLod); }
         protected override int GetParamIdSampler(bool sourceLod = false)
         {
             return ParamIdSampler(sourceLod);
@@ -432,6 +432,17 @@ namespace Crest
         public static void BindNull(IPropertyWrapper properties, bool sourceLod = false)
         {
             properties.SetTexture(ParamIdSampler(sourceLod), TextureArrayHelpers.BlackTextureArray);
+        }
+
+#if UNITY_2019_3_OR_NEWER
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+#endif
+        static void InitStatics()
+        {
+            // Init here from 2019.3 onwards
+            sp_LD_SliceIndex = Shader.PropertyToID("_LD_SliceIndex");
+            sp_LODChange = Shader.PropertyToID("_LODChange");
+            s_textureArrayParamIds = new TextureArrayParamIds(s_textureArrayName);
         }
     }
 }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrClipSurface.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrClipSurface.cs
@@ -58,9 +58,9 @@ namespace Crest
             _targetsClear = drawList.Count == 0;
         }
 
-        public static string TextureArrayName = "_LD_TexArray_ClipSurface";
-        private static TextureArrayParamIds textureArrayParamIds = new TextureArrayParamIds(TextureArrayName);
-        public static int ParamIdSampler(bool sourceLod = false) { return textureArrayParamIds.GetId(sourceLod); }
+        readonly static string s_textureArrayName = "_LD_TexArray_ClipSurface";
+        private static TextureArrayParamIds s_textureArrayParamIds = new TextureArrayParamIds(s_textureArrayName);
+        public static int ParamIdSampler(bool sourceLod = false) { return s_textureArrayParamIds.GetId(sourceLod); }
         protected override int GetParamIdSampler(bool sourceLod = false)
         {
             return ParamIdSampler(sourceLod);
@@ -68,6 +68,15 @@ namespace Crest
         public static void BindNull(IPropertyWrapper properties, bool sourceLod = false)
         {
             properties.SetTexture(ParamIdSampler(sourceLod), TextureArrayHelpers.BlackTextureArray);
+        }
+
+#if UNITY_2019_3_OR_NEWER
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+#endif
+        static void InitStatics()
+        {
+            // Init here from 2019.3 onwards
+            s_textureArrayParamIds = new TextureArrayParamIds(s_textureArrayName);
         }
     }
 }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrDynWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrDynWaves.cs
@@ -33,11 +33,11 @@ namespace Crest
         bool[] _active;
         public bool SimActive(int lodIdx) { return _active[lodIdx]; }
 
-        int sp_HorizDisplace = Shader.PropertyToID("_HorizDisplace");
-        int sp_DisplaceClamp = Shader.PropertyToID("_DisplaceClamp");
-        int sp_Damping = Shader.PropertyToID("_Damping");
-        int sp_Gravity = Shader.PropertyToID("_Gravity");
-        int sp_LaplacianAxisX = Shader.PropertyToID("_LaplacianAxisX");
+        readonly int sp_HorizDisplace = Shader.PropertyToID("_HorizDisplace");
+        readonly int sp_DisplaceClamp = Shader.PropertyToID("_DisplaceClamp");
+        readonly int sp_Damping = Shader.PropertyToID("_Damping");
+        readonly int sp_Gravity = Shader.PropertyToID("_Gravity");
+        readonly int sp_LaplacianAxisX = Shader.PropertyToID("_LaplacianAxisX");
 
         protected override void InitData()
         {

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrDynWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrDynWaves.cs
@@ -33,11 +33,11 @@ namespace Crest
         bool[] _active;
         public bool SimActive(int lodIdx) { return _active[lodIdx]; }
 
-        static int sp_HorizDisplace = Shader.PropertyToID("_HorizDisplace");
-        static int sp_DisplaceClamp = Shader.PropertyToID("_DisplaceClamp");
-        static int sp_Damping = Shader.PropertyToID("_Damping");
-        static int sp_Gravity = Shader.PropertyToID("_Gravity");
-        static int sp_LaplacianAxisX = Shader.PropertyToID("_LaplacianAxisX");
+        int sp_HorizDisplace = Shader.PropertyToID("_HorizDisplace");
+        int sp_DisplaceClamp = Shader.PropertyToID("_DisplaceClamp");
+        int sp_Damping = Shader.PropertyToID("_Damping");
+        int sp_Gravity = Shader.PropertyToID("_Gravity");
+        int sp_LaplacianAxisX = Shader.PropertyToID("_LaplacianAxisX");
 
         protected override void InitData()
         {
@@ -147,9 +147,9 @@ namespace Crest
             substepDt = Mathf.Min(maxDt, frameDt / numSubsteps);
         }
 
-        public static string TextureArrayName = "_LD_TexArray_DynamicWaves";
-        private static TextureArrayParamIds textureArrayParamIds = new TextureArrayParamIds(TextureArrayName);
-        public static int ParamIdSampler(bool sourceLod = false) { return textureArrayParamIds.GetId(sourceLod); }
+        readonly static string s_textureArrayName = "_LD_TexArray_DynamicWaves";
+        private static TextureArrayParamIds s_textureArrayParamIds = new TextureArrayParamIds(s_textureArrayName);
+        public static int ParamIdSampler(bool sourceLod = false) { return s_textureArrayParamIds.GetId(sourceLod); }
         protected override int GetParamIdSampler(bool sourceLod = false)
         {
             return ParamIdSampler(sourceLod);
@@ -157,6 +157,15 @@ namespace Crest
         public static void BindNull(IPropertyWrapper properties, bool sourceLod = false)
         {
             properties.SetTexture(ParamIdSampler(sourceLod), TextureArrayHelpers.BlackTextureArray);
+        }
+
+#if UNITY_2019_3_OR_NEWER
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+#endif
+        static void InitStatics()
+        {
+            // Init here from 2019.3 onwards
+            s_textureArrayParamIds = new TextureArrayParamIds(s_textureArrayName);
         }
     }
 }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrFlow.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrFlow.cs
@@ -77,9 +77,9 @@ namespace Crest
             }
         }
 
-        public static string TextureArrayName = "_LD_TexArray_Flow";
-        private static TextureArrayParamIds textureArrayParamIds = new TextureArrayParamIds(TextureArrayName);
-        public static int ParamIdSampler(bool sourceLod = false) { return textureArrayParamIds.GetId(sourceLod); }
+        readonly static string s_textureArrayName = "_LD_TexArray_Flow";
+        private static TextureArrayParamIds s_textureArrayParamIds = new TextureArrayParamIds(s_textureArrayName);
+        public static int ParamIdSampler(bool sourceLod = false) { return s_textureArrayParamIds.GetId(sourceLod); }
         protected override int GetParamIdSampler(bool sourceLod = false)
         {
             return ParamIdSampler(sourceLod);
@@ -87,6 +87,15 @@ namespace Crest
         public static void BindNull(IPropertyWrapper properties, bool sourceLod = false)
         {
             properties.SetTexture(ParamIdSampler(sourceLod), TextureArrayHelpers.BlackTextureArray);
+        }
+
+#if UNITY_2019_3_OR_NEWER
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+#endif
+        static void InitStatics()
+        {
+            // Init here from 2019.3 onwards
+            s_textureArrayParamIds = new TextureArrayParamIds(s_textureArrayName);
         }
     }
 }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrFoam.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrFoam.cs
@@ -25,11 +25,11 @@ namespace Crest
             return settings;
         }
 
-        int sp_FoamFadeRate = Shader.PropertyToID("_FoamFadeRate");
-        int sp_WaveFoamStrength = Shader.PropertyToID("_WaveFoamStrength");
-        int sp_WaveFoamCoverage = Shader.PropertyToID("_WaveFoamCoverage");
-        int sp_ShorelineFoamMaxDepth = Shader.PropertyToID("_ShorelineFoamMaxDepth");
-        int sp_ShorelineFoamStrength = Shader.PropertyToID("_ShorelineFoamStrength");
+        readonly int sp_FoamFadeRate = Shader.PropertyToID("_FoamFadeRate");
+        readonly int sp_WaveFoamStrength = Shader.PropertyToID("_WaveFoamStrength");
+        readonly int sp_WaveFoamCoverage = Shader.PropertyToID("_WaveFoamCoverage");
+        readonly int sp_ShorelineFoamMaxDepth = Shader.PropertyToID("_ShorelineFoamMaxDepth");
+        readonly int sp_ShorelineFoamStrength = Shader.PropertyToID("_ShorelineFoamStrength");
 
 
         protected override void Start()

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrFoam.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrFoam.cs
@@ -25,11 +25,11 @@ namespace Crest
             return settings;
         }
 
-        static int sp_FoamFadeRate = Shader.PropertyToID("_FoamFadeRate");
-        static int sp_WaveFoamStrength = Shader.PropertyToID("_WaveFoamStrength");
-        static int sp_WaveFoamCoverage = Shader.PropertyToID("_WaveFoamCoverage");
-        static int sp_ShorelineFoamMaxDepth = Shader.PropertyToID("_ShorelineFoamMaxDepth");
-        static int sp_ShorelineFoamStrength = Shader.PropertyToID("_ShorelineFoamStrength");
+        int sp_FoamFadeRate = Shader.PropertyToID("_FoamFadeRate");
+        int sp_WaveFoamStrength = Shader.PropertyToID("_WaveFoamStrength");
+        int sp_WaveFoamCoverage = Shader.PropertyToID("_WaveFoamCoverage");
+        int sp_ShorelineFoamMaxDepth = Shader.PropertyToID("_ShorelineFoamMaxDepth");
+        int sp_ShorelineFoamStrength = Shader.PropertyToID("_ShorelineFoamStrength");
 
 
         protected override void Start()
@@ -85,9 +85,9 @@ namespace Crest
             numSubsteps = 1;
         }
 
-        public static string TextureArrayName = "_LD_TexArray_Foam";
-        private static TextureArrayParamIds textureArrayParamIds = new TextureArrayParamIds(TextureArrayName);
-        public static int ParamIdSampler(bool sourceLod = false) { return textureArrayParamIds.GetId(sourceLod); }
+        readonly static string s_textureArrayName = "_LD_TexArray_Foam";
+        private static TextureArrayParamIds s_textureArrayParamIds = new TextureArrayParamIds(s_textureArrayName);
+        public static int ParamIdSampler(bool sourceLod = false) { return s_textureArrayParamIds.GetId(sourceLod); }
         protected override int GetParamIdSampler(bool sourceLod = false)
         {
             return ParamIdSampler(sourceLod);
@@ -95,6 +95,15 @@ namespace Crest
         public static void BindNull(IPropertyWrapper properties, bool sourceLod = false)
         {
             properties.SetTexture(ParamIdSampler(sourceLod), TextureArrayHelpers.BlackTextureArray);
+        }
+
+#if UNITY_2019_3_OR_NEWER
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+#endif
+        static void InitStatics()
+        {
+            // Init here from 2019.3 onwards
+            s_textureArrayParamIds = new TextureArrayParamIds(s_textureArrayName);
         }
     }
 }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrPersistent.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrPersistent.cs
@@ -17,7 +17,7 @@ namespace Crest
         RenderTexture _sources;
         PropertyWrapperCompute _renderSimProperties;
 
-        int sp_LD_TexArray_Target = Shader.PropertyToID("_LD_TexArray_Target");
+        readonly int sp_LD_TexArray_Target = Shader.PropertyToID("_LD_TexArray_Target");
 
         protected ComputeShader _shader;
 
@@ -26,8 +26,8 @@ namespace Crest
 
         float _substepDtPrevious = 1f / 60f;
 
-        int sp_SimDeltaTime = Shader.PropertyToID("_SimDeltaTime");
-        int sp_SimDeltaTimePrev = Shader.PropertyToID("_SimDeltaTimePrev");
+        readonly int sp_SimDeltaTime = Shader.PropertyToID("_SimDeltaTime");
+        readonly int sp_SimDeltaTimePrev = Shader.PropertyToID("_SimDeltaTimePrev");
 
         protected override void Start()
         {

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrPersistent.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrPersistent.cs
@@ -17,7 +17,7 @@ namespace Crest
         RenderTexture _sources;
         PropertyWrapperCompute _renderSimProperties;
 
-        static int sp_LD_TexArray_Target = Shader.PropertyToID("_LD_TexArray_Target");
+        int sp_LD_TexArray_Target = Shader.PropertyToID("_LD_TexArray_Target");
 
         protected ComputeShader _shader;
 
@@ -26,8 +26,8 @@ namespace Crest
 
         float _substepDtPrevious = 1f / 60f;
 
-        public static int sp_SimDeltaTime = Shader.PropertyToID("_SimDeltaTime");
-        static int sp_SimDeltaTimePrev = Shader.PropertyToID("_SimDeltaTimePrev");
+        int sp_SimDeltaTime = Shader.PropertyToID("_SimDeltaTime");
+        int sp_SimDeltaTimePrev = Shader.PropertyToID("_SimDeltaTimePrev");
 
         protected override void Start()
         {

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
@@ -46,9 +46,9 @@ namespace Crest
             _targetsClear = drawList.Count == 0;
         }
 
-        public static string TextureArrayName = "_LD_TexArray_SeaFloorDepth";
-        private static TextureArrayParamIds textureArrayParamIds = new TextureArrayParamIds(TextureArrayName);
-        public static int ParamIdSampler(bool sourceLod = false) { return textureArrayParamIds.GetId(sourceLod); }
+        readonly static string s_textureArrayName = "_LD_TexArray_SeaFloorDepth";
+        private static TextureArrayParamIds s_textureArrayParamIds = new TextureArrayParamIds(s_textureArrayName);
+        public static int ParamIdSampler(bool sourceLod = false) { return s_textureArrayParamIds.GetId(sourceLod); }
         protected override int GetParamIdSampler(bool sourceLod = false)
         {
             return ParamIdSampler(sourceLod);
@@ -56,6 +56,15 @@ namespace Crest
         public static void BindNull(IPropertyWrapper properties, bool sourceLod = false)
         {
             properties.SetTexture(ParamIdSampler(sourceLod), TextureArrayHelpers.BlackTextureArray);
+        }
+
+#if UNITY_2019_3_OR_NEWER
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+#endif
+        static void InitStatics()
+        {
+            // Init here from 2019.3 onwards
+            s_textureArrayParamIds = new TextureArrayParamIds(s_textureArrayName);
         }
     }
 }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodTransform.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodTransform.cs
@@ -160,5 +160,17 @@ namespace Crest
                 _renderDataSource[lodIdx]._posSnapped -= newOrigin;
             }
         }
+
+#if UNITY_2019_3_OR_NEWER
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+#endif
+        static void InitStatics()
+        {
+            // Init here from 2019.3 onwards
+            s_paramsPosScale = Shader.PropertyToID("_LD_Pos_Scale");
+            s_paramsPosScaleSource = Shader.PropertyToID("_LD_Pos_Scale_Source");
+            s_paramsOcean = Shader.PropertyToID("_LD_Params");
+            s_paramsOceanSource = Shader.PropertyToID("_LD_Params_Source");
+        }
     }
 }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
@@ -65,6 +65,16 @@ namespace Crest
 
         public int MaterialCount => _materials.Length;
         public Material GetMaterial(int index) => _materials[index];
+
+#if UNITY_2019_3_OR_NEWER
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+#endif
+        static void InitStatics()
+        {
+            // Init here from 2019.3 onwards
+            _registrar = new Dictionary<System.Type, List<ILodDataInput>>();
+            sp_Weight = Shader.PropertyToID("_Weight");
+        }
     }
 
     /// <summary>

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsAnimatedWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsAnimatedWaves.cs
@@ -19,7 +19,7 @@ namespace Crest
             GerstnerWavesCPU,
             ComputeShaderQueries,
         }
-        [Header("Readback to CPU")]
+        
         [Tooltip("Where to obtain ocean shape on CPU for physics / gameplay."), SerializeField]
         CollisionSources _collisionSource = CollisionSources.ComputeShaderQueries;
         public CollisionSources CollisionSource { get { return _collisionSource; } }
@@ -51,7 +51,7 @@ namespace Crest
             if (result == null)
             {
                 // this should not be hit - return null to create null ref exceptions
-                Debug.Assert(false, "Could not create collision provider. Collision source = " + _collisionSource.ToString());
+                Debug.Assert(false, "Could not create collision provider. Collision source = " + _collisionSource.ToString(), this);
                 return null;
             }
 

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Shadows/LodDataMgrShadow.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Shadows/LodDataMgrShadow.cs
@@ -32,15 +32,15 @@ namespace Crest
         private int krnl_UpdateShadow;
         public const string UpdateShadow = "UpdateShadow";
 
-        int sp_CenterPos = Shader.PropertyToID("_CenterPos");
-        int sp_Scale = Shader.PropertyToID("_Scale");
-        int sp_CamPos = Shader.PropertyToID("_CamPos");
-        int sp_CamForward = Shader.PropertyToID("_CamForward");
-        int sp_JitterDiameters_CurrentFrameWeights = Shader.PropertyToID("_JitterDiameters_CurrentFrameWeights");
-        int sp_MainCameraProjectionMatrix = Shader.PropertyToID("_MainCameraProjectionMatrix");
-        int sp_SimDeltaTime = Shader.PropertyToID("_SimDeltaTime");
-        int sp_LD_SliceIndex_Source = Shader.PropertyToID("_LD_SliceIndex_Source");
-        int sp_LD_TexArray_Target = Shader.PropertyToID("_LD_TexArray_Target");
+        readonly int sp_CenterPos = Shader.PropertyToID("_CenterPos");
+        readonly int sp_Scale = Shader.PropertyToID("_Scale");
+        readonly int sp_CamPos = Shader.PropertyToID("_CamPos");
+        readonly int sp_CamForward = Shader.PropertyToID("_CamForward");
+        readonly int sp_JitterDiameters_CurrentFrameWeights = Shader.PropertyToID("_JitterDiameters_CurrentFrameWeights");
+        readonly int sp_MainCameraProjectionMatrix = Shader.PropertyToID("_MainCameraProjectionMatrix");
+        readonly int sp_SimDeltaTime = Shader.PropertyToID("_SimDeltaTime");
+        readonly int sp_LD_SliceIndex_Source = Shader.PropertyToID("_LD_SliceIndex_Source");
+        readonly int sp_LD_TexArray_Target = Shader.PropertyToID("_LD_TexArray_Target");
 
         SimSettingsShadow Settings { get { return OceanRenderer.Instance._simSettingsShadow; } }
         public override void UseSettings(SimSettingsBase settings) { OceanRenderer.Instance._simSettingsShadow = settings as SimSettingsShadow; }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Shadows/LodDataMgrShadow.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Shadows/LodDataMgrShadow.cs
@@ -32,15 +32,15 @@ namespace Crest
         private int krnl_UpdateShadow;
         public const string UpdateShadow = "UpdateShadow";
 
-        static int sp_CenterPos = Shader.PropertyToID("_CenterPos");
-        static int sp_Scale = Shader.PropertyToID("_Scale");
-        static int sp_CamPos = Shader.PropertyToID("_CamPos");
-        static int sp_CamForward = Shader.PropertyToID("_CamForward");
-        static int sp_JitterDiameters_CurrentFrameWeights = Shader.PropertyToID("_JitterDiameters_CurrentFrameWeights");
-        static int sp_MainCameraProjectionMatrix = Shader.PropertyToID("_MainCameraProjectionMatrix");
-        static int sp_SimDeltaTime = Shader.PropertyToID("_SimDeltaTime");
-        static int sp_LD_SliceIndex_Source = Shader.PropertyToID("_LD_SliceIndex_Source");
-        static int sp_LD_TexArray_Target = Shader.PropertyToID("_LD_TexArray_Target");
+        int sp_CenterPos = Shader.PropertyToID("_CenterPos");
+        int sp_Scale = Shader.PropertyToID("_Scale");
+        int sp_CamPos = Shader.PropertyToID("_CamPos");
+        int sp_CamForward = Shader.PropertyToID("_CamForward");
+        int sp_JitterDiameters_CurrentFrameWeights = Shader.PropertyToID("_JitterDiameters_CurrentFrameWeights");
+        int sp_MainCameraProjectionMatrix = Shader.PropertyToID("_MainCameraProjectionMatrix");
+        int sp_SimDeltaTime = Shader.PropertyToID("_SimDeltaTime");
+        int sp_LD_SliceIndex_Source = Shader.PropertyToID("_LD_SliceIndex_Source");
+        int sp_LD_TexArray_Target = Shader.PropertyToID("_LD_TexArray_Target");
 
         SimSettingsShadow Settings { get { return OceanRenderer.Instance._simSettingsShadow; } }
         public override void UseSettings(SimSettingsBase settings) { OceanRenderer.Instance._simSettingsShadow = settings as SimSettingsShadow; }
@@ -250,9 +250,9 @@ namespace Crest
             }
         }
 
-        public static string TextureArrayName = "_LD_TexArray_Shadow";
-        private static TextureArrayParamIds textureArrayParamIds = new TextureArrayParamIds(TextureArrayName);
-        public static int ParamIdSampler(bool sourceLod = false) { return textureArrayParamIds.GetId(sourceLod); }
+        readonly static string s_textureArrayName = "_LD_TexArray_Shadow";
+        private static TextureArrayParamIds s_textureArrayParamIds = new TextureArrayParamIds(s_textureArrayName);
+        public static int ParamIdSampler(bool sourceLod = false) { return s_textureArrayParamIds.GetId(sourceLod); }
         protected override int GetParamIdSampler(bool sourceLod = false)
         {
             return ParamIdSampler(sourceLod);
@@ -260,6 +260,15 @@ namespace Crest
         public static void BindNull(IPropertyWrapper properties, bool sourceLod = false)
         {
             properties.SetTexture(ParamIdSampler(sourceLod), TextureArrayHelpers.BlackTextureArray);
+        }
+
+#if UNITY_2019_3_OR_NEWER
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+#endif
+        static void InitStatics()
+        {
+            // Init here from 2019.3 onwards
+            s_textureArrayParamIds = new TextureArrayParamIds(s_textureArrayName);
         }
     }
 }

--- a/crest/Assets/Crest/Crest/Scripts/OceanChunkRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanChunkRenderer.cs
@@ -29,11 +29,11 @@ namespace Crest
         int _lodDataResolution = 256;
         int _geoDownSampleFactor = 1;
 
-        static readonly int sp_ReflectionTex = Shader.PropertyToID("_ReflectionTex");
-        static readonly int sp_GeomData = Shader.PropertyToID("_GeomData");
-        static readonly int sp_ForceUnderwater = Shader.PropertyToID("_ForceUnderwater");
+        static int sp_ReflectionTex = Shader.PropertyToID("_ReflectionTex");
+        static int sp_GeomData = Shader.PropertyToID("_GeomData");
+        static int sp_ForceUnderwater = Shader.PropertyToID("_ForceUnderwater");
         // MeshScaleLerp, FarNormalsWeight, LODIndex (debug)
-        public static readonly int sp_InstanceData = Shader.PropertyToID("_InstanceData");
+        public static int sp_InstanceData = Shader.PropertyToID("_InstanceData");
 
         void Start()
         {
@@ -188,6 +188,18 @@ namespace Crest
         public void SetInstanceData(int lodIndex, int totalLodCount, int lodDataResolution, int geoDownSampleFactor)
         {
             _lodIndex = lodIndex; _totalLodCount = totalLodCount; _lodDataResolution = lodDataResolution; _geoDownSampleFactor = geoDownSampleFactor;
+        }
+
+#if UNITY_2019_3_OR_NEWER
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+#endif
+        static void InitStatics()
+        {
+            // Init here from 2019.3 onwards
+            sp_ReflectionTex = Shader.PropertyToID("_ReflectionTex");
+            sp_GeomData = Shader.PropertyToID("_GeomData");
+            sp_ForceUnderwater = Shader.PropertyToID("_ForceUnderwater");
+            sp_InstanceData = Shader.PropertyToID("_InstanceData");
         }
     }
 

--- a/crest/Assets/Crest/Crest/Scripts/OceanChunkRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanChunkRenderer.cs
@@ -61,12 +61,20 @@ namespace Crest
         private void OnEnable()
         {
 #if UNITY_2018
+            DeregisterBeginCameraRenderingEvent();
             RenderPipeline.beginCameraRendering += BeginCameraRendering;
 #else
+            DeregisterBeginCameraRenderingEvent();
             RenderPipelineManager.beginCameraRendering += BeginCameraRendering;
 #endif
         }
+
         private void OnDisable()
+        {
+            DeregisterBeginCameraRenderingEvent();
+        }
+
+        private static void DeregisterBeginCameraRenderingEvent()
         {
 #if UNITY_2018
             RenderPipeline.beginCameraRendering -= BeginCameraRendering;
@@ -78,9 +86,9 @@ namespace Crest
         static Camera _currentCamera = null;
 
 #if UNITY_2018
-        private void BeginCameraRendering(Camera camera)
+        private static void BeginCameraRendering(Camera camera)
 #else
-        private void BeginCameraRendering(ScriptableRenderContext context, Camera camera)
+        private static void BeginCameraRendering(ScriptableRenderContext context, Camera camera)
 #endif
         {
             _currentCamera = camera;
@@ -200,6 +208,13 @@ namespace Crest
             sp_GeomData = Shader.PropertyToID("_GeomData");
             sp_ForceUnderwater = Shader.PropertyToID("_ForceUnderwater");
             sp_InstanceData = Shader.PropertyToID("_InstanceData");
+            _currentCamera = null;
+        }
+
+        [RuntimeInitializeOnLoadMethod]
+        static void RunOnStart()
+        {
+            DeregisterBeginCameraRenderingEvent();
         }
     }
 

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -135,6 +135,7 @@ namespace Crest
         [HideInInspector] public LodDataMgrFlow _lodDataFlow;
         [HideInInspector] public LodDataMgrFoam _lodDataFoam;
         [HideInInspector] public LodDataMgrShadow _lodDataShadow;
+
         /// <summary>
         /// The number of LODs/scales that the ocean is currently using.
         /// </summary>
@@ -147,12 +148,13 @@ namespace Crest
 
         SampleHeightHelper _sampleHeightHelper = new SampleHeightHelper();
 
-        readonly static int sp_crestTime = Shader.PropertyToID("_CrestTime");
-        readonly static int sp_texelsPerWave = Shader.PropertyToID("_TexelsPerWave");
-        readonly static int sp_oceanCenterPosWorld = Shader.PropertyToID("_OceanCenterPosWorld");
-        readonly static int sp_meshScaleLerp = Shader.PropertyToID("_MeshScaleLerp");
-        readonly static int sp_sliceCount = Shader.PropertyToID("_SliceCount");
+        public static OceanRenderer Instance { get; private set; }
 
+        int sp_crestTime = Shader.PropertyToID("_CrestTime");
+        int sp_texelsPerWave = Shader.PropertyToID("_TexelsPerWave");
+        int sp_oceanCenterPosWorld = Shader.PropertyToID("_OceanCenterPosWorld");
+        int sp_meshScaleLerp = Shader.PropertyToID("_MeshScaleLerp");
+        int sp_sliceCount = Shader.PropertyToID("_SliceCount");
 
         void Awake()
         {
@@ -226,6 +228,15 @@ namespace Crest
                 // None found - create
                 _timeProvider = gameObject.AddComponent<TimeProviderDefault>();
             }
+        }
+
+#if UNITY_2019_3_OR_NEWER
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+#endif
+        static void InitStatics()
+        {
+            // Init here from 2019.3 onwards
+            Instance = null;
         }
 
         void LateUpdate()
@@ -357,8 +368,6 @@ namespace Crest
         /// The maximum height that the shape scripts are displacing the shape.
         /// </summary>
         public float MaxVertDisplacement { get { return _maxVertDispFromShape; } }
-
-        public static OceanRenderer Instance { get; private set; }
 
         /// <summary>
         /// Provides ocean shape to CPU.

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -150,11 +150,11 @@ namespace Crest
 
         public static OceanRenderer Instance { get; private set; }
 
-        int sp_crestTime = Shader.PropertyToID("_CrestTime");
-        int sp_texelsPerWave = Shader.PropertyToID("_TexelsPerWave");
-        int sp_oceanCenterPosWorld = Shader.PropertyToID("_OceanCenterPosWorld");
-        int sp_meshScaleLerp = Shader.PropertyToID("_MeshScaleLerp");
-        int sp_sliceCount = Shader.PropertyToID("_SliceCount");
+        readonly int sp_crestTime = Shader.PropertyToID("_CrestTime");
+        readonly int sp_texelsPerWave = Shader.PropertyToID("_TexelsPerWave");
+        readonly int sp_oceanCenterPosWorld = Shader.PropertyToID("_OceanCenterPosWorld");
+        readonly int sp_meshScaleLerp = Shader.PropertyToID("_MeshScaleLerp");
+        readonly int sp_sliceCount = Shader.PropertyToID("_SliceCount");
 
         void Awake()
         {

--- a/crest/Assets/Crest/Crest/Scripts/Reflection/OceanPlanarReflection.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Reflection/OceanPlanarReflection.cs
@@ -15,9 +15,10 @@ namespace Crest
 {
     internal static class PreparedReflections
     {
-        private static volatile RenderTexture _currentreflectiontexture;
+        private static volatile RenderTexture _currentreflectiontexture = null;
         private static volatile int _referenceCameraInstanceId = -1;
         private static volatile KeyValuePair<int, RenderTexture>[] _collection = new KeyValuePair<int, RenderTexture>[0];
+
         public static RenderTexture GetRenderTexture(int camerainstanceid)
         {
             if (camerainstanceid == _referenceCameraInstanceId)
@@ -61,6 +62,17 @@ namespace Crest
             // Rebuild with new element if not found
             _collection = currentcollection
                 .Append(new KeyValuePair<int, RenderTexture>(instanceId, reflectionTexture)).ToArray();
+        }
+
+#if UNITY_2019_3_OR_NEWER
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+#endif
+        static void InitStatics()
+        {
+            // Init here from 2019.3 onwards
+            _currentreflectiontexture = null;
+            _referenceCameraInstanceId = -1;
+            _collection = new KeyValuePair<int, RenderTexture>[0];
         }
     }
 

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
@@ -90,16 +90,16 @@ namespace Crest
         // Shader to be used to render evaluate Gerstner waves for each LOD
         Shader _waveShader;
 
-        int sp_TwoPiOverWavelengths = Shader.PropertyToID("_TwoPiOverWavelengths");
-        int sp_Amplitudes = Shader.PropertyToID("_Amplitudes");
-        int sp_WaveDirX = Shader.PropertyToID("_WaveDirX");
-        int sp_WaveDirZ = Shader.PropertyToID("_WaveDirZ");
-        int sp_Phases = Shader.PropertyToID("_Phases");
-        int sp_ChopAmps = Shader.PropertyToID("_ChopAmps");
-        int sp_NumInBatch = Shader.PropertyToID("_NumInBatch");
-        int sp_AttenuationInShallows = Shader.PropertyToID("_AttenuationInShallows");
-        int sp_NumWaveVecs = Shader.PropertyToID("_NumWaveVecs");
-        int sp_TargetPointData = Shader.PropertyToID("_TargetPointData");
+        readonly int sp_TwoPiOverWavelengths = Shader.PropertyToID("_TwoPiOverWavelengths");
+        readonly int sp_Amplitudes = Shader.PropertyToID("_Amplitudes");
+        readonly int sp_WaveDirX = Shader.PropertyToID("_WaveDirX");
+        readonly int sp_WaveDirZ = Shader.PropertyToID("_WaveDirZ");
+        readonly int sp_Phases = Shader.PropertyToID("_Phases");
+        readonly int sp_ChopAmps = Shader.PropertyToID("_ChopAmps");
+        readonly int sp_NumInBatch = Shader.PropertyToID("_NumInBatch");
+        readonly int sp_AttenuationInShallows = Shader.PropertyToID("_AttenuationInShallows");
+        readonly int sp_NumWaveVecs = Shader.PropertyToID("_NumWaveVecs");
+        readonly int sp_TargetPointData = Shader.PropertyToID("_TargetPointData");
 
         // IMPORTANT - this mirrors the constant with the same name in ShapeGerstnerBatch.shader, both must be updated together!
         const int BATCH_SIZE = 32;

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
@@ -90,16 +90,16 @@ namespace Crest
         // Shader to be used to render evaluate Gerstner waves for each LOD
         Shader _waveShader;
 
-        static int sp_TwoPiOverWavelengths = Shader.PropertyToID("_TwoPiOverWavelengths");
-        static int sp_Amplitudes = Shader.PropertyToID("_Amplitudes");
-        static int sp_WaveDirX = Shader.PropertyToID("_WaveDirX");
-        static int sp_WaveDirZ = Shader.PropertyToID("_WaveDirZ");
-        static int sp_Phases = Shader.PropertyToID("_Phases");
-        static int sp_ChopAmps = Shader.PropertyToID("_ChopAmps");
-        static int sp_NumInBatch = Shader.PropertyToID("_NumInBatch");
-        static int sp_AttenuationInShallows = Shader.PropertyToID("_AttenuationInShallows");
-        static int sp_NumWaveVecs = Shader.PropertyToID("_NumWaveVecs");
-        static int sp_TargetPointData = Shader.PropertyToID("_TargetPointData");
+        int sp_TwoPiOverWavelengths = Shader.PropertyToID("_TwoPiOverWavelengths");
+        int sp_Amplitudes = Shader.PropertyToID("_Amplitudes");
+        int sp_WaveDirX = Shader.PropertyToID("_WaveDirX");
+        int sp_WaveDirZ = Shader.PropertyToID("_WaveDirZ");
+        int sp_Phases = Shader.PropertyToID("_Phases");
+        int sp_ChopAmps = Shader.PropertyToID("_ChopAmps");
+        int sp_NumInBatch = Shader.PropertyToID("_NumInBatch");
+        int sp_AttenuationInShallows = Shader.PropertyToID("_AttenuationInShallows");
+        int sp_NumWaveVecs = Shader.PropertyToID("_NumWaveVecs");
+        int sp_TargetPointData = Shader.PropertyToID("_TargetPointData");
 
         // IMPORTANT - this mirrors the constant with the same name in ShapeGerstnerBatch.shader, both must be updated together!
         const int BATCH_SIZE = 32;
@@ -114,12 +114,12 @@ namespace Crest
         // scratch data used by batching code
         struct UpdateBatchScratchData
         {
-            public static Vector4[] _twoPiOverWavelengthsBatch = new Vector4[BATCH_SIZE / 4];
-            public static Vector4[] _ampsBatch = new Vector4[BATCH_SIZE / 4];
-            public static Vector4[] _waveDirXBatch = new Vector4[BATCH_SIZE / 4];
-            public static Vector4[] _waveDirZBatch = new Vector4[BATCH_SIZE / 4];
-            public static Vector4[] _phasesBatch = new Vector4[BATCH_SIZE / 4];
-            public static Vector4[] _chopAmpsBatch = new Vector4[BATCH_SIZE / 4];
+            public readonly static Vector4[] _twoPiOverWavelengthsBatch = new Vector4[BATCH_SIZE / 4];
+            public readonly static Vector4[] _ampsBatch = new Vector4[BATCH_SIZE / 4];
+            public readonly static Vector4[] _waveDirXBatch = new Vector4[BATCH_SIZE / 4];
+            public readonly static Vector4[] _waveDirZBatch = new Vector4[BATCH_SIZE / 4];
+            public readonly static Vector4[] _phasesBatch = new Vector4[BATCH_SIZE / 4];
+            public readonly static Vector4[] _chopAmpsBatch = new Vector4[BATCH_SIZE / 4];
         }
 
         void Start()
@@ -728,6 +728,15 @@ namespace Crest
         public bool RetrieveSucceeded(int queryStatus)
         {
             return queryStatus == 0;
+        }
+
+#if UNITY_2019_3_OR_NEWER
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+#endif
+        static void InitStatics()
+        {
+            // Init here from 2019.3 onwards
+            _rasterMesh = null;
         }
     }
 


### PR DESCRIPTION
## Status

Ready to merge.

One of our users needs this with a priority if possible. @daleeidd if you're working today could you please give this a review? If not it's fine. Thanks!

## What / why

The speedup entering/exiting playmode when domain reload is disabled in 2019.3 is incredible.

As noted in #373, crest did not support this option before now.

If the domain is not reloaded, any static variables will retain there value across the transition. There is a special callback that can be used to initialise these variables if needed. More info: https://docs.unity3d.com/2019.3/Documentation/Manual/DomainReloading.html

## How

Some of our statics don't need to be reset across reloads. Some statics didnt need to be statics at all (for example, some shader param ids where private, and members of a class that were basically a singleton, so there was no point making them static - e.g. `sp_LD_TexArray_Flow`).

The remaining statics received (re)initialisation in the callback. The callback isn't usable pre-2019.3, so i've left initialisation both in line in the variable declaration, and in the callback function.

I could have ifdef'd out the entire callback function (`InitStatics`) each time, but `TextureArrayHelpers` actually needs to call the function as it has non-trivial initialisation, so i decided to go with this.

Also, `TextureArrayHelpers` used to depend on OceanRenderer from static functions which was a weird dependency, because it created a texture array with the current lod count slices, and the current lod resolution. I realised i could just create it as (4, 4, MAX_LOD_COUNT), where 4 is a 'small number' (2 may have worked as well, or maybe 1, but i seem to recall 4 being a min size for some gpu related things like compression, and thought it may as well make sense to use this). This saves memory, probably improves perf, and removes the dependency.

(A final note, it would be good agree a coding standard for statics (perhaps here: https://github.com/crest-ocean/crest/blob/master/CONTRIBUTING.md ). I think they were originally `s_` but have evolved a bit organically and there is a range of things like no prefix, `_`, `s_`, `sp_`, and `krnl_`. I started setting them to `s_` but stopped as i think it would be best to agree something we're all happy with, and it probably deserves a new PR).

## Tests

I ran the example scenes in both 2018.4 and 2019.3 and all seems fine here. I ran a standalone build from 2019.3 as well and it seemed to work.

## Issues

None that i'm aware of, besides the pitfall of double initialisation, which i'm not sure can be easily resolved in a way that is elegant and works on versions pre-2019.3 and after.
