### PR TITLE
Warn on reuse of a SampleHeightHelper multiple times in a frame

### DIFF
--- a/crest/Assets/Crest/Crest-Examples/BoatDev/Scripts/BoatAlignNormal.cs
+++ b/crest/Assets/Crest/Crest-Examples/BoatDev/Scripts/BoatAlignNormal.cs
@@ -86,7 +86,7 @@ public class BoatAlignNormal : FloatingObjectBase
         var collProvider = OceanRenderer.Instance.CollisionProvider;
         var position = transform.position;
 
-        _sampleHeightHelper.Init(transform.position, _boatWidth);
+        _sampleHeightHelper.Init(transform.position, _boatWidth, true);
         var height = OceanRenderer.Instance.SeaLevel;
         var normal = Vector3.up;
         var waterSurfaceVel = Vector3.zero;
@@ -162,7 +162,7 @@ public class BoatAlignNormal : FloatingObjectBase
 
         if (_useBoatLength)
         {
-            _sampleHeightHelperLengthwise.Init(transform.position, _boatLength);
+            _sampleHeightHelperLengthwise.Init(transform.position, _boatLength, true);
             var dummy = 0f;
             if (_sampleHeightHelperLengthwise.Sample(ref dummy, ref normalLongitudinal))
             {

--- a/crest/Assets/Crest/Crest/Scripts/Collision/SamplingHelpers.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Collision/SamplingHelpers.cs
@@ -3,7 +3,7 @@
 namespace Crest
 {
     /// <summary>
-    /// Helper to obtain the ocean surface height at a single location. This is not particularly efficient to sample a single height,
+    /// Helper to obtain the ocean surface height at a single location per frame. This is not particularly efficient to sample a single height,
     /// but is a fairly common case.
     /// </summary>
     public class SampleHeightHelper
@@ -15,16 +15,30 @@ namespace Crest
 
         float _minLength = 0f;
 
+#if UNITY_EDITOR
+        int _lastFrame = -1;
+#endif
+
         /// <summary>
-        /// Call this to prime the sampling
+        /// Call this to prime the sampling. The SampleHeightHelper is good for one query per frame - if it is called multiple times in one frame
+        /// it will throw a warning. Calls from FixedUpdate are an exception to this - pass true as the last argument to disable the warning.
         /// </summary>
         /// <param name="i_queryPos">World space position to sample</param>
         /// <param name="i_minLength">The smallest length scale you are interested in. If you are sampling data for boat physics,
         /// pass in the boats width. Larger objects will ignore small wavelengths.</param>
-        public void Init(Vector3 i_queryPos, float i_minLength)
+        /// <param name="fromFixedUpdate">Pass true if calling from FixedUpdate(). This will omit a warning when there on multipled-FixedUpdate frames.</param>
+        public void Init(Vector3 i_queryPos, float i_minLength = 0f, bool fromFixedUpdate = false)
         {
             _queryPos[0] = i_queryPos;
             _minLength = i_minLength;
+
+#if UNITY_EDITOR
+            if (_lastFrame >= Time.frameCount && !fromFixedUpdate)
+            {
+                Debug.LogWarning("Each SampleHeightHelper object services a single height query per frame. To perform multiple queries, create multiple SampleHeightHelper objects or use the CollProvider.Query() API directly.");
+            }
+            _lastFrame = Time.frameCount;
+#endif
         }
 
         /// <summary>

--- a/crest/Assets/Crest/Crest/Scripts/Collision/SamplingHelpers.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Collision/SamplingHelpers.cs
@@ -33,7 +33,7 @@ namespace Crest
             _minLength = i_minLength;
 
 #if UNITY_EDITOR
-            if (_lastFrame >= Time.frameCount && !fromFixedUpdate)
+            if (!fromFixedUpdate && _lastFrame >= Time.frameCount)
             {
                 Debug.LogWarning("Each SampleHeightHelper object services a single height query per frame. To perform multiple queries, create multiple SampleHeightHelper objects or use the CollProvider.Query() API directly.");
             }

--- a/crest/Assets/Crest/Crest/Scripts/Interaction/SimpleFloatingObject.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Interaction/SimpleFloatingObject.cs
@@ -74,7 +74,7 @@ namespace Crest
             var position = transform.position;
 
             var normal = Vector3.up; var waterSurfaceVel = Vector3.zero;
-            _sampleHeightHelper.Init(transform.position, _objectWidth);
+            _sampleHeightHelper.Init(transform.position, _objectWidth, true);
             _sampleHeightHelper.Sample(ref _displacementToObject, ref normal, ref waterSurfaceVel);
 
             var undispPos = transform.position - _displacementToObject;


### PR DESCRIPTION
This is a big pitfall that is too easy to get wrong - the intuitive
thing is to reuse SampleHeightHelper multiple times, but it will
simply overwrite the query position before the result is sent
to the GPU (if the compute height queries system is used).

This change throws a warning if the position is set multiple times
in a frame.

Unfortunately there is a case where this is valid - FixedUpdate can
be called multiple times per frame. I added an arg to indicate this
which will suppress the warning. Some collision providers will be
happy to receive multiple queries per frame. The compute height
query system will just overwrite the query pos and send off the
final (last) fixedupdate position to the GPU. This is imperfect but
I don't see how this can work better.