### PR TITLE
Fix Material Preview error on Metal: not enough components in fragment shader

### DIFF
--- a/crest/Assets/Crest/Crest-Examples/Whirlpool/Shaders/Resources/FlowWhirlpool.shader
+++ b/crest/Assets/Crest/Crest-Examples/Whirlpool/Shaders/Resources/FlowWhirlpool.shader
@@ -39,7 +39,7 @@ Shader "Crest/Inputs/Flow/Whirlpool"
 				return o;
 			}
 
-			float2 Frag(Varyings input) : SV_Target
+			float4 Frag(Varyings input) : SV_Target
 			{
 				float2 flow = float2(0.0, 0.0);
 
@@ -63,7 +63,7 @@ Shader "Crest/Inputs/Flow/Whirlpool"
 					);
 				}
 
-				return flow;
+				return float4(flow, 0.0, 0.0);
 			}
 
 			ENDCG

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/FlowAddFlowMap.shader
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/FlowAddFlowMap.shader
@@ -50,9 +50,9 @@ Shader "Crest/Inputs/Flow/Add Flow Map"
 				return o;
 			}
 
-			float2 Frag(Varyings input) : SV_Target
+			float4 Frag(Varyings input) : SV_Target
 			{
-				return (tex2D(_FlowMap, input.uv).xy - 0.5) * _Strength;
+				return float4((tex2D(_FlowMap, input.uv).xy - 0.5) * _Strength, 0.0, 0.0);
 			}
 
 			ENDCG

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/FlowFixedDirection.shader
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/FlowFixedDirection.shader
@@ -44,9 +44,9 @@ Shader "Crest/Inputs/Flow/Fixed Direction"
 				return o;
 			}
 
-			float2 Frag(Varyings input) : SV_Target
+			float4 Frag(Varyings input) : SV_Target
 			{
-				return input.vel;
+				return float4(input.vel, 0.0, 0.0);
 			}
 			ENDCG
 		}

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/OceanDepths.shader
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/OceanDepths.shader
@@ -42,9 +42,9 @@ Shader "Crest/Inputs/Depth/Ocean Depth From Geometry"
 				return o;
 			}
 
-			float Frag(Varyings input) : SV_Target
+			float4 Frag(Varyings input) : SV_Target
 			{
-				return input.depth;
+				return float4(input.depth, 0.0, 0.0, 0.0);
 			}
 			ENDCG
 		}


### PR DESCRIPTION
Fixes #488 

The error produced from this is because of the Material Preview in the Editor. This error does not stop the shaders from working correctly.

I've submitted a bug report to Unity. We could ignore this or revert it once fixed.