### PR TITLE
Ouch - fix a ton of unprotected logs, all of which may produce NaNs

### DIFF
--- a/crest/Assets/Crest/Crest/Shaders/OceanEmission.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanEmission.hlsl
@@ -143,7 +143,7 @@ void ApplyCaustics(in const half3 i_view, in const half3 i_lightDir, in const fl
 	// Compute mip index manually, with bias based on sea floor depth. We compute it manually because if it is computed automatically it produces ugly patches
 	// where samples are stretched/dilated. The bias is to give a focusing effect to caustics - they are sharpest at a particular depth. This doesn't work amazingly
 	// well and could be replaced.
-	float mipLod = log2(i_sceneZ) + abs(sceneDepth - _CausticsFocalDepth) / _CausticsDepthOfField;
+	float mipLod = log2(max(i_sceneZ, 1.0)) + abs(sceneDepth - _CausticsFocalDepth) / _CausticsDepthOfField;
 	// project along light dir, but multiply by a fudge factor reduce the angle bit - compensates for fact that in real life
 	// caustics come from many directions and don't exhibit such a strong directonality
 	float2 surfacePosXZ = scenePos.xz + i_lightDir.xz * sceneDepth / (4.*i_lightDir.y);

--- a/crest/Assets/Crest/Crest/Shaders/OceanHelpersNew.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanHelpersNew.hlsl
@@ -127,7 +127,7 @@ void PosToSliceIndices
 	const float2 offsetFromCenter = abs(worldXZ - _OceanCenterPosWorld.xz);
 	const float taxicab = max(offsetFromCenter.x, offsetFromCenter.y);
 	const float radius0 = minScale;
-	const float sliceNumber = clamp(log2(taxicab / radius0), minSlice, _SliceCount - 1.0);
+	const float sliceNumber = clamp(log2(max(taxicab / radius0, 1.0)), minSlice, _SliceCount - 1.0);
 
 	lodAlpha = frac(sliceNumber);
 	slice0 = floor(sliceNumber);

--- a/crest/Assets/Crest/Crest/Shaders/OceanLODData.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanLODData.hlsl
@@ -116,7 +116,7 @@ void PosToSliceIndices(const float2 worldXZ, const float meshScaleLerp, const fl
 	const float2 offsetFromCenter = abs(worldXZ - _OceanCenterPosWorld.xz);
 	const float taxicab = max(offsetFromCenter.x, offsetFromCenter.y);
 	const float radius0 = _LD_Pos_Scale[0].z;
-	const float sliceNumber = clamp(log2(taxicab / radius0), minSlice, _SliceCount - 1.0);
+	const float sliceNumber = clamp(log2(max(taxicab / radius0, 1.0)), minSlice, _SliceCount - 1.0);
 
 	lodAlpha = frac(sliceNumber);
 	slice0 = (uint)sliceNumber;

--- a/crest/Assets/Crest/Crest/Shaders/Resources/QueryDisplacements.compute
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/QueryDisplacements.compute
@@ -40,7 +40,7 @@ void CSMain(uint3 id : SV_DispatchThreadID)
 	const float minGridSize = data.z;
 
 	const float gridSizeSlice0 = _LD_Params[0].x;
-	const float minSlice = clamp(floor(log2(minGridSize / gridSizeSlice0)), 0.0, _SliceCount - 1.0);
+	const float minSlice = clamp(floor(log2(max(minGridSize / gridSizeSlice0, 1.0))), 0.0, _SliceCount - 1.0);
 
 	// Perform iteration to invert the displacement vector field - find position that displaces to query position,
 	// and return displacement at that point.

--- a/crest/Assets/Crest/Crest/Shaders/Resources/QueryFlow.compute
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/QueryFlow.compute
@@ -43,7 +43,7 @@ void CSMain(uint3 id : SV_DispatchThreadID)
 	const float minGridSize = data.z;
 
 	const float gridSizeSlice0 = _LD_Params[0].x;
-	const float minSlice = clamp(floor(log2(minGridSize / gridSizeSlice0)), 0.0, _SliceCount - 1.0);
+	const float minSlice = clamp(floor(log2(max(minGridSize / gridSizeSlice0, 1.0))), 0.0, _SliceCount - 1.0);
 
 	_ResultFlows[id.x] = ComputeFlow(queryPosXZ, minSlice);
 }


### PR DESCRIPTION
Status: Ready to merge.

The all time silliest issue in crest. Theres a bunch of cases where we can compute log(0). This is a bad time as it gives -INF on hlsl.

This might be causing particular badness on metal - some instrumentation i added for someone reported a NaN coming from the height queries, which led to finding this. Hopefully this change helps or resolves the issue, but in any case it is necessary.

