### PR TITLE
Show a proxy plane at the ocean sea level

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -2,6 +2,7 @@
 
 // This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
 
+using UnityEditor;
 using UnityEngine;
 
 namespace Crest
@@ -103,6 +104,9 @@ namespace Crest
 
         [Header("Debug Params")]
 
+        [SerializeField]
+        bool _showProxyPlane = true;
+
         [Tooltip("Attach debug gui that adds some controls and allows to visualise the ocean data."), SerializeField]
         bool _attachDebugGUI = false;
 
@@ -185,7 +189,7 @@ namespace Crest
             InitViewpoint();
             InitTimeProvider();
 
-            if(_attachDebugGUI && GetComponent<OceanDebugGUI>() == null)
+            if (_attachDebugGUI && GetComponent<OceanDebugGUI>() == null)
             {
                 gameObject.AddComponent<OceanDebugGUI>();
             }
@@ -417,6 +421,34 @@ namespace Crest
         private static void OnReLoadScripts()
         {
             Instance = FindObjectOfType<OceanRenderer>();
+        }
+
+        GameObject _proxyPlane;
+
+        private void OnDrawGizmos()
+        {
+            if (_proxyPlane == null)
+            {
+                _proxyPlane = GameObject.CreatePrimitive(PrimitiveType.Plane);
+                DestroyImmediate(_proxyPlane.GetComponent<Collider>());
+                _proxyPlane.hideFlags = HideFlags.HideAndDontSave;
+                _proxyPlane.transform.parent = transform;
+                _proxyPlane.transform.localPosition = Vector3.zero;
+                _proxyPlane.transform.localRotation = Quaternion.identity;
+                _proxyPlane.transform.localScale = 4000f * Vector3.one;
+
+                var mat = new Material(Shader.Find("Hidden/Crest/OceanProxy"));
+                _proxyPlane.GetComponent<Renderer>().sharedMaterial = mat;
+            }
+
+            if (_proxyPlane.activeSelf != _showProxyPlane)
+            {
+                _proxyPlane.SetActive(_showProxyPlane);
+
+                // Scene view doesnt automatically refresh which makes the option confusing, so force it
+                EditorWindow view = EditorWindow.GetWindow<SceneView>();
+                view.Repaint();
+            }
         }
 #endif
     }

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -106,6 +106,10 @@ namespace Crest
 
         [SerializeField]
         bool _showProxyPlane = true;
+#if UNITY_EDITOR
+        GameObject _proxyPlane;
+        const string kProxyShader = "Hidden/Crest/OceanProxy";
+#endif
 
         [Tooltip("Attach debug gui that adds some controls and allows to visualise the ocean data."), SerializeField]
         bool _attachDebugGUI = false;
@@ -423,11 +427,16 @@ namespace Crest
             Instance = FindObjectOfType<OceanRenderer>();
         }
 
-        GameObject _proxyPlane;
-
         private void OnDrawGizmos()
         {
-            if (_proxyPlane == null)
+            // Don't need proxy if in play mode
+            if (EditorApplication.isPlaying)
+            {
+                return;
+            }
+
+            // Create proxy if not present already, and proxy enabled
+            if (_proxyPlane == null && _showProxyPlane)
             {
                 _proxyPlane = GameObject.CreatePrimitive(PrimitiveType.Plane);
                 DestroyImmediate(_proxyPlane.GetComponent<Collider>());
@@ -436,12 +445,12 @@ namespace Crest
                 _proxyPlane.transform.localPosition = Vector3.zero;
                 _proxyPlane.transform.localRotation = Quaternion.identity;
                 _proxyPlane.transform.localScale = 4000f * Vector3.one;
-
-                var mat = new Material(Shader.Find("Hidden/Crest/OceanProxy"));
-                _proxyPlane.GetComponent<Renderer>().sharedMaterial = mat;
+                
+                _proxyPlane.GetComponent<Renderer>().sharedMaterial = new Material(Shader.Find(kProxyShader));
             }
 
-            if (_proxyPlane.activeSelf != _showProxyPlane)
+            // Change active state of proxy if necessary
+            if (_proxyPlane != null && _proxyPlane.activeSelf != _showProxyPlane)
             {
                 _proxyPlane.SetActive(_showProxyPlane);
 

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -105,7 +105,9 @@ namespace Crest
         [Header("Debug Params")]
 
         [SerializeField]
+#pragma warning disable 414
         bool _showProxyPlane = true;
+#pragma warning restore 414
 #if UNITY_EDITOR
         GameObject _proxyPlane;
         const string kProxyShader = "Hidden/Crest/OceanProxy";

--- a/crest/Assets/Crest/Crest/Shaders/Misc.meta
+++ b/crest/Assets/Crest/Crest/Shaders/Misc.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 98e016f479062154fac3afc6fd85506b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/crest/Assets/Crest/Crest/Shaders/Misc/OceanProxy.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Misc/OceanProxy.shader
@@ -1,0 +1,55 @@
+﻿// Crest Ocean System
+
+// This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
+
+Shader "Hidden/Crest/OceanProxy"
+{
+    SubShader
+    {
+        Tags { "RenderType"="Transparent" "Queue"="Transparent"}
+		Blend SrcAlpha OneMinusSrcAlpha
+		ZWrite Off
+
+        Pass
+        {
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            // make fog work
+            #pragma multi_compile_fog
+
+            #include "UnityCG.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float2 uv : TEXCOORD0;
+            };
+
+            struct v2f
+            {
+                UNITY_FOG_COORDS(1)
+                float4 vertex : SV_POSITION;
+            };
+
+            v2f vert (appdata v)
+            {
+                v2f o;
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                UNITY_TRANSFER_FOG(o, o.vertex);
+                return o;
+            }
+
+            fixed4 frag (v2f i) : SV_Target
+            {
+                fixed4 col = fixed4(0.0, 0.3, 1.0, 0.5);
+
+                // apply fog
+                UNITY_APPLY_FOG(i.fogCoord, col);
+
+                return col;
+            }
+            ENDCG
+        }
+    }
+}

--- a/crest/Assets/Crest/Crest/Shaders/Misc/OceanProxy.shader.meta
+++ b/crest/Assets/Crest/Crest/Shaders/Misc/OceanProxy.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 718f5f399c29fed4fa3b3461cc7b46a3
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
**Status:** ready to merge

Creates a transparent plane at the ocean height in the scene at the sea level, to use as reference.

![image](https://user-images.githubusercontent.com/939901/79837287-1861dd80-83a9-11ea-83b4-b4e63bbe9e1a.png)

Creates a hidden, nonsaved transparent plane gameobject. Done this way because it doesnt seem to be possible to have gizmo drawing intersect with the scene.

Only creates if in edit mode and proxy is enabled.

Tests: in win64 editor, and made win64 standalone build.
