### PR TITLE
Remove duplicated weight/strength input on object-water interaction

### DIFF
--- a/crest/Assets/Crest/Crest-Examples/BoatDev/Data/BoatAlignNormal.prefab
+++ b/crest/Assets/Crest/Crest-Examples/BoatDev/Data/BoatAlignNormal.prefab
@@ -322,7 +322,6 @@ MonoBehaviour:
   _localOffset: {x: 0, y: 0, z: 0}
   _noiseFreq: 6
   _noiseAmp: 0
-  _weight: 5
   _weightUpDownMul: 0.3
   _teleportSpeed: 500
   _warnOnTeleport: 0
@@ -518,7 +517,6 @@ MonoBehaviour:
   _localOffset: {x: 0, y: 0, z: 0}
   _noiseFreq: 6
   _noiseAmp: 0
-  _weight: 3
   _weightUpDownMul: 0.3
   _teleportSpeed: 500
   _warnOnTeleport: 0

--- a/crest/Assets/Crest/Crest-Examples/BoatDev/Data/BoatProbes.prefab
+++ b/crest/Assets/Crest/Crest-Examples/BoatDev/Data/BoatProbes.prefab
@@ -662,7 +662,6 @@ MonoBehaviour:
   _localOffset: {x: 0, y: 0, z: 0}
   _noiseFreq: 6
   _noiseAmp: 0
-  _weight: 8
   _weightUpDownMul: 0.3
   _teleportSpeed: 500
   _warnOnTeleport: 0
@@ -776,7 +775,6 @@ MonoBehaviour:
   _localOffset: {x: 0, y: 0, z: 0}
   _noiseFreq: 6
   _noiseAmp: 0
-  _weight: 8
   _weightUpDownMul: 0.3
   _teleportSpeed: 500
   _warnOnTeleport: 0

--- a/crest/Assets/Crest/Crest-Examples/BoatDev/Materials/WaterInteractionBoatAlignNormalBack.mat
+++ b/crest/Assets/Crest/Crest-Examples/BoatDev/Materials/WaterInteractionBoatAlignNormalBack.mat
@@ -74,7 +74,7 @@ Material:
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 1
     - _SrcBlend: 1
-    - _Strength: 166.66667
+    - _Strength: 830
     - _UVSec: 0
     - _ZWrite: 1
     m_Colors:

--- a/crest/Assets/Crest/Crest-Examples/BoatDev/Materials/WaterInteractionBoatAlignNormalFront.mat
+++ b/crest/Assets/Crest/Crest-Examples/BoatDev/Materials/WaterInteractionBoatAlignNormalFront.mat
@@ -74,7 +74,7 @@ Material:
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 1
     - _SrcBlend: 1
-    - _Strength: 200
+    - _Strength: 600
     - _UVSec: 0
     - _ZWrite: 1
     m_Colors:

--- a/crest/Assets/Crest/Crest-Examples/BoatDev/Materials/WaterInteractionBoatProbes.mat
+++ b/crest/Assets/Crest/Crest-Examples/BoatDev/Materials/WaterInteractionBoatProbes.mat
@@ -74,7 +74,7 @@ Material:
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 1
     - _SrcBlend: 1
-    - _Strength: 92.85714
+    - _Strength: 736
     - _UVSec: 0
     - _ZWrite: 1
     m_Colors:

--- a/crest/Assets/Crest/Crest-Examples/BoatDev/Scenes/Internal/BoatSceneCore.prefab
+++ b/crest/Assets/Crest/Crest-Examples/BoatDev/Scenes/Internal/BoatSceneCore.prefab
@@ -3488,7 +3488,6 @@ MonoBehaviour:
   _localOffset: {x: 0, y: 0, z: 0}
   _noiseFreq: 6
   _noiseAmp: 0
-  _weight: 8
   _weightUpDownMul: 0.3
   _teleportSpeed: 500
   _warnOnTeleport: 0

--- a/crest/Assets/Crest/Crest/Scripts/Interaction/ObjectWaterInteraction.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Interaction/ObjectWaterInteraction.cs
@@ -20,8 +20,6 @@ namespace Crest
         [Range(0f, 1f), SerializeField]
         float _noiseAmp = 0.5f;
 
-        [Range(-1f, 1f), SerializeField]
-        float _weight = 1f;
         [Range(0f, 2f), SerializeField]
         float _weightUpDownMul = 0.5f;
 
@@ -161,7 +159,7 @@ namespace Crest
 
             float dt; int steps;
             ocean._lodDataDynWaves.GetSimSubstepData(ocean.DeltaTimeDynamics, out steps, out dt);
-            float weight = _boat.InWater ? _weight / simsActive : 0f;
+            float weight = _boat.InWater ? 1f / simsActive : 0f;
 
             _renderer.GetPropertyBlock(_mpb);
 


### PR DESCRIPTION
**Status:** Ready to merge

**Overview:**

Weight input on script and Strength input on the material are multiplied
together. This causes confusion as people arent sure what the difference
between the two is.

This change fixes the weight at 1, leaving only the strength param. Some
weights were set > 1, this change bakes that into the materials.

**Tests:**

Ran boat scenes in editor and verified wakes and other interactions look unchanged.

**Issues:**

If people have weights that aren't 1, this change will suddenly increase the strength of the interaction. I suggest to mitigate this with release notes.
