### PR TITLE
Fix sea floor depths being at maxed value when not enabled

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Helpers/TextureArrayHelpers.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/TextureArrayHelpers.cs
@@ -23,6 +23,7 @@ namespace Crest
         // This is used as alternative to Texture2D.blackTexture, as using that
         // is not possible in some shaders.
         public static Texture2DArray BlackTextureArray { get; private set; }
+        public static Texture2DArray WhiteTextureArray { get; private set; }
 
         // Unity 2018.* does not support blitting to texture arrays, so have
         // implemented a custom version to clear to black
@@ -61,6 +62,24 @@ namespace Crest
                 }
 
                 BlackTextureArray.name = "Black Texture2DArray";
+            }
+
+            if (WhiteTextureArray == null)
+            {
+                WhiteTextureArray = new Texture2DArray(
+                    SMALL_TEXTURE_DIM, SMALL_TEXTURE_DIM,
+                    LodDataMgr.MAX_LOD_COUNT,
+                    Texture2D.whiteTexture.format,
+                    false,
+                    false
+                );
+
+                for (int textureArrayIndex = 0; textureArrayIndex < LodDataMgr.MAX_LOD_COUNT; textureArrayIndex++)
+                {
+                    Graphics.CopyTexture(Texture2D.whiteTexture, 0, 0, WhiteTextureArray, textureArrayIndex, 0);
+                }
+
+                WhiteTextureArray.name = "White Texture2DArray";
             }
 
             s_clearToBlackShader = Resources.Load<ComputeShader>(CLEAR_TO_BLACK_SHADER_NAME);

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/TextureArrayHelpers.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/TextureArrayHelpers.cs
@@ -37,12 +37,12 @@ namespace Crest
             );
         }
 
-        public static Texture2DArray CreateTexture2DArray(Texture2D texture, TextureFormat format)
+        public static Texture2DArray CreateTexture2DArray(Texture2D texture)
         {
             var array = new Texture2DArray(
                 SMALL_TEXTURE_DIM, SMALL_TEXTURE_DIM,
                 LodDataMgr.MAX_LOD_COUNT,
-                format,
+                texture.format,
                 false,
                 false
             );
@@ -65,7 +65,7 @@ namespace Crest
 
             if (BlackTextureArray == null)
             {
-                BlackTextureArray = CreateTexture2DArray(Texture2D.blackTexture, Texture2D.blackTexture.format);
+                BlackTextureArray = CreateTexture2DArray(Texture2D.blackTexture);
                 BlackTextureArray.name = "Black Texture2DArray";
             }
 

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/TextureArrayHelpers.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/TextureArrayHelpers.cs
@@ -23,7 +23,6 @@ namespace Crest
         // This is used as alternative to Texture2D.blackTexture, as using that
         // is not possible in some shaders.
         public static Texture2DArray BlackTextureArray { get; private set; }
-        public static Texture2DArray WhiteTextureArray { get; private set; }
 
         // Unity 2018.* does not support blitting to texture arrays, so have
         // implemented a custom version to clear to black
@@ -38,6 +37,24 @@ namespace Crest
             );
         }
 
+        public static Texture2DArray CreateTexture2DArray(Texture2D texture, TextureFormat format)
+        {
+            var array = new Texture2DArray(
+                SMALL_TEXTURE_DIM, SMALL_TEXTURE_DIM,
+                LodDataMgr.MAX_LOD_COUNT,
+                format,
+                false,
+                false
+            );
+
+            for (int textureArrayIndex = 0; textureArrayIndex < LodDataMgr.MAX_LOD_COUNT; textureArrayIndex++)
+            {
+                Graphics.CopyTexture(texture, 0, 0, array, textureArrayIndex, 0);
+            }
+
+            return array;
+        }
+
 #if UNITY_2019_3_OR_NEWER
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
 #endif
@@ -48,38 +65,8 @@ namespace Crest
 
             if (BlackTextureArray == null)
             {
-                BlackTextureArray = new Texture2DArray(
-                    SMALL_TEXTURE_DIM, SMALL_TEXTURE_DIM,
-                    LodDataMgr.MAX_LOD_COUNT,
-                    Texture2D.blackTexture.format,
-                    false,
-                    false
-                );
-
-                for (int textureArrayIndex = 0; textureArrayIndex < LodDataMgr.MAX_LOD_COUNT; textureArrayIndex++)
-                {
-                    Graphics.CopyTexture(Texture2D.blackTexture, 0, 0, BlackTextureArray, textureArrayIndex, 0);
-                }
-
+                BlackTextureArray = CreateTexture2DArray(Texture2D.blackTexture, Texture2D.blackTexture.format);
                 BlackTextureArray.name = "Black Texture2DArray";
-            }
-
-            if (WhiteTextureArray == null)
-            {
-                WhiteTextureArray = new Texture2DArray(
-                    SMALL_TEXTURE_DIM, SMALL_TEXTURE_DIM,
-                    LodDataMgr.MAX_LOD_COUNT,
-                    Texture2D.whiteTexture.format,
-                    false,
-                    false
-                );
-
-                for (int textureArrayIndex = 0; textureArrayIndex < LodDataMgr.MAX_LOD_COUNT; textureArrayIndex++)
-                {
-                    Graphics.CopyTexture(Texture2D.whiteTexture, 0, 0, WhiteTextureArray, textureArrayIndex, 0);
-                }
-
-                WhiteTextureArray.name = "White Texture2DArray";
             }
 
             s_clearToBlackShader = Resources.Load<ComputeShader>(CLEAR_TO_BLACK_SHADER_NAME);

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
@@ -55,7 +55,7 @@ namespace Crest
         }
         public static void BindNull(IPropertyWrapper properties, bool sourceLod = false)
         {
-            properties.SetTexture(ParamIdSampler(sourceLod), TextureArrayHelpers.BlackTextureArray);
+            properties.SetTexture(ParamIdSampler(sourceLod), TextureArrayHelpers.WhiteTextureArray);
         }
 
 #if UNITY_2019_3_OR_NEWER

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
@@ -70,8 +70,8 @@ namespace Crest
 
         static void InitNullTexture()
         {
-            var texture = Texture2D.whiteTexture;
-            // Null texture needs to be white with a 1000 intensity. 
+            var texture = Instantiate<Texture2D>(Texture2D.whiteTexture);
+            // Null texture needs to be white (uses R channel) with a 1000 intensity. 
             var color = new Color(1000, 1000, 1000, 1);
             Color[] pixels = Enumerable.Repeat(color, texture.height * texture.width).ToArray();
             texture.SetPixels(pixels);

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
@@ -2,6 +2,7 @@
 
 // This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
 
+using System.Linq;
 using UnityEngine;
 using UnityEngine.Rendering;
 
@@ -22,6 +23,13 @@ namespace Crest
         bool _targetsClear = false;
 
         public const string ShaderName = "Crest/Inputs/Depth/Cached Depths";
+
+        static Texture2DArray s_nullTexture2DArray;
+
+        static LodDataMgrSeaFloorDepth()
+        {
+            InitStatics();
+        }
 
         public override void BuildCommandBuffer(OceanRenderer ocean, CommandBuffer buf)
         {
@@ -55,7 +63,7 @@ namespace Crest
         }
         public static void BindNull(IPropertyWrapper properties, bool sourceLod = false)
         {
-            properties.SetTexture(ParamIdSampler(sourceLod), TextureArrayHelpers.WhiteTextureArray);
+            properties.SetTexture(ParamIdSampler(sourceLod), s_nullTexture2DArray);
         }
 
 #if UNITY_2019_3_OR_NEWER
@@ -65,6 +73,18 @@ namespace Crest
         {
             // Init here from 2019.3 onwards
             s_textureArrayParamIds = new TextureArrayParamIds(s_textureArrayName);
+
+            // Null texture needs to be white with a 1000 intensity.
+            if (s_nullTexture2DArray == null)
+            {
+                var texture = Texture2D.whiteTexture;
+                var color = new Color(1000, 1000, 1000, 1);
+                Color[] pixels = Enumerable.Repeat(color, texture.height * texture.width).ToArray();
+                texture.SetPixels(pixels);
+                texture.Apply();
+                s_nullTexture2DArray = TextureArrayHelpers.CreateTexture2DArray(texture, Texture2D.whiteTexture.format);
+                s_nullTexture2DArray.name = "Sea Floor Depth Null Texture";
+            }
         }
     }
 }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
@@ -58,20 +58,26 @@ namespace Crest
         }
         public static void BindNull(IPropertyWrapper properties, bool sourceLod = false)
         {
-            // Null texture needs to be white with a 1000 intensity. Texture2D.whiteTexture prevents us from 
-            // initialising this in a static constructor. Seemed appropriate to do it here.
+            // Texture2D.whiteTexture prevents us from initialising this in a static constructor. Seemed appropriate to
+            // do it here.
             if (s_nullTexture2DArray == null)
             {
-                var texture = Texture2D.whiteTexture;
-                var color = new Color(1000, 1000, 1000, 1);
-                Color[] pixels = Enumerable.Repeat(color, texture.height * texture.width).ToArray();
-                texture.SetPixels(pixels);
-                texture.Apply();
-                s_nullTexture2DArray = TextureArrayHelpers.CreateTexture2DArray(texture, Texture2D.whiteTexture.format);
-                s_nullTexture2DArray.name = "Sea Floor Depth Null Texture";
+                InitNullTexture();
             }
 
             properties.SetTexture(ParamIdSampler(sourceLod), s_nullTexture2DArray);
+        }
+
+        static void InitNullTexture()
+        {
+            var texture = Texture2D.whiteTexture;
+            // Null texture needs to be white with a 1000 intensity. 
+            var color = new Color(1000, 1000, 1000, 1);
+            Color[] pixels = Enumerable.Repeat(color, texture.height * texture.width).ToArray();
+            texture.SetPixels(pixels);
+            texture.Apply();
+            s_nullTexture2DArray = TextureArrayHelpers.CreateTexture2DArray(texture, Texture2D.whiteTexture.format);
+            s_nullTexture2DArray.name = "Sea Floor Depth Null Texture";
         }
 
 #if UNITY_2019_3_OR_NEWER

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
@@ -76,7 +76,7 @@ namespace Crest
             Color[] pixels = Enumerable.Repeat(color, texture.height * texture.width).ToArray();
             texture.SetPixels(pixels);
             texture.Apply();
-            s_nullTexture2DArray = TextureArrayHelpers.CreateTexture2DArray(texture, Texture2D.whiteTexture.format);
+            s_nullTexture2DArray = TextureArrayHelpers.CreateTexture2DArray(texture);
             s_nullTexture2DArray.name = "Sea Floor Depth Null Texture";
         }
 

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
@@ -26,11 +26,6 @@ namespace Crest
 
         static Texture2DArray s_nullTexture2DArray;
 
-        static LodDataMgrSeaFloorDepth()
-        {
-            InitStatics();
-        }
-
         public override void BuildCommandBuffer(OceanRenderer ocean, CommandBuffer buf)
         {
             base.BuildCommandBuffer(ocean, buf);
@@ -63,18 +58,8 @@ namespace Crest
         }
         public static void BindNull(IPropertyWrapper properties, bool sourceLod = false)
         {
-            properties.SetTexture(ParamIdSampler(sourceLod), s_nullTexture2DArray);
-        }
-
-#if UNITY_2019_3_OR_NEWER
-        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
-#endif
-        static void InitStatics()
-        {
-            // Init here from 2019.3 onwards
-            s_textureArrayParamIds = new TextureArrayParamIds(s_textureArrayName);
-
-            // Null texture needs to be white with a 1000 intensity.
+            // Null texture needs to be white with a 1000 intensity. Texture2D.whiteTexture prevents us from 
+            // initialising this in a static constructor. Seemed appropriate to do it here.
             if (s_nullTexture2DArray == null)
             {
                 var texture = Texture2D.whiteTexture;
@@ -85,6 +70,17 @@ namespace Crest
                 s_nullTexture2DArray = TextureArrayHelpers.CreateTexture2DArray(texture, Texture2D.whiteTexture.format);
                 s_nullTexture2DArray.name = "Sea Floor Depth Null Texture";
             }
+
+            properties.SetTexture(ParamIdSampler(sourceLod), s_nullTexture2DArray);
+        }
+
+#if UNITY_2019_3_OR_NEWER
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+#endif
+        static void InitStatics()
+        {
+            // Init here from 2019.3 onwards
+            s_textureArrayParamIds = new TextureArrayParamIds(s_textureArrayName);
         }
     }
 }

--- a/crest/Assets/Crest/Crest/Scripts/OceanChunkRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanChunkRenderer.cs
@@ -127,7 +127,7 @@ namespace Crest
             ldaws.BindResultData(_mpb);
             if (ldflow) ldflow.BindResultData(_mpb);
             if (ldfoam) ldfoam.BindResultData(_mpb); else LodDataMgrFoam.BindNull(_mpb);
-            if (ldsds) ldsds.BindResultData(_mpb);
+            if (ldsds) ldsds.BindResultData(_mpb); else LodDataMgrSeaFloorDepth.BindNull(_mpb);
             if (ldclip) ldclip.BindResultData(_mpb); else LodDataMgrClipSurface.BindNull(_mpb);
             if (ldshadows) ldshadows.BindResultData(_mpb); else LodDataMgrShadow.BindNull(_mpb);
 


### PR DESCRIPTION
Zero state for sea floor depths is red. Before this, it was black which makes the ocean completely flat and maxes foam values.

Is using a white texture like so suitable?

Also, should I go through and `BindNull` for depths everywhere else to be safe? The one I added wasn't necessary to fix this issue, but might be a good idea to be safe.