### PR TITLE
Fix Shallow Subsurface Scattering popping

### DIFF
--- a/crest/Assets/Crest/Crest/Shaders/Ocean.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Ocean.shader
@@ -329,7 +329,7 @@ Shader "Crest/Ocean"
 				}
 
 				// Data that needs to be sampled at the displaced position
-				if (wt_smallerLod > 0.001)
+				if (wt_smallerLod > 0.0001)
 				{
 					const float3 uv_slice_smallerLodDisp = WorldToUV(o.worldPos.xz);
 
@@ -338,10 +338,13 @@ Shader "Crest/Ocean"
 					#endif
 
 					#if _SHADOWS_ON
-					SampleShadow(_LD_TexArray_Shadow, uv_slice_smallerLodDisp, wt_smallerLod, o.flow_shadow.zw);
+					if (wt_smallerLod > 0.001)
+					{
+						SampleShadow(_LD_TexArray_Shadow, uv_slice_smallerLodDisp, wt_smallerLod, o.flow_shadow.zw);
+					}
 					#endif
 				}
-				if (wt_biggerLod > 0.001)
+				if (wt_biggerLod > 0.0001)
 				{
 					const float3 uv_slice_biggerLodDisp = WorldToUV_BiggerLod(o.worldPos.xz);
 
@@ -350,7 +353,10 @@ Shader "Crest/Ocean"
 					#endif
 
 					#if _SHADOWS_ON
-					SampleShadow(_LD_TexArray_Shadow, uv_slice_biggerLodDisp, wt_biggerLod, o.flow_shadow.zw);
+					if (wt_biggerLod > 0.001)
+					{
+						SampleShadow(_LD_TexArray_Shadow, uv_slice_biggerLodDisp, wt_biggerLod, o.flow_shadow.zw);
+					}
 					#endif
 				}
 


### PR DESCRIPTION
I was noticing popping in VR. Narrowed it down to the shallow subsurface scattering.

![Popping](https://user-images.githubusercontent.com/5249806/78984558-e90dce00-7b69-11ea-996e-6f25ead02d0a.jpg)

Pops exhibited with camera transform X and Z values between 39.201 and
39.205. 0.0001 seems to eliminate it entirely.

It probably wasn't that noticeable in 2D with certain ocean material settings. Specular etc can mask the problem enough. And 2D type of movement would probably skip past it.

It affects both BIRP and URP. Not sure about SG.