### PR TITLE
Move far plane calculations to the CPU

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterPostProcessUtils.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterPostProcessUtils.cs
@@ -207,6 +207,7 @@ namespace Crest
         {
             // Set up back points of frustum
             NativeArray<Vector3> v_screenXY_viewZ = new NativeArray<Vector3>(4, Allocator.Temp);
+            NativeArray<Vector3> v_world = new NativeArray<Vector3>(4, Allocator.Temp);
             try
             {
 
@@ -216,75 +217,83 @@ namespace Crest
                 v_screenXY_viewZ[3] = new Vector3(1f, 0f, cam.farClipPlane);
 
                 // Project out to world
-                var v_world = new Vector3[4];
-                for (int i = 0; i < 4; i++)
+                for (int i = 0; i < v_world.Length; i++)
                 {
                     v_world[i] = cam.ViewportToWorldPoint(v_screenXY_viewZ[i]);
                 }
 
-                var intersectionsScreen = new Vector2[2];
+                NativeArray<Vector2> intersectionsScreen = new NativeArray<Vector2>(2, Allocator.Temp);
                 // This is only used to disambiguate the normal later. Could be removed if we were more careful with point order/indices below.
-                var intersectionsWorld = new Vector3[2];
-                var resultCount = 0;
-
-                // Iterate over each back point
-                for (int i = 0; i < 4; i++)
+                NativeArray<Vector3> intersectionsWorld = new NativeArray<Vector3>(2, Allocator.Temp);
+                try
                 {
-                    // Get next back point, to obtain line segment between them
-                    var inext = (i + 1) % 4;
+                    var resultCount = 0;
 
-                    // See if one point is above and one point is below sea level - then sign of the two differences
-                    // will be different, and multiplying them will give a negative
-                    if ((v_world[i].y - seaLevel) * (v_world[inext].y - seaLevel) < 0f)
-                    {
-                        // Proportion along line segment where intersection occurs
-                        var prop = (seaLevel - v_world[i].y) / (v_world[inext].y - v_world[i].y);
-                        intersectionsScreen[resultCount] = Vector2.Lerp(v_screenXY_viewZ[i], v_screenXY_viewZ[inext], prop);
-                        intersectionsWorld[resultCount] = Vector3.Lerp(v_world[i], v_world[inext], prop);
-
-                        resultCount++;
-                    }
-                }
-
-                // Two distinct results - far plane intersects water
-                if (resultCount == 2 /*&& (props[1] - props[0]).sqrMagnitude > 0.000001f*/)
-                {
-                    resultPos = intersectionsScreen[0];
-                    var tangent = intersectionsScreen[0] - intersectionsScreen[1];
-                    resultNormal.x = -tangent.y;
-                    resultNormal.y = tangent.x;
-
-                    if (Vector3.Dot(intersectionsWorld[0] - intersectionsWorld[1], cam.transform.right) > 0f)
-                    {
-                        resultNormal = -resultNormal;
-                    }
-                }
-                else
-                {
-                    // 1 or 0 results - far plane either touches ocean plane or is completely above/below
-                    resultNormal = Vector2.up;
+                    // Iterate over each back point
                     for (int i = 0; i < 4; i++)
                     {
-                        if (v_world[i].y < seaLevel)
+                        // Get next back point, to obtain line segment between them
+                        var inext = (i + 1) % 4;
+
+                        // See if one point is above and one point is below sea level - then sign of the two differences
+                        // will be different, and multiplying them will give a negative
+                        if ((v_world[i].y - seaLevel) * (v_world[inext].y - seaLevel) < 0f)
                         {
-                            // Underwater
-                            resultPos = Vector2.zero;
-                            return;
-                        }
-                        else if (v_world[i].y > seaLevel)
-                        {
-                            // Underwater
-                            resultPos = Vector2.up;
-                            return;
+                            // Proportion along line segment where intersection occurs
+                            var prop = (seaLevel - v_world[i].y) / (v_world[inext].y - v_world[i].y);
+                            intersectionsScreen[resultCount] = Vector2.Lerp(v_screenXY_viewZ[i], v_screenXY_viewZ[inext], prop);
+                            intersectionsWorld[resultCount] = Vector3.Lerp(v_world[i], v_world[inext], prop);
+
+                            resultCount++;
                         }
                     }
 
-                    throw new System.Exception("GetHorizonPosNormal: Could not determine if far plane is above or below water.");
+                    // Two distinct results - far plane intersects water
+                    if (resultCount == 2 /*&& (props[1] - props[0]).sqrMagnitude > 0.000001f*/)
+                    {
+                        resultPos = intersectionsScreen[0];
+                        var tangent = intersectionsScreen[0] - intersectionsScreen[1];
+                        resultNormal.x = -tangent.y;
+                        resultNormal.y = tangent.x;
+
+                        if (Vector3.Dot(intersectionsWorld[0] - intersectionsWorld[1], cam.transform.right) > 0f)
+                        {
+                            resultNormal = -resultNormal;
+                        }
+                    }
+                    else
+                    {
+                        // 1 or 0 results - far plane either touches ocean plane or is completely above/below
+                        resultNormal = Vector2.up;
+                        for (int i = 0; i < 4; i++)
+                        {
+                            if (v_world[i].y < seaLevel)
+                            {
+                                // Underwater
+                                resultPos = Vector2.zero;
+                                return;
+                            }
+                            else if (v_world[i].y > seaLevel)
+                            {
+                                // Underwater
+                                resultPos = Vector2.up;
+                                return;
+                            }
+                        }
+
+                        throw new System.Exception("GetHorizonPosNormal: Could not determine if far plane is above or below water.");
+                    }
+                }
+                finally
+                {
+                    intersectionsScreen.Dispose();
+                    intersectionsWorld.Dispose();
                 }
             }
             finally
             {
                 v_screenXY_viewZ.Dispose();
+                v_world.Dispose();
             }
         }
     }

--- a/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterPostProcessUtils.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterPostProcessUtils.cs
@@ -275,6 +275,11 @@ namespace Crest
                         {
                             resultNormal = -resultNormal;
                         }
+
+                        if (camera.transform.up.y <= 0f)
+                        {
+                            resultNormal = -resultNormal;
+                        }
                     }
                     else
                     {

--- a/crest/Assets/Crest/Crest/Shaders/Ocean.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Ocean.shader
@@ -241,6 +241,8 @@ Shader "Crest/Ocean"
 			{
 				// The old unity macros require this name and type.
 				float4 vertex : POSITION;
+
+				UNITY_VERTEX_INPUT_INSTANCE_ID
 			};
 
 			struct Varyings
@@ -256,6 +258,8 @@ Shader "Crest/Ocean"
 				half4 grabPos : TEXCOORD9;
 
 				UNITY_FOG_COORDS(3)
+
+				UNITY_VERTEX_OUTPUT_STEREO
 			};
 
 			#include "OceanConstants.hlsl"
@@ -267,6 +271,10 @@ Shader "Crest/Ocean"
 			Varyings Vert(Attributes v)
 			{
 				Varyings o;
+
+				UNITY_SETUP_INSTANCE_ID(v);
+				UNITY_INITIALIZE_OUTPUT(Varyings, o);
+				UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
 
 				// Move to world space
 				o.worldPos = mul(unity_ObjectToWorld, float4(v.vertex.xyz, 1.0));

--- a/crest/Assets/Crest/Crest/Shaders/OceanConstants.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanConstants.hlsl
@@ -26,4 +26,10 @@
 // Water rendered from below
 #define UNDERWATER_MASK_WATER_SURFACE_BELOW 2.0
 
+#if defined(UNITY_SINGLE_PASS_STEREO) || defined(UNITY_STEREO_INSTANCING_ENABLED) || defined(UNITY_STEREO_MULTIVIEW_ENABLED)
+#define CREST_HANDLE_XR 1
+#else
+#define CREST_HANDLE_XR 0
+#endif
+
 #endif // CREST_CONSTANTS_H

--- a/crest/Assets/Crest/Crest/Shaders/Resources/OceanUnderwaterMask.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/OceanUnderwaterMask.shader
@@ -25,11 +25,15 @@ Shader "Crest/Underwater/Ocean Mask"
 			{
 				// The old unity macros require this name and type.
 				float4 vertex : POSITION;
+
+				UNITY_VERTEX_INPUT_INSTANCE_ID
 			};
 
 			struct Varyings
 			{
 				float4 positionCS : SV_POSITION;
+
+				UNITY_VERTEX_OUTPUT_STEREO
 			};
 
 
@@ -47,6 +51,11 @@ Shader "Crest/Underwater/Ocean Mask"
 			Varyings Vert(Attributes v)
 			{
 				Varyings output;
+
+
+				UNITY_SETUP_INSTANCE_ID(v);
+				UNITY_INITIALIZE_OUTPUT(Varyings, output);
+				UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(output);
 
 				float3 worldPos = mul(unity_ObjectToWorld, float4(v.vertex.xyz, 1.0));
 

--- a/crest/Assets/Crest/Crest/Shaders/Resources/UnderwaterPostProcess.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/UnderwaterPostProcess.shader
@@ -74,8 +74,6 @@ Shader "Crest/Underwater/Post Process"
 			float4 _HorizonPosNormal;
 			float4 _HorizonPosNormalRight;
 
-			#define CREST_HANDLE_XR UNITY_SINGLE_PASS_STEREO || UNITY_STEREO_INSTANCING_ENABLED || UNITY_STEREO_MULTIVIEW_ENABLED
-
 			struct Attributes
 			{
 				float4 positionOS : POSITION;
@@ -168,6 +166,7 @@ Shader "Crest/Underwater/Post Process"
 #endif // !_FULL_SCREEN_EFFECT
 
 				const float2 uvScreenSpace = UnityStereoTransformScreenSpaceTex(input.uv);
+
 				half3 sceneColour = tex2D(_MainTex, uvScreenSpace).rgb;
 
 				float sceneZ01 = tex2D(_CameraDepthTexture, uvScreenSpace).x;


### PR DESCRIPTION
@huwb did the legwork for this one in another branch that was then back-ported to BIRP. The plan here is to ensure that the flickering horizon line no longer appears in the distance by moving the calculations for that to the CPU.

It's less of a problem than it was before, but it's still present. Unfortunatley single-pass rendering doesn't work with this either, even though I believe that I have made the requisite changes to ensure that it should work.

The horizon line can still appear incredibly rarely unfortunately, the next step is going to be trying to move some of the calculations to doubles of possible.