### PR TITLE
Flush query guids every frame

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Collision/QueryBase.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Collision/QueryBase.cs
@@ -92,13 +92,8 @@ namespace Crest
                 // The last index should never increment and land on the first index - it should only happen the other way around.
                 Debug.Assert(_segmentAcquire != _segmentRelease, "Segment registrar scratch exhausted.");
 
-                _segments[_segmentAcquire]._numQueries = _segments[lastIndex]._numQueries;
-
+                _segments[_segmentAcquire]._numQueries = 0;
                 _segments[_segmentAcquire]._segments.Clear();
-                foreach (var segment in _segments[lastIndex]._segments)
-                {
-                    _segments[_segmentAcquire]._segments.Add(segment.Key, segment.Value);
-                }
             }
 
             public void ReleaseLast()
@@ -549,5 +544,7 @@ namespace Crest
         {
             return (queryStatus & (int)QueryStatus.RetrieveFailed) == 0;
         }
+
+        public int ResultGuidCount => _resultSegments != null ? _resultSegments.Count : 0;
     }
 }

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/OceanDebugGUI.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/OceanDebugGUI.cs
@@ -116,6 +116,13 @@ namespace Crest
                         GUI.Label(new Rect(x, y, w, h), string.Format("Sim steps: {0:0.00000} x {1}", dt, steps)); y += h;
                     }
 
+                    if (OceanRenderer.Instance.CollisionProvider != null && OceanRenderer.Instance.CollisionProvider is QueryBase)
+                    {
+                        var querySystem = OceanRenderer.Instance.CollisionProvider as QueryBase;
+                        Debug.Assert(querySystem != null);
+                        GUI.Label(new Rect(x, y, w, h), string.Format("Query result GUIDs: {0}", querySystem.ResultGuidCount)); y += h;
+                    }
+
 #if UNITY_EDITOR
                     if (GUI.Button(new Rect(x, y, w, h), "Select Ocean Mat"))
                     {


### PR DESCRIPTION
**Status:** Ready to merge

In the compute height query system, queries are made with an identifying GUID. This registers the query and the GUID is used to track it across frames.

Right now we are never flushing GUIDs which is bad. The code is manually populating the registrar with last frame's guids every time its acquired. The number of query GUIDs grows montonically, eventually throwing the "max guids" error.

I believe queries are uploaded and processed if they are present, even if they're no longer being actually used.

This code avoids repopulating newly acquired query registrars with previous frames' GUIDs. This seems to work and it seems like a better solution.

I also added a line to the gui overlay to report how many guids there are in each frame's results.