### PR TITLE
Sort ocean inputs based on render queue

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgr.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgr.cs
@@ -178,12 +178,12 @@ namespace Crest
             var drawList = RegisterLodDataInputBase.GetRegistrar(GetType());
             foreach (var draw in drawList)
             {
-                if (!draw.Enabled)
+                if (!draw.Value.Enabled)
                 {
                     continue;
                 }
 
-                draw.Draw(buf, 1f, 0, lodIdx);
+                draw.Value.Draw(buf, 1f, 0, lodIdx);
             }
         }
 
@@ -197,16 +197,16 @@ namespace Crest
             var drawList = RegisterLodDataInputBase.GetRegistrar(GetType());
             foreach (var draw in drawList)
             {
-                if (!draw.Enabled)
+                if (!draw.Value.Enabled)
                 {
                     continue;
                 }
 
                 int isTransition;
-                float weight = filter.Filter(draw, out isTransition);
+                float weight = filter.Filter(draw.Value, out isTransition);
                 if (weight > 0f)
                 {
-                    draw.Draw(buf, weight, isTransition, lodIdx);
+                    draw.Value.Draw(buf, weight, isTransition, lodIdx);
                 }
             }
         }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
@@ -44,15 +44,15 @@ namespace Crest
         public static int sp_Weight = Shader.PropertyToID("_Weight");
 
         static DuplicateKeyComparer<int> s_comparer = new DuplicateKeyComparer<int>();
-        static Dictionary<Type, OceanInput> _registrar = new Dictionary<Type, OceanInput>();
+        static Dictionary<Type, OceanInput> s_registrar = new Dictionary<Type, OceanInput>();
 
         public static OceanInput GetRegistrar(Type lodDataMgrType)
         {
             OceanInput registered;
-            if (!_registrar.TryGetValue(lodDataMgrType, out registered))
+            if (!s_registrar.TryGetValue(lodDataMgrType, out registered))
             {
                 registered = new OceanInput(s_comparer);
-                _registrar.Add(lodDataMgrType, registered);
+                s_registrar.Add(lodDataMgrType, registered);
             }
             return registered;
         }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
@@ -91,7 +91,7 @@ namespace Crest
         static void InitStatics()
         {
             // Init here from 2019.3 onwards
-            _registrar = new Dictionary<System.Type, OceanInput>();
+            s_registrar.Clear();
             sp_Weight = Shader.PropertyToID("_Weight");
         }
     }

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
@@ -296,7 +296,7 @@ namespace Crest
             var registered = RegisterLodDataInputBase.GetRegistrar(typeof(LodDataMgrAnimWaves));
             foreach (var batch in _batches)
             {
-                registered.Add(batch);
+                registered.Add(0, batch);
             }
         }
 
@@ -493,7 +493,7 @@ namespace Crest
                 var registered = RegisterLodDataInputBase.GetRegistrar(typeof(LodDataMgrAnimWaves));
                 foreach (var batch in _batches)
                 {
-                    registered.Remove(batch);
+                    registered.RemoveAt(registered.IndexOfValue(batch));
                 }
 
                 _batches = null;


### PR DESCRIPTION
**Status:** Ready to merge

This will allow ordering between clip shaders (include before remove). This change is taken from the `feature/local-water-bodies` branch where it seems to work.

Merging this into master should have no impact on existing content/functionality whatsoever as there are no order dependencies that I'm aware of between current inputs, so it should be inconsequential if the order the inputs are submitted changes.

It could conceivably add a bit of extra cost to adding/removing ocean inputs due to the sorting, but the number of inputs will rarely be large so it seems unlikely it will ever be an issue.
