### PR TITLE
Fix ocean depth disabled state properly

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Helpers/TextureArrayHelpers.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/TextureArrayHelpers.cs
@@ -41,6 +41,19 @@ namespace Crest
             );
         }
 
+        public static Texture2D CreateTexture2D(Color color, TextureFormat format)
+        {
+            var texture = new Texture2D(SMALL_TEXTURE_DIM, SMALL_TEXTURE_DIM, format, false, false);
+            Color[] pixels = new Color[texture.height * texture.width];
+            for (int i = 0; i < pixels.Length; i++)
+            {
+                pixels[i] = color;
+            }
+            texture.SetPixels(pixels);
+            texture.Apply();
+            return texture;
+        }
+
         public static Texture2DArray CreateTexture2DArray(Texture2D texture)
         {
             var array = new Texture2DArray(

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
@@ -69,16 +69,9 @@ namespace Crest
 
         static void InitNullTexture()
         {
-            var texture = Instantiate<Texture2D>(Texture2D.whiteTexture);
-            // Null texture needs to be white (uses R channel) with a 1000 intensity.
-            var color = new Color(1000, 1000, 1000, 1);
-            Color[] pixels = new Color[texture.height * texture.width];
-            for(int i = 0; i < pixels.Length; i++)
-            {
-                pixels[i] = color;
-            }
-            texture.SetPixels(pixels);
-            texture.Apply();
+            // We want the null texture to be the depth attenuation begins (1000 metres)
+            // Depth textures use HDR values
+            var texture = TextureArrayHelpers.CreateTexture2D(Color.red * 1000f, UnityEngine.TextureFormat.RGB9e5Float);
             s_nullTexture2DArray = TextureArrayHelpers.CreateTexture2DArray(texture);
             s_nullTexture2DArray.name = "Sea Floor Depth Null Texture";
         }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
@@ -23,6 +23,8 @@ namespace Crest
 
         public const string ShaderName = "Crest/Inputs/Depth/Cached Depths";
 
+        // We want the null colour to be the depth where wave attenuation begins (1000 metres)
+        readonly static Color s_nullColor = Color.red * 1000f;
         static Texture2DArray s_nullTexture2DArray;
 
         public override void BuildCommandBuffer(OceanRenderer ocean, CommandBuffer buf)
@@ -39,7 +41,7 @@ namespace Crest
             for (int lodIdx = OceanRenderer.Instance.CurrentLodCount - 1; lodIdx >= 0; lodIdx--)
             {
                 buf.SetRenderTarget(_targets, 0, CubemapFace.Unknown, lodIdx);
-                buf.ClearRenderTarget(false, true, Color.red * 1000f);
+                buf.ClearRenderTarget(false, true, s_nullColor);
                 buf.SetGlobalInt(sp_LD_SliceIndex, lodIdx);
                 SubmitDraws(lodIdx, buf);
             }
@@ -69,9 +71,8 @@ namespace Crest
 
         static void InitNullTexture()
         {
-            // We want the null texture to be the depth attenuation begins (1000 metres)
             // Depth textures use HDR values
-            var texture = TextureArrayHelpers.CreateTexture2D(Color.red * 1000f, UnityEngine.TextureFormat.RGB9e5Float);
+            var texture = TextureArrayHelpers.CreateTexture2D(s_nullColor, UnityEngine.TextureFormat.RGB9e5Float);
             s_nullTexture2DArray = TextureArrayHelpers.CreateTexture2DArray(texture);
             s_nullTexture2DArray.name = "Sea Floor Depth Null Texture";
         }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
@@ -59,8 +59,7 @@ namespace Crest
         }
         public static void BindNull(IPropertyWrapper properties, bool sourceLod = false)
         {
-            // Texture2D.whiteTexture prevents us from initialising this in a static constructor. Seemed appropriate to
-            // do it here.
+            // TextureArrayHelpers prevents use from using this in a static constructor due to blackTexture usage
             if (s_nullTexture2DArray == null)
             {
                 InitNullTexture();

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
@@ -417,6 +417,10 @@ namespace Crest
                 {
                     OceanRenderer.Instance._lodDataSeaDepths.BindResultData(mat, false);
                 }
+                else
+                {
+                    LodDataMgrSeaFloorDepth.BindNull(mat, false);
+                }
 
                 if (_directTowardsPoint)
                 {


### PR DESCRIPTION
Previous attempt: #432 

I wasn't diligent with this one. It fixed the foam problem but nothing else. The issue that remained is when the ocean depth is disabled, the value would be clamped to 0-1 due to not being an HDR texture.

I tested it on Metal, DirectX and Vulkan. I am using the [RGB9e5Float](https://docs.unity3d.com/ScriptReference/TextureFormat.RGB9e5Float.html) format. It appears to be well supported.

The alternative is to map the depth values to 0-1 instead.