### PR TITLE
Make Crest handle failed compute shader loads more gracefully

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/BuildCommandBuffer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/BuildCommandBuffer.cs
@@ -42,42 +42,42 @@ namespace Crest
         {
             /////////////////////////////////////////////////////////////////////////////////////////////////////////////////
             // --- Ocean depths
-            if (ocean._lodDataSeaDepths)
+            if (ocean._lodDataSeaDepths && ocean._lodDataSeaDepths.enabled)
             {
                 ocean._lodDataSeaDepths.BuildCommandBuffer(ocean, buf);
             }
 
             /////////////////////////////////////////////////////////////////////////////////////////////////////////////////
             // --- Flow data
-            if (ocean._lodDataFlow)
+            if (ocean._lodDataFlow && ocean._lodDataFlow.enabled)
             {
                 ocean._lodDataFlow.BuildCommandBuffer(ocean, buf);
             }
 
             /////////////////////////////////////////////////////////////////////////////////////////////////////////////////
             // --- Dynamic wave simulations
-            if (ocean._lodDataDynWaves)
+            if (ocean._lodDataDynWaves && ocean._lodDataDynWaves.enabled)
             {
                 ocean._lodDataDynWaves.BuildCommandBuffer(ocean, buf);
             }
 
             /////////////////////////////////////////////////////////////////////////////////////////////////////////////////
             // --- Animated waves next
-            if (ocean._lodDataAnimWaves)
+            if (ocean._lodDataAnimWaves && ocean._lodDataAnimWaves.enabled)
             {
                 ocean._lodDataAnimWaves.BuildCommandBuffer(ocean, buf);
             }
 
             /////////////////////////////////////////////////////////////////////////////////////////////////////////////////
             // --- Foam simulation
-            if (ocean._lodDataFoam)
+            if (ocean._lodDataFoam && ocean._lodDataFoam.enabled)
             {
                 ocean._lodDataFoam.BuildCommandBuffer(ocean, buf);
             }
 
             /////////////////////////////////////////////////////////////////////////////////////////////////////////////////
             // --- Clip surface
-            if (ocean._lodDataClipSurface)
+            if (ocean._lodDataClipSurface && ocean._lodDataClipSurface.enabled)
             {
                 ocean._lodDataClipSurface.BuildCommandBuffer(ocean, buf);
             }

--- a/crest/Assets/Crest/Crest/Scripts/Collision/QueryBase.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Collision/QueryBase.cs
@@ -490,10 +490,6 @@ namespace Crest
         {
             _dataArrivedAction = new System.Action<AsyncGPUReadbackRequest>(DataArrived);
 
-            _shaderProcessQueries = Resources.Load<ComputeShader>(QueryShaderName);
-            _kernelHandle = _shaderProcessQueries.FindKernel(QueryKernelName);
-            _wrapper = new PropertyWrapperComputeStandalone(_shaderProcessQueries, _kernelHandle);
-
             if (_maxQueryCount != OceanRenderer.Instance._simSettingsAnimatedWaves.MaxQueryCount)
             {
                 _maxQueryCount = OceanRenderer.Instance._simSettingsAnimatedWaves.MaxQueryCount;
@@ -505,6 +501,15 @@ namespace Crest
 
             _queryResults = new NativeArray<Vector3>(_maxQueryCount, Allocator.Persistent, NativeArrayOptions.ClearMemory);
             _queryResultsLast = new NativeArray<Vector3>(_maxQueryCount, Allocator.Persistent, NativeArrayOptions.ClearMemory);
+
+            _shaderProcessQueries = ComputeShaderHelpers.LoadShader(QueryShaderName);
+            if (_shaderProcessQueries == null)
+            {
+                enabled = false;
+                return;
+            }
+            _kernelHandle = _shaderProcessQueries.FindKernel(QueryKernelName);
+            _wrapper = new PropertyWrapperComputeStandalone(_shaderProcessQueries, _kernelHandle);
         }
 
         protected virtual void OnDisable()

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/ComputeShaderHelpers.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/ComputeShaderHelpers.cs
@@ -1,0 +1,18 @@
+
+
+using UnityEngine;
+
+namespace Crest
+{
+    public static class ComputeShaderHelpers
+    {
+
+        public static ComputeShader LoadShader(string path)
+        {
+            // We provide this helper function to ensure the user gets a friendly error message in this error case
+            ComputeShader computeShader = Resources.Load<ComputeShader>(path);
+            Debug.AssertFormat(computeShader != null, "The shader {0} failed to load, this is likely due to an import error. Please reimport Crest to fix this", path);
+            return computeShader;
+        }
+    }
+}

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/ComputeShaderHelpers.cs.meta
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/ComputeShaderHelpers.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 25f4723a1aac93a4dafb7834623df5b4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/TextureArrayHelpers.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/TextureArrayHelpers.cs
@@ -28,6 +28,10 @@ namespace Crest
         // implemented a custom version to clear to black
         public static void ClearToBlack(RenderTexture dst)
         {
+            if(s_clearToBlackShader == null)
+            {
+                return;
+            }
             s_clearToBlackShader.SetTexture(krnl_ClearToBlack, sp_LD_TexArray_Target, dst);
             s_clearToBlackShader.Dispatch(
                 krnl_ClearToBlack,
@@ -69,8 +73,11 @@ namespace Crest
                 BlackTextureArray.name = "Black Texture2DArray";
             }
 
-            s_clearToBlackShader = Resources.Load<ComputeShader>(CLEAR_TO_BLACK_SHADER_NAME);
-            krnl_ClearToBlack = s_clearToBlackShader.FindKernel(CLEAR_TO_BLACK_SHADER_NAME);
+            s_clearToBlackShader = ComputeShaderHelpers.LoadShader(CLEAR_TO_BLACK_SHADER_NAME);
+            if(s_clearToBlackShader != null)
+            {
+                krnl_ClearToBlack = s_clearToBlackShader.FindKernel(CLEAR_TO_BLACK_SHADER_NAME);
+            }
         }
     }
 }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrAnimWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrAnimWaves.cs
@@ -76,7 +76,12 @@ namespace Crest
             // different animated wave LODs. As we use a single texture array
             // for all LODs, we employ a compute shader as only they can
             // read and write to the same texture.
-            _combineShader = Resources.Load<ComputeShader>(ShaderName);
+            _combineShader = ComputeShaderHelpers.LoadShader(ShaderName);
+            if(_combineShader == null)
+            {
+                enabled = false;
+                return;
+            }
             krnl_ShapeCombine = _combineShader.FindKernel("ShapeCombine");
             krnl_ShapeCombine_DISABLE_COMBINE = _combineShader.FindKernel("ShapeCombine_DISABLE_COMBINE");
             krnl_ShapeCombine_FLOW_ON = _combineShader.FindKernel("ShapeCombine_FLOW_ON");

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrAnimWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrAnimWaves.cs
@@ -76,21 +76,6 @@ namespace Crest
             // different animated wave LODs. As we use a single texture array
             // for all LODs, we employ a compute shader as only they can
             // read and write to the same texture.
-            _combineShader = ComputeShaderHelpers.LoadShader(ShaderName);
-            if(_combineShader == null)
-            {
-                enabled = false;
-                return;
-            }
-            krnl_ShapeCombine = _combineShader.FindKernel("ShapeCombine");
-            krnl_ShapeCombine_DISABLE_COMBINE = _combineShader.FindKernel("ShapeCombine_DISABLE_COMBINE");
-            krnl_ShapeCombine_FLOW_ON = _combineShader.FindKernel("ShapeCombine_FLOW_ON");
-            krnl_ShapeCombine_FLOW_ON_DISABLE_COMBINE = _combineShader.FindKernel("ShapeCombine_FLOW_ON_DISABLE_COMBINE");
-            krnl_ShapeCombine_DYNAMIC_WAVE_SIM_ON = _combineShader.FindKernel("ShapeCombine_DYNAMIC_WAVE_SIM_ON");
-            krnl_ShapeCombine_DYNAMIC_WAVE_SIM_ON_DISABLE_COMBINE = _combineShader.FindKernel("ShapeCombine_DYNAMIC_WAVE_SIM_ON_DISABLE_COMBINE");
-            krnl_ShapeCombine_FLOW_ON_DYNAMIC_WAVE_SIM_ON = _combineShader.FindKernel("ShapeCombine_FLOW_ON_DYNAMIC_WAVE_SIM_ON");
-            krnl_ShapeCombine_FLOW_ON_DYNAMIC_WAVE_SIM_ON_DISABLE_COMBINE = _combineShader.FindKernel("ShapeCombine_FLOW_ON_DYNAMIC_WAVE_SIM_ON_DISABLE_COMBINE");
-            _combineProperties = new PropertyWrapperCompute();
 
             int resolution = OceanRenderer.Instance.LodDataResolution;
             var desc = new RenderTextureDescriptor(resolution, resolution, TextureFormat, 0);
@@ -106,6 +91,22 @@ namespace Crest
                 var mat = new Material(combineShader);
                 _combineMaterial[i] = new PropertyWrapperMaterial(mat);
             }
+
+            _combineShader = ComputeShaderHelpers.LoadShader(ShaderName);
+            if(_combineShader == null)
+            {
+                enabled = false;
+                return;
+            }
+            krnl_ShapeCombine = _combineShader.FindKernel("ShapeCombine");
+            krnl_ShapeCombine_DISABLE_COMBINE = _combineShader.FindKernel("ShapeCombine_DISABLE_COMBINE");
+            krnl_ShapeCombine_FLOW_ON = _combineShader.FindKernel("ShapeCombine_FLOW_ON");
+            krnl_ShapeCombine_FLOW_ON_DISABLE_COMBINE = _combineShader.FindKernel("ShapeCombine_FLOW_ON_DISABLE_COMBINE");
+            krnl_ShapeCombine_DYNAMIC_WAVE_SIM_ON = _combineShader.FindKernel("ShapeCombine_DYNAMIC_WAVE_SIM_ON");
+            krnl_ShapeCombine_DYNAMIC_WAVE_SIM_ON_DISABLE_COMBINE = _combineShader.FindKernel("ShapeCombine_DYNAMIC_WAVE_SIM_ON_DISABLE_COMBINE");
+            krnl_ShapeCombine_FLOW_ON_DYNAMIC_WAVE_SIM_ON = _combineShader.FindKernel("ShapeCombine_FLOW_ON_DYNAMIC_WAVE_SIM_ON");
+            krnl_ShapeCombine_FLOW_ON_DYNAMIC_WAVE_SIM_ON_DISABLE_COMBINE = _combineShader.FindKernel("ShapeCombine_FLOW_ON_DYNAMIC_WAVE_SIM_ON_DISABLE_COMBINE");
+            _combineProperties = new PropertyWrapperCompute();
         }
 
         RenderTexture CreateCombineBuffer(RenderTextureDescriptor desc)

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrPersistent.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrPersistent.cs
@@ -38,7 +38,12 @@ namespace Crest
 
         void CreateProperties(int lodCount)
         {
-            _shader = Resources.Load<ComputeShader>(ShaderSim);
+            _shader = ComputeShaderHelpers.LoadShader(ShaderSim);
+            if(_shader == null)
+            {
+                enabled = false;
+                return;
+            }
             _renderSimProperties = new PropertyWrapperCompute();
         }
 

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsAnimatedWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsAnimatedWaves.cs
@@ -19,7 +19,7 @@ namespace Crest
             GerstnerWavesCPU,
             ComputeShaderQueries,
         }
-        
+
         [Tooltip("Where to obtain ocean shape on CPU for physics / gameplay."), SerializeField]
         CollisionSources _collisionSource = CollisionSources.ComputeShaderQueries;
         public CollisionSources CollisionSource { get { return _collisionSource; } }
@@ -50,9 +50,11 @@ namespace Crest
 
             if (result == null)
             {
-                // this should not be hit - return null to create null ref exceptions
-                Debug.Assert(false, "Could not create collision provider. Collision source = " + _collisionSource.ToString(), this);
-                return null;
+                // this should not be hit, but can be if compute shaders aren't loaded correctly.
+                // they will print out appropriate errors, so we don't want to return just null and have null reference
+                // exceptions spamming the logs.
+                Debug.LogError($"Could not create collision provider. Collision source = {_collisionSource.ToString()}", this);
+                return new CollProviderNull();
             }
 
             return result;

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Shadows/LodDataMgrShadow.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Shadows/LodDataMgrShadow.cs
@@ -56,7 +56,12 @@ namespace Crest
             base.Start();
 
             _renderProperties = new PropertyWrapperCompute();
-            _updateShadowShader = Resources.Load<ComputeShader>(UpdateShadow);
+            _updateShadowShader = ComputeShaderHelpers.LoadShader(UpdateShadow);
+            if(_updateShadowShader == null)
+            {
+                enabled = false;
+                return;
+            }
 
             try
             {


### PR DESCRIPTION
A common issues users have is that compute shaders won't load correctly through no fault of their own. However, previously Crest would just null-reference exception all over the place without a clear indication to the user as to why.

This change aims to ensure two things:

- When a compute shader fails to load, we give a good error message explaining that and provide a common solution.

- Crest no longer spams the log with new null reference exceptions every frame if the compute shaders fail to load.

The first point is achived by replacing the calls to `Resources.Load` to a call into a wrapper which asserts if the load fails.

The second point is achived by finding all the bits of code which only run under the assumption that compute shaders will successfully load, and ensure that they now simply stop updating or just *do nothing* if that assumption fails.

Below is a screenshot showing what I get if I have manually deleted all the compute shaders myself:
![image](https://user-images.githubusercontent.com/10348641/76910180-3a95a680-68a5-11ea-949f-e13f8bb265a1.png)
