### PR TITLE
Use displacement for clip surface convex hull

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/BuildCommandBuffer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/BuildCommandBuffer.cs
@@ -48,13 +48,6 @@ namespace Crest
             }
 
             /////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-            // --- Clip surface
-            if (ocean._lodDataClipSurface)
-            {
-                ocean._lodDataClipSurface.BuildCommandBuffer(ocean, buf);
-            }
-
-            /////////////////////////////////////////////////////////////////////////////////////////////////////////////////
             // --- Flow data
             if (ocean._lodDataFlow)
             {
@@ -80,6 +73,13 @@ namespace Crest
             if (ocean._lodDataFoam)
             {
                 ocean._lodDataFoam.BuildCommandBuffer(ocean, buf);
+            }
+
+            /////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+            // --- Clip surface
+            if (ocean._lodDataClipSurface)
+            {
+                ocean._lodDataClipSurface.BuildCommandBuffer(ocean, buf);
             }
         }
 

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgr.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgr.cs
@@ -183,7 +183,7 @@ namespace Crest
                     continue;
                 }
 
-                draw.Draw(buf, 1f, 0);
+                draw.Draw(buf, 1f, 0, lodIdx);
             }
         }
 
@@ -206,7 +206,7 @@ namespace Crest
                 float weight = filter.Filter(draw, out isTransition);
                 if (weight > 0f)
                 {
-                    draw.Draw(buf, weight, isTransition);
+                    draw.Draw(buf, weight, isTransition, lodIdx);
                 }
             }
         }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterClipSurfaceInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterClipSurfaceInput.cs
@@ -21,7 +21,7 @@ namespace Crest
         [Tooltip("Prevents inputs from cancelling each other out when aligned vertically. It is imperfect so custom logic might be needed for your use case.")]
         [SerializeField] bool _disableClipSurfaceWhenTooFarFromSurface = true;
 
-        [Tooltip("Large and choppy waves require higher iterations to have accurate holes.")]
+        [Tooltip("Large, choppy waves require higher iterations to have accurate holes.")]
         [SerializeField] uint _animatedWavesDisplacementSamplingIterations = 4;
 
         public override float Wavelength => 0f;

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterClipSurfaceInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterClipSurfaceInput.cs
@@ -22,7 +22,7 @@ namespace Crest
         [SerializeField] bool _disableClipSurfaceWhenTooFarFromSurface = true;
 
         [Tooltip("Large and choppy waves require higher iterations to have accurate holes.")]
-        [SerializeField] int _animatedWavesDisplacementSamplingIterations = 4;
+        [SerializeField] uint _animatedWavesDisplacementSamplingIterations = 4;
 
         public override float Wavelength => 0f;
 
@@ -92,7 +92,7 @@ namespace Crest
                 var lodCount = OceanRenderer.Instance.CurrentLodCount;
                 var lodDataAnimWaves = OceanRenderer.Instance._lodDataAnimWaves;
                 _mpb.SetInt(LodDataMgr.sp_LD_SliceIndex, lodIdx);
-                _mpb.SetInt(sp_DisplacementSamplingIterations, _animatedWavesDisplacementSamplingIterations);
+                _mpb.SetInt(sp_DisplacementSamplingIterations, (int)_animatedWavesDisplacementSamplingIterations);
                 lodDataAnimWaves.BindResultData(_mpb);
 
                 // blend LOD 0 shape in/out to avoid pop, if the ocean might scale up later (it is smaller than its maximum scale)

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterClipSurfaceInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterClipSurfaceInput.cs
@@ -21,6 +21,9 @@ namespace Crest
         [Tooltip("Prevents inputs from cancelling each other out when aligned vertically. It is imperfect so custom logic might be needed for your use case.")]
         [SerializeField] bool _disableClipSurfaceWhenTooFarFromSurface = true;
 
+        [Tooltip("Large and choppy waves require higher iterations to have accurate holes.")]
+        [SerializeField] int _animatedWavesDisplacementSamplingIterations = 4;
+
         public override float Wavelength => 0f;
 
         protected override Color GizmoColor => new Color(0f, 1f, 1f, 0.5f);
@@ -28,6 +31,8 @@ namespace Crest
         PropertyWrapperMPB _mpb;
         Renderer _rend;
         SampleHeightHelper _sampleHeightHelper = new SampleHeightHelper();
+
+        static int sp_DisplacementSamplingIterations = Shader.PropertyToID("_DisplacementSamplingIterations");
 
         protected override void OnEnable()
         {
@@ -87,6 +92,7 @@ namespace Crest
                 var lodCount = OceanRenderer.Instance.CurrentLodCount;
                 var lodDataAnimWaves = OceanRenderer.Instance._lodDataAnimWaves;
                 _mpb.SetInt(LodDataMgr.sp_LD_SliceIndex, lodIdx);
+                _mpb.SetInt(sp_DisplacementSamplingIterations, _animatedWavesDisplacementSamplingIterations);
                 lodDataAnimWaves.BindResultData(_mpb);
 
                 // blend LOD 0 shape in/out to avoid pop, if the ocean might scale up later (it is smaller than its maximum scale)

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
@@ -10,7 +10,7 @@ namespace Crest
 {
     public interface ILodDataInput
     {
-        void Draw(CommandBuffer buf, float weight, int isTransition);
+        void Draw(CommandBuffer buf, float weight, int isTransition, int lodIdx);
         float Wavelength { get; }
         bool Enabled { get; }
     }
@@ -53,11 +53,14 @@ namespace Crest
             }
         }
 
-        public void Draw(CommandBuffer buf, float weight, int isTransition)
+        public void Draw(CommandBuffer buf, float weight, int isTransition, int lodIdx)
         {
             if (_renderer && weight > 0f)
             {
                 _materials[isTransition].SetFloat(sp_Weight, weight);
+
+                _materials[0].SetInt(LodDataMgr.sp_LD_SliceIndex, lodIdx);
+                _materials[1].SetInt(LodDataMgr.sp_LD_SliceIndex, lodIdx);
 
                 buf.DrawRenderer(_renderer, _materials[isTransition]);
             }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
@@ -58,9 +58,7 @@ namespace Crest
             if (_renderer && weight > 0f)
             {
                 _materials[isTransition].SetFloat(sp_Weight, weight);
-
-                _materials[0].SetInt(LodDataMgr.sp_LD_SliceIndex, lodIdx);
-                _materials[1].SetInt(LodDataMgr.sp_LD_SliceIndex, lodIdx);
+                _materials[isTransition].SetInt(LodDataMgr.sp_LD_SliceIndex, lodIdx);
 
                 buf.DrawRenderer(_renderer, _materials[isTransition]);
             }

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
@@ -47,7 +47,7 @@ namespace Crest
             public float Wavelength { get; set; }
             public bool Enabled { get; set; }
 
-            public void Draw(CommandBuffer buf, float weight, int isTransition)
+            public void Draw(CommandBuffer buf, float weight, int isTransition, int lodIdx)
             {
                 if (Enabled && weight > 0f)
                 {

--- a/crest/Assets/Crest/Crest/Shaders/OceanHelpersDriven.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanHelpersDriven.hlsl
@@ -36,7 +36,7 @@ half4 SampleOceanDataAtWorldPosition(in Texture2DArray i_oceanData, in const flo
 }
 
 // Used to get the world position of the ocean surface from the world position by using fixed-point iteration
-float3 SampleOceanDataAtWorldPosition(in const Texture2DArray i_oceanData, in const float3 i_positionWS, in const uint i_iterations)
+float3 SampleOceanDataDisplacedToWorldPosition(in const Texture2DArray i_oceanData, in const float3 i_positionWS, in const uint i_iterations)
 {
 	float3 undisplacedPosition = InvertDisplacement(i_oceanData, _LD_Pos_Scale[_LD_SliceIndex], _LD_Params[_LD_SliceIndex], _LD_SliceIndex, i_positionWS, i_iterations);
 	return SampleOceanDataAtWorldPosition(i_oceanData, undisplacedPosition);

--- a/crest/Assets/Crest/Crest/Shaders/OceanHelpersDriven.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanHelpersDriven.hlsl
@@ -35,4 +35,59 @@ half4 SampleOceanDataAtWorldPosition(in Texture2DArray i_oceanData, in const flo
 	return result;
 }
 
+float3 SampleOceanDataAtWorldPosition
+(
+	in const Texture2DArray i_oceanData,
+	in const float2 i_positionXZWS,
+	in const float i_minSlice
+)
+{
+	uint slice0, slice1;
+	float lodAlpha;
+	PosToSliceIndices(i_positionXZWS, _MeshScaleLerp, i_minSlice, slice0, slice1, lodAlpha);
+
+	const float wt_smallerLod = (1. - lodAlpha) * _LD_Params[slice0].z;
+	const float wt_biggerLod = (1. - wt_smallerLod) * _LD_Params[slice1].z;
+
+	float3 result = 0.0;
+
+	if (wt_smallerLod > 0.001)
+	{
+		float3 uv_slice = WorldToUV(i_positionXZWS, _LD_Pos_Scale[slice0], _LD_Params[slice0], slice0);
+		result += wt_smallerLod * i_oceanData.SampleLevel(LODData_linear_clamp_sampler, uv_slice, 0).xyz;
+	}
+	if (wt_biggerLod > 0.001)
+	{
+		float3 uv_slice = WorldToUV(i_positionXZWS, _LD_Pos_Scale[slice1], _LD_Params[slice1], slice1);
+		result += wt_biggerLod * i_oceanData.SampleLevel(LODData_linear_clamp_sampler, uv_slice, 0).xyz;
+	}
+
+	return result;
+}
+
+float3 SampleOceanDataAtWorldPosition
+(
+	in const Texture2DArray i_oceanData,
+	in const float3 i_positionWS,
+	in const float i_minSlice,
+	in const uint i_iterations
+)
+{
+	const float2 queryPositionXZ = i_positionWS.xz;
+	const float minGridSize = i_minSlice;
+
+	const float gridSizeSlice0 = _LD_Params[0].x;
+	const float minSlice = clamp(floor(log2(minGridSize / gridSizeSlice0)), 0.0, _SliceCount - 1.0);
+
+	float2 undisplacedPosition = queryPositionXZ;
+	for (uint i = 0; i < i_iterations; i++)
+	{
+		const float3 displacement = SampleOceanDataAtWorldPosition(i_oceanData, undisplacedPosition, minSlice);
+		const float2 error = (undisplacedPosition + displacement.xz) - queryPositionXZ;
+		undisplacedPosition -= error;
+	}
+
+	return SampleOceanDataAtWorldPosition(i_oceanData, undisplacedPosition, minSlice);
+}
+
 #endif // CREST_OCEAN_HELPERS_H

--- a/crest/Assets/Crest/Crest/Shaders/OceanHelpersDriven.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanHelpersDriven.hlsl
@@ -35,59 +35,19 @@ half4 SampleOceanDataAtWorldPosition(in Texture2DArray i_oceanData, in const flo
 	return result;
 }
 
-float3 SampleOceanDataAtWorldPosition
-(
-	in const Texture2DArray i_oceanData,
-	in const float2 i_positionXZWS,
-	in const float i_minSlice
-)
+float3 SampleOceanDataAtWorldPosition(in const Texture2DArray i_oceanData, in const float3 i_positionWS, in const uint i_iterations)
 {
-	uint slice0, slice1;
-	float lodAlpha;
-	PosToSliceIndices(i_positionXZWS, _MeshScaleLerp, i_minSlice, slice0, slice1, lodAlpha);
+	const float3 queryPositionXZ = i_positionWS.xyz;
 
-	const float wt_smallerLod = (1. - lodAlpha) * _LD_Params[slice0].z;
-	const float wt_biggerLod = (1. - wt_smallerLod) * _LD_Params[slice1].z;
-
-	float3 result = 0.0;
-
-	if (wt_smallerLod > 0.001)
-	{
-		float3 uv_slice = WorldToUV(i_positionXZWS, _LD_Pos_Scale[slice0], _LD_Params[slice0], slice0);
-		result += wt_smallerLod * i_oceanData.SampleLevel(LODData_linear_clamp_sampler, uv_slice, 0).xyz;
-	}
-	if (wt_biggerLod > 0.001)
-	{
-		float3 uv_slice = WorldToUV(i_positionXZWS, _LD_Pos_Scale[slice1], _LD_Params[slice1], slice1);
-		result += wt_biggerLod * i_oceanData.SampleLevel(LODData_linear_clamp_sampler, uv_slice, 0).xyz;
-	}
-
-	return result;
-}
-
-float3 SampleOceanDataAtWorldPosition
-(
-	in const Texture2DArray i_oceanData,
-	in const float3 i_positionWS,
-	in const float i_minSlice,
-	in const uint i_iterations
-)
-{
-	const float2 queryPositionXZ = i_positionWS.xz;
-	const float minGridSize = i_minSlice;
-
-	const float gridSizeSlice0 = _LD_Params[0].x;
-	const float minSlice = clamp(floor(log2(minGridSize / gridSizeSlice0)), 0.0, _SliceCount - 1.0);
-
-	float2 undisplacedPosition = queryPositionXZ;
+	float3 undisplacedPosition = queryPositionXZ;
 	for (uint i = 0; i < i_iterations; i++)
 	{
-		const float3 displacement = SampleOceanDataAtWorldPosition(i_oceanData, undisplacedPosition, minSlice);
-		const float2 error = (undisplacedPosition + displacement.xz) - queryPositionXZ;
+		const float3 displacement = SampleOceanDataAtWorldPosition(i_oceanData, undisplacedPosition);
+		const float3 error = (undisplacedPosition + displacement) - queryPositionXZ;
 		undisplacedPosition -= error;
 	}
 
-	return SampleOceanDataAtWorldPosition(i_oceanData, undisplacedPosition, minSlice);
+	return SampleOceanDataAtWorldPosition(i_oceanData, undisplacedPosition);
 }
 
 #endif // CREST_OCEAN_HELPERS_H

--- a/crest/Assets/Crest/Crest/Shaders/OceanHelpersDriven.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanHelpersDriven.hlsl
@@ -38,16 +38,7 @@ half4 SampleOceanDataAtWorldPosition(in Texture2DArray i_oceanData, in const flo
 // Used to get the world position of the ocean surface from the world position by using fixed-point iteration
 float3 SampleOceanDataAtWorldPosition(in const Texture2DArray i_oceanData, in const float3 i_positionWS, in const uint i_iterations)
 {
-	const float3 queryPositionXZ = i_positionWS.xyz;
-
-	float3 undisplacedPosition = queryPositionXZ;
-	for (uint i = 0; i < i_iterations; i++)
-	{
-		const float3 displacement = SampleOceanDataAtWorldPosition(i_oceanData, undisplacedPosition);
-		const float3 error = (undisplacedPosition + displacement) - queryPositionXZ;
-		undisplacedPosition -= error;
-	}
-
+	float3 undisplacedPosition = InvertDisplacement(i_oceanData, _LD_Pos_Scale[_LD_SliceIndex], _LD_Params[_LD_SliceIndex], _LD_SliceIndex, i_positionWS, i_iterations);
 	return SampleOceanDataAtWorldPosition(i_oceanData, undisplacedPosition);
 }
 

--- a/crest/Assets/Crest/Crest/Shaders/OceanHelpersDriven.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanHelpersDriven.hlsl
@@ -35,6 +35,7 @@ half4 SampleOceanDataAtWorldPosition(in Texture2DArray i_oceanData, in const flo
 	return result;
 }
 
+// Used to get the world position of the ocean surface from the world position by using fixed-point iteration
 float3 SampleOceanDataAtWorldPosition(in const Texture2DArray i_oceanData, in const float3 i_positionWS, in const uint i_iterations)
 {
 	const float3 queryPositionXZ = i_positionWS.xyz;

--- a/crest/Assets/Crest/Crest/Shaders/OceanHelpersNew.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanHelpersNew.hlsl
@@ -146,4 +146,27 @@ void PosToSliceIndices
 	}
 }
 
+// Perform iteration to invert the displacement vector field - find position that displaces to query position.
+float3 InvertDisplacement
+(
+	in const Texture2DArray i_oceanData,
+	in float3 i_oceanPosScale,
+	in float4 i_oceanParams,
+	in uint i_sliceIndex,
+	in const float3 i_positionWS,
+	in const uint i_iterations
+)
+{
+	float3 invertedDisplacedPosition = i_positionWS;
+	for (uint i = 0; i < i_iterations; i++)
+	{
+		const float3 uv_slice = WorldToUV(invertedDisplacedPosition.xz, i_oceanPosScale, i_oceanParams, i_sliceIndex);
+		const float3 displacement = i_oceanData.SampleLevel(LODData_linear_clamp_sampler, uv_slice, 0.0);
+		const float3 error = (invertedDisplacedPosition + displacement) - i_positionWS;
+		invertedDisplacedPosition -= error;
+	}
+
+	return invertedDisplacedPosition;
+}
+
 #endif // CREST_OCEAN_HELPERS_H

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/ClipSurfaceConvexHull.shader
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/ClipSurfaceConvexHull.shader
@@ -25,6 +25,10 @@ Shader "Crest/Inputs/Clip Surface/Convex Hull"
 			#include "../../OceanHelpersNew.hlsl"
 			#include "../../OceanHelpersDriven.hlsl"
 
+			CBUFFER_START(CrestPerOceanInput)
+			int _DisplacementSamplingIterations;
+			CBUFFER_END
+
 			struct Attributes
 			{
 				float3 positionOS : POSITION;
@@ -44,15 +48,13 @@ Shader "Crest/Inputs/Clip Surface/Convex Hull"
 				return o;
 			}
 
-			#define ITERATIONS 4
-
 			float4 Frag(Varyings input) : SV_Target
 			{
 				float3 surfacePositionWS = SampleOceanDataAtWorldPosition
 				(
 					_LD_TexArray_AnimatedWaves,
 					input.positionWS,
-					ITERATIONS
+					_DisplacementSamplingIterations
 				);
 
 				// Move to sea level
@@ -82,6 +84,10 @@ Shader "Crest/Inputs/Clip Surface/Convex Hull"
 			#include "../../OceanHelpersNew.hlsl"
 			#include "../../OceanHelpersDriven.hlsl"
 
+			CBUFFER_START(CrestPerOceanInput)
+			int _DisplacementSamplingIterations;
+			CBUFFER_END
+
 			struct Attributes
 			{
 				float3 positionOS : POSITION;
@@ -101,15 +107,13 @@ Shader "Crest/Inputs/Clip Surface/Convex Hull"
 				return o;
 			}
 
-			#define ITERATIONS 4
-
 			float4 Frag(Varyings input) : SV_Target
 			{
 				float3 surfacePositionWS = SampleOceanDataAtWorldPosition
 				(
 					_LD_TexArray_AnimatedWaves,
 					input.positionWS,
-					ITERATIONS
+					_DisplacementSamplingIterations
 				);
 
 				// Move to sea level

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/ClipSurfaceConvexHull.shader
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/ClipSurfaceConvexHull.shader
@@ -50,7 +50,7 @@ Shader "Crest/Inputs/Clip Surface/Convex Hull"
 
 			float4 Frag(Varyings input) : SV_Target
 			{
-				float3 surfacePositionWS = SampleOceanDataAtWorldPosition
+				float3 surfacePositionWS = SampleOceanDataDisplacedToWorldPosition
 				(
 					_LD_TexArray_AnimatedWaves,
 					input.positionWS,
@@ -109,7 +109,7 @@ Shader "Crest/Inputs/Clip Surface/Convex Hull"
 
 			float4 Frag(Varyings input) : SV_Target
 			{
-				float3 surfacePositionWS = SampleOceanDataAtWorldPosition
+				float3 surfacePositionWS = SampleOceanDataDisplacedToWorldPosition
 				(
 					_LD_TexArray_AnimatedWaves,
 					input.positionWS,

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/ClipSurfaceConvexHull.shader
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/ClipSurfaceConvexHull.shader
@@ -26,7 +26,7 @@ Shader "Crest/Inputs/Clip Surface/Convex Hull"
 			#include "../../OceanHelpersDriven.hlsl"
 
 			CBUFFER_START(CrestPerOceanInput)
-			int _DisplacementSamplingIterations;
+			uint _DisplacementSamplingIterations;
 			CBUFFER_END
 
 			struct Attributes
@@ -85,7 +85,7 @@ Shader "Crest/Inputs/Clip Surface/Convex Hull"
 			#include "../../OceanHelpersDriven.hlsl"
 
 			CBUFFER_START(CrestPerOceanInput)
-			int _DisplacementSamplingIterations;
+			uint _DisplacementSamplingIterations;
 			CBUFFER_END
 
 			struct Attributes

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/ClipSurfaceConvexHull.shader
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/ClipSurfaceConvexHull.shader
@@ -44,7 +44,6 @@ Shader "Crest/Inputs/Clip Surface/Convex Hull"
 				return o;
 			}
 
-			#define MIN_SLICE 2.0
 			#define ITERATIONS 4
 
 			float4 Frag(Varyings input) : SV_Target
@@ -53,7 +52,6 @@ Shader "Crest/Inputs/Clip Surface/Convex Hull"
 				(
 					_LD_TexArray_AnimatedWaves,
 					input.positionWS,
-					MIN_SLICE,
 					ITERATIONS
 				);
 
@@ -103,7 +101,6 @@ Shader "Crest/Inputs/Clip Surface/Convex Hull"
 				return o;
 			}
 
-			#define MIN_SLICE 2.0
 			#define ITERATIONS 4
 
 			float4 Frag(Varyings input) : SV_Target
@@ -112,7 +109,6 @@ Shader "Crest/Inputs/Clip Surface/Convex Hull"
 				(
 					_LD_TexArray_AnimatedWaves,
 					input.positionWS,
-					MIN_SLICE,
 					ITERATIONS
 				);
 

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/ClipSurfaceConvexHull.shader
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/ClipSurfaceConvexHull.shader
@@ -44,14 +44,24 @@ Shader "Crest/Inputs/Clip Surface/Convex Hull"
 				return o;
 			}
 
+			#define MIN_SLICE 2.0
+			#define ITERATIONS 4
+
 			float4 Frag(Varyings input) : SV_Target
 			{
-				float3 surfacePositionWS = SampleOceanDataAtWorldPosition(_LD_TexArray_AnimatedWaves, input.positionWS).xyz;
+				float3 surfacePositionWS = SampleOceanDataAtWorldPosition
+				(
+					_LD_TexArray_AnimatedWaves,
+					input.positionWS,
+					MIN_SLICE,
+					ITERATIONS
+				);
+
 				// Move to sea level
 				surfacePositionWS.y += _OceanCenterPosWorld.y;
 
 				// Write red if underwater
-				if (input.positionWS.y >= surfacePositionWS.y)
+				if (input.positionWS.y > surfacePositionWS.y)
 				{
 					clip(-1);
 				}
@@ -93,14 +103,24 @@ Shader "Crest/Inputs/Clip Surface/Convex Hull"
 				return o;
 			}
 
+			#define MIN_SLICE 2.0
+			#define ITERATIONS 4
+
 			float4 Frag(Varyings input) : SV_Target
 			{
-				float3 surfacePositionWS = SampleOceanDataAtWorldPosition(_LD_TexArray_AnimatedWaves, input.positionWS).xyz;
+				float3 surfacePositionWS = SampleOceanDataAtWorldPosition
+				(
+					_LD_TexArray_AnimatedWaves,
+					input.positionWS,
+					MIN_SLICE,
+					ITERATIONS
+				);
+
 				// Move to sea level
 				surfacePositionWS.y += _OceanCenterPosWorld.y;
 
 				// Write black if underwater
-				if (input.positionWS.y >= surfacePositionWS.y)
+				if (input.positionWS.y > surfacePositionWS.y)
 				{
 					clip(-1);
 				}


### PR DESCRIPTION
Before, the CSCH (clip surface convex hull) appeared to work pretty well. But once there was enough waveform displacement, due to chop and possibly other sources, the clipped area would become less accurate to the point where it would no longer appear.

This samples the displacement using the same code as the query displacement compute shader. Four iterations works well when testing which is what the other shader used too. I am not sure how we should set the minimum slice. I found that two was a good value. But it should probably be influenced by `_TexelsPerWave`?

I will need to add some documentation. Should I delete the old function (the first `SampleOceanDataAtWorldPosition`)?