### PR TITLE
Compute LOD black point fade

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -158,6 +158,10 @@ namespace Crest
         readonly int sp_oceanCenterPosWorld = Shader.PropertyToID("_OceanCenterPosWorld");
         readonly int sp_meshScaleLerp = Shader.PropertyToID("_MeshScaleLerp");
         readonly int sp_sliceCount = Shader.PropertyToID("_SliceCount");
+        readonly int sp_blackPointFade = Shader.PropertyToID("_CrestBlackPointFade");
+
+        float _baseMeshDensity;
+        float _blackPointFade;
 
         void Awake()
         {
@@ -174,6 +178,12 @@ namespace Crest
 
             Instance = this;
             Scale = Mathf.Clamp(Scale, _minScale, _maxScale);
+
+            // Resolution is over 4 tiles across
+            _baseMeshDensity = _lodDataResolution * 0.25f / _geometryDownSampleFactor;
+            // 0.4f is the "best" value when base mesh density is 8. Scaling down from there produces results similar to
+            // hand crafted values which looked good when the ocean is flat
+            _blackPointFade = 0.4f / (_baseMeshDensity / 8f);
 
             OceanBuilder.GenerateMesh(this, _lodDataResolution, _geometryDownSampleFactor, _lodCount);
 
@@ -253,6 +263,7 @@ namespace Crest
             Shader.SetGlobalFloat(sp_texelsPerWave, MinTexelsPerWave);
             Shader.SetGlobalFloat(sp_crestTime, CurrentTime);
             Shader.SetGlobalFloat(sp_sliceCount, CurrentLodCount);
+            Shader.SetGlobalFloat(sp_blackPointFade, _blackPointFade);
 
             // LOD 0 is blended in/out when scale changes, to eliminate pops. Here we set it as a global, whereas in OceanChunkRenderer it
             // is applied to LOD0 tiles only through _InstanceData. This global can be used in compute, where we only apply this factor for slice 0.

--- a/crest/Assets/Crest/Crest/Shaders/OceanGlobals.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanGlobals.hlsl
@@ -17,6 +17,7 @@ float _TexelsPerWave;
 float3 _OceanCenterPosWorld;
 float _SliceCount;
 float _MeshScaleLerp;
+float _CrestBlackPointFade;
 
 float3 _PrimaryLightDirection;
 float3 _PrimaryLightIntensity;

--- a/crest/Assets/Crest/Crest/Shaders/OceanGlobals.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanGlobals.hlsl
@@ -17,7 +17,8 @@ float _TexelsPerWave;
 float3 _OceanCenterPosWorld;
 float _SliceCount;
 float _MeshScaleLerp;
-float _CrestBlackPointFade;
+float _CrestLodAlphaBlackPointFade;
+float _CrestLodAlphaBlackPointWhitePointFade;
 
 float3 _PrimaryLightDirection;
 float3 _PrimaryLightIntensity;

--- a/crest/Assets/Crest/Crest/Shaders/OceanHelpers.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanHelpers.hlsl
@@ -16,7 +16,7 @@ float ComputeLodAlpha(float3 i_worldPos, float i_meshScaleAlpha)
 	// lod alpha is remapped to ensure patches weld together properly. patches can vary significantly in shape (with
 	// strips added and removed), and this variance depends on the base density of the mesh, as this defines the strip width.
 	// using .15 as black and .85 as white should work for base mesh density as low as 16.
-	const float BLACK_POINT = 0.15, WHITE_POINT = 0.85;
+	const float BLACK_POINT = _CrestBlackPointFade, WHITE_POINT = 1 - _CrestBlackPointFade;
 	lodAlpha = max((lodAlpha - BLACK_POINT) / (WHITE_POINT - BLACK_POINT), 0.);
 
 	// blend out lod0 when viewpoint gains altitude

--- a/crest/Assets/Crest/Crest/Shaders/OceanHelpers.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanHelpers.hlsl
@@ -13,11 +13,10 @@ float ComputeLodAlpha(float3 i_worldPos, float i_meshScaleAlpha)
 	// interpolation factor to next lod (lower density / higher sampling period)
 	float lodAlpha = taxicab_norm / _LD_Pos_Scale[_LD_SliceIndex].z - 1.0;
 
-	// lod alpha is remapped to ensure patches weld together properly. patches can vary significantly in shape (with
-	// strips added and removed), and this variance depends on the base density of the mesh, as this defines the strip width.
-	// using .15 as black and .85 as white should work for base mesh density as low as 16.
-	const float BLACK_POINT = _CrestBlackPointFade, WHITE_POINT = 1 - _CrestBlackPointFade;
-	lodAlpha = max((lodAlpha - BLACK_POINT) / (WHITE_POINT - BLACK_POINT), 0.);
+	// LOD alpha is remapped to ensure patches weld together properly. Patches can vary significantly in shape (with
+	// strips added and removed), and this variance depends on the base vertex density of the mesh, as this defines the 
+	// strip width.
+	lodAlpha = max((lodAlpha - _CrestLodAlphaBlackPointFade) / _CrestLodAlphaBlackPointWhitePointFade, 0.);
 
 	// blend out lod0 when viewpoint gains altitude
 	lodAlpha = min(lodAlpha + i_meshScaleAlpha, 1.);

--- a/crest/Assets/Crest/Crest/Shaders/OceanVertHelpers.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanVertHelpers.hlsl
@@ -16,11 +16,10 @@ float ComputeLodAlpha(float3 i_worldPos, float i_meshScaleAlpha, in const float3
 	// TODO - pass this in, and then make a node to provide it automatically
 	float lodAlpha = taxicab_norm / i_oceanPosScale0.z - 1.0;
 
-	// lod alpha is remapped to ensure patches weld together properly. patches can vary significantly in shape (with
-	// strips added and removed), and this variance depends on the base density of the mesh, as this defines the strip width.
-	// using .15 as black and .85 as white should work for base mesh density as low as 16.
-	const float BLACK_POINT = _CrestBlackPointFade, WHITE_POINT = 1 - _CrestBlackPointFade;
-	lodAlpha = max((lodAlpha - BLACK_POINT) / (WHITE_POINT - BLACK_POINT), 0.);
+	// LOD alpha is remapped to ensure patches weld together properly. Patches can vary significantly in shape (with
+	// strips added and removed), and this variance depends on the base vertex density of the mesh, as this defines the 
+	// strip width.
+	lodAlpha = max((lodAlpha - _CrestLodAlphaBlackPointFade) / _CrestLodAlphaBlackPointWhitePointFade, 0.);
 
 	// blend out lod0 when viewpoint gains altitude
 	lodAlpha = min(lodAlpha + i_meshScaleAlpha, 1.);

--- a/crest/Assets/Crest/Crest/Shaders/OceanVertHelpers.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanVertHelpers.hlsl
@@ -19,7 +19,7 @@ float ComputeLodAlpha(float3 i_worldPos, float i_meshScaleAlpha, in const float3
 	// lod alpha is remapped to ensure patches weld together properly. patches can vary significantly in shape (with
 	// strips added and removed), and this variance depends on the base density of the mesh, as this defines the strip width.
 	// using .15 as black and .85 as white should work for base mesh density as low as 16.
-	const float BLACK_POINT = 0.15, WHITE_POINT = 0.85;
+	const float BLACK_POINT = _CrestBlackPointFade, WHITE_POINT = 1 - _CrestBlackPointFade;
 	lodAlpha = max((lodAlpha - BLACK_POINT) / (WHITE_POINT - BLACK_POINT), 0.);
 
 	// blend out lod0 when viewpoint gains altitude


### PR DESCRIPTION
Computes the LOD black point fade from the mesh density. By computing the value we reduce gaps between tiles for lower mesh densities and reduce popping for higher mesh densities.

First discussed in #456. It helps solve one cause of that problem.

The formula is based on hand crafted values that produced no gaps when ocean
is flat. It works pretty well when displaced too.

The approach to getting these values is to have a range parameter which sets the black point fade value for easy testing. The ocean needs to be flat. Then in play mode, switch to the scene view to show the camera and surrounding ocean tiles. Moving the camera around will expose gaps (even vertically). Change the black point value and repeat until no gaps appear.

It is still not 100% perfect as displacement can still produce gaps which can be noticed underwater if looking out for them (they appear as a few pixels here any there). Flying underwater with the simulation frozen is a good way to reproduce these gaps. I couldn't find a value prevent them all. I got to a point where higher or lower value would produces gaps sadly.

I found that a mesh density below 16 produces too many gaps too often to be useable.

Good values (it was hardcoded as 0.15):
- 008: 0.376
- 012: 0.250
- 016: 0.188
- 024: 0.126
- 032: 0.094
- 064: 0.047
- 128: 0.023
- 160: 0.018

The formula gets it pretty close to these values.