### PR TITLE
Make _LightShadowData knockout apply to Metal as well

### DIFF
--- a/crest/Assets/Crest/Crest/Shaders/Resources/UpdateShadow.compute
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/UpdateShadow.compute
@@ -14,14 +14,14 @@
 //     _LightShadowData at kernel UpdateShadow
 // We skirt around this by defining our own _LightShadowData as a float4, and
 // then making sure that the *real* _LightShadowData variabel is knocked-out.
-#if SHADER_API_VULKAN
+#if SHADER_API_VULKAN || SHADER_API_METAL
 uniform float4 _LightShadowData;
 #define _LightShadowData _LightShadowData_KNOCKED_OUT
 #endif
 
 #include "UnityCG.cginc"
 
-#if SHADER_API_VULKAN
+#if SHADER_API_VULKAN || SHADER_API_METAL
 #undef _LightShadowData
 #endif
 


### PR DESCRIPTION
Fixes #449.

We already had the problem from the issue (UpdateShadow compute shader not compiling) on Vulkan, so applying the same fix to Metal was a straightforward thing to do.

Honestly though, I think part of the issue does come from the fact that we are trying to do this shadow stuff in a compute shader, and unfortunately Unity doesn't support having standard shaders target a specific slice in a texture array until 2019.1 (which is why we don't do this with a compute shader in URP), so we have to stick with the compute shader in BIRP for now. 