### PR TITLE
Simple first version of dashboard

### DIFF
--- a/crest/Assets/Development.meta
+++ b/crest/Assets/Development.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d9fc318dcee127f43a02f59eee10c7c9
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/crest/Assets/Development/Editor.meta
+++ b/crest/Assets/Development/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f137975aa1f4f4543b2d972024a7adea
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/crest/Assets/Development/Editor/Crest.Development.Editor.asmdef
+++ b/crest/Assets/Development/Editor/Crest.Development.Editor.asmdef
@@ -1,0 +1,14 @@
+{
+    "name": "Crest.Development.Editor",
+    "references": [],
+    "optionalUnityReferences": [],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": []
+}

--- a/crest/Assets/Development/Editor/Crest.Development.Editor.asmdef.meta
+++ b/crest/Assets/Development/Editor/Crest.Development.Editor.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d51143676d57340d6af012d92c325928
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/crest/Assets/Development/Editor/WindowCrestDashboard.cs
+++ b/crest/Assets/Development/Editor/WindowCrestDashboard.cs
@@ -1,0 +1,49 @@
+﻿// Crest Ocean System
+
+// This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
+
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEditor.SceneManagement;
+using UnityEngine;
+
+namespace Crest
+{
+    using SceneItem = KeyValuePair<string, string>;
+
+    public class WindowCrestDashboard : EditorWindow
+    {
+        List<SceneItem> _scenes = new List<SceneItem> {
+            new SceneItem("main", "Assets/Crest/Crest-Examples/Main/Scenes/main.unity"),
+            new SceneItem("boat", "Assets/Crest/Crest-Examples/BoatDev/Scenes/boat.unity"),
+            new SceneItem("threeboats", "Assets/Crest/Crest-Examples/BoatDev/Scenes/threeboats.unity"),
+            new SceneItem("whirlpool", "Assets/Crest/Crest-Examples/Whirlpool/Scenes/whirlpool.unity"),
+        };
+
+        private void OnGUI()
+        {
+            OnGUILoadSceneButtons();
+        }
+
+        void OnGUILoadSceneButtons()
+        {
+            EditorGUILayout.BeginHorizontal();
+
+            foreach (var kvp in _scenes)
+            {
+                if (GUILayout.Button(kvp.Key))
+                {
+                    EditorSceneManager.OpenScene(kvp.Value);
+                }
+            }
+
+            EditorGUILayout.EndHorizontal();
+        }
+
+        [MenuItem("Window/Crest/Dashboard")]
+        public static void ShowWindow()
+        {
+            GetWindow<WindowCrestDashboard>("Crest Dashboard");
+        }
+    }
+}

--- a/crest/Assets/Development/Editor/WindowCrestDashboard.cs.meta
+++ b/crest/Assets/Development/Editor/WindowCrestDashboard.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9e09d5a9b3b9dc74bbed49d6ed35e92e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Status: Ready to merge

This is a general purpose window to add dev stuff, but would not be intended to be included in published packages. Hence it is put outside the main crest folder.

So far it has scene loading buttons.

We could add buttons to resave SGs or to do other automation.

Thoughts @daleeidd / @moosichu ?

Thanks!
