### PR TITLE
Make array initalisation use loop instead of LINQ

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
@@ -2,7 +2,6 @@
 
 // This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
 
-using System.Linq;
 using UnityEngine;
 using UnityEngine.Rendering;
 
@@ -71,9 +70,13 @@ namespace Crest
         static void InitNullTexture()
         {
             var texture = Instantiate<Texture2D>(Texture2D.whiteTexture);
-            // Null texture needs to be white (uses R channel) with a 1000 intensity. 
+            // Null texture needs to be white (uses R channel) with a 1000 intensity.
             var color = new Color(1000, 1000, 1000, 1);
-            Color[] pixels = Enumerable.Repeat(color, texture.height * texture.width).ToArray();
+            Color[] pixels = new Color[texture.height * texture.width];
+            for(int i = 0; i < pixels.Length; i++)
+            {
+                pixels[i] = color;
+            }
             texture.SetPixels(pixels);
             texture.Apply();
             s_nullTexture2DArray = TextureArrayHelpers.CreateTexture2DArray(texture);


### PR DESCRIPTION
Motivation:

LINQ functions, whilst convenient can be slow and generate more gargbage than neccessary. This change was motivated by #432 an is incredibly minor.

The main reason I'm making a PR for this is because I noticed that Texture2D has a new NativeArray API: https://docs.unity3d.com/2018.4/Documentation/ScriptReference/Texture2D.GetRawTextureData.html

I looked into using it, but in the end I went for the safe incremental improvement. But I thought it would be worth highlighting this as an option we could start using in the future. 