### PR TITLE
Help Box Validation Messages

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Helpers/AssignLayer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/AssignLayer.cs
@@ -1,8 +1,12 @@
 ﻿using UnityEngine;
 
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
+
 namespace Crest
 {
-    public class AssignLayer : MonoBehaviour, IValidated
+    public partial class AssignLayer : MonoBehaviour
     {
         [SerializeField]
         string _layerName = "";
@@ -11,29 +15,49 @@ namespace Crest
         {
             enabled = false;
 
-            if (!Validate(OceanRenderer.Instance))
+#if UNITY_EDITOR
+            if (!Validate(OceanRenderer.Instance, ValidatedHelper.DebugLog))
             {
                 return;
             }
+#endif
 
             gameObject.layer = LayerMask.NameToLayer(_layerName);
         }
+    }
 
-        public bool Validate(OceanRenderer ocean)
+#if UNITY_EDITOR
+    public partial class AssignLayer : IValidated
+    {
+        public bool Validate(OceanRenderer ocean, ValidatedHelper.ShowMessage showMessage)
         {
             if (string.IsNullOrEmpty(_layerName))
             {
-                Debug.LogError("Validation: Layer name required by AssignLayer script. Click this error to see the script in question.", this);
+                showMessage
+                (
+                    "Layer name required by AssignLayer script. Click this error to see the script in question.",
+                    MessageType.Error, this
+                );
+
                 return false;
             }
-            
+
             if (LayerMask.NameToLayer(_layerName) < 0)
             {
-                Debug.LogError("Validation: Layer " + _layerName + " does not exist in the project, please add it.", this);
+                showMessage
+                (
+                    $"Layer {_layerName} does not exist in the project, please add it.",
+                    MessageType.Error, this
+                );
+
                 return false;
             }
 
             return true;
         }
     }
+
+    [CustomEditor(typeof(AssignLayer)), CanEditMultipleObjects]
+    class AssignLayerEditor : ValidatedEditor { }
+#endif
 }

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/AssignLayer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/AssignLayer.cs
@@ -36,7 +36,7 @@ namespace Crest
                 showMessage
                 (
                     "Layer name required by AssignLayer script. Click this error to see the script in question.",
-                    MessageType.Error, this
+                    ValidatedHelper.MessageType.Error, this
                 );
 
                 return false;
@@ -47,7 +47,7 @@ namespace Crest
                 showMessage
                 (
                     $"Layer {_layerName} does not exist in the project, please add it.",
-                    MessageType.Error, this
+                    ValidatedHelper.MessageType.Error, this
                 );
 
                 return false;

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/UnderwaterEffect.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/UnderwaterEffect.cs
@@ -214,7 +214,7 @@ namespace Crest
                 showMessage
                 (
                     "Underwater effects expect to be parented to a camera.",
-                    MessageType.Error, this
+                    ValidatedHelper.MessageType.Error, this
                 );
 
                 isValid = false;
@@ -228,7 +228,7 @@ namespace Crest
                 showMessage
                 (
                     $"Shader assigned to underwater effect expected to be of type <i>{shaderPrefix}</i>.",
-                    MessageType.Error, this
+                    ValidatedHelper.MessageType.Error, this
                 );
 
                 isValid = false;
@@ -248,7 +248,7 @@ namespace Crest
                             $"Keyword {keyword} was enabled on the underwater material <i>{renderer.sharedMaterial.name}</i>"
                             + $"but not on the ocean material <i>{ocean.OceanMaterial.name}</i>, underwater appearance "
                             + "may not match ocean surface in standalone builds.",
-                            MessageType.Warning, this
+                            ValidatedHelper.MessageType.Warning, this
                         );
                     }
                 }
@@ -267,7 +267,7 @@ namespace Crest
                             $"Keyword {keyword} is enabled on the ocean material <i>{ocean.OceanMaterial.name}</i> but "
                             + $"not on the underwater material <i>{renderer.sharedMaterial.name}</i>, underwater "
                             + "appearance may not match ocean surface in standalone builds.",
-                            MessageType.Warning, this
+                            ValidatedHelper.MessageType.Warning, this
                         );
                     }
                 }

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/UnderwaterEffect.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/UnderwaterEffect.cs
@@ -4,13 +4,18 @@
 
 using UnityEngine;
 
+#if UNITY_EDITOR
+using UnityEditor;
+using System.Collections.Generic;
+#endif
+
 namespace Crest
 {
     /// <summary>
     /// Handles effects that need to track the water surface. Feeds in wave data and disables rendering when
     /// not close to water.
     /// </summary>
-    public class UnderwaterEffect : MonoBehaviour
+    public partial class UnderwaterEffect : MonoBehaviour
     {
         [Header("Copy params from Ocean material")]
 
@@ -46,14 +51,16 @@ namespace Crest
             _rend.sortingOrder = _overrideSortingOrder ? _overridenSortingOrder : -LodDataMgr.MAX_LOD_COUNT - 1;
             GetComponent<MeshFilter>().mesh = Mesh2DGrid(0, 2, -0.5f, -0.5f, 1f, 1f, GEOM_HORIZ_DIVISIONS, 1);
 
-            // hack - push forward so the geometry wont be frustum culled. there might be better ways to draw
-            // this stuff.
-            if (transform.parent.GetComponent<Camera>() == null)
+#if UNITY_EDITOR
+            if (!Validate(OceanRenderer.Instance, ValidatedHelper.DebugLog))
             {
-                Debug.LogError("Underwater effects expect to be parented to a camera.", this);
                 enabled = false;
                 return;
             }
+#endif
+
+            // hack - push forward so the geometry wont be frustum culled. there might be better ways to draw
+            // this stuff.
             transform.localPosition = Vector3.forward;
 
             ConfigureMaterial();
@@ -62,17 +69,6 @@ namespace Crest
         void ConfigureMaterial()
         {
             if (OceanRenderer.Instance == null) return;
-
-            var keywords = _rend.material.shaderKeywords;
-            foreach (var keyword in keywords)
-            {
-                if (keyword == "_COMPILESHADERWITHDEBUGINFO_ON") continue;
-
-                if (!OceanRenderer.Instance.OceanMaterial.IsKeywordEnabled(keyword))
-                {
-                    Debug.LogWarning("Keyword " + keyword + " was enabled on the ocean material but not on the underwater material " + _rend.sharedMaterial.name + ", underwater appearance may not match ocean surface in standalone builds.", this);
-                }
-            }
 
             if (_copyParamsOnStartup)
             {
@@ -194,4 +190,94 @@ namespace Crest
             return mesh;
         }
     }
+
+#if UNITY_EDITOR
+    public partial class UnderwaterEffect : IValidated
+    {
+        // List of keywords shared with the ocean shader. Because finding this out dynamically is more difficult.
+        static readonly List<string> sharedKeywords = new List<string>()
+        {
+            "_SUBSURFACESCATTERING_ON",
+            "_SUBSURFACESHALLOWCOLOUR_ON",
+            "_TRANSPARENCY_ON",
+            "_CAUSTICS_ON",
+            "_SHADOWS_ON",
+        };
+
+        public bool Validate(OceanRenderer ocean, ValidatedHelper.ShowMessage showMessage)
+        {
+            var isValid = true;
+
+            // Check that underwater effect is parented to a camera.
+            if (transform.parent.GetComponent<Camera>() == null)
+            {
+                showMessage
+                (
+                    "Underwater effects expect to be parented to a camera.",
+                    MessageType.Error, this
+                );
+
+                isValid = false;
+            }
+
+            // Check that underwater effect has correct material assigned.
+            var shaderPrefix = "Crest/Underwater";
+            var renderer = GetComponent<Renderer>();
+            if (renderer.sharedMaterial && renderer.sharedMaterial.shader && !renderer.sharedMaterial.shader.name.StartsWith(shaderPrefix))
+            {
+                showMessage
+                (
+                    $"Shader assigned to underwater effect expected to be of type <i>{shaderPrefix}</i>.",
+                    MessageType.Error, this
+                );
+
+                isValid = false;
+            }
+            else if (renderer.sharedMaterial.shader.name == "Crest/Underwater Curtain")
+            {
+                // Check that enabled underwater material keywords are enabled on the ocean material.
+                var keywords = renderer.sharedMaterial.shaderKeywords;
+                foreach (var keyword in keywords)
+                {
+                    if (keyword == "_COMPILESHADERWITHDEBUGINFO_ON") continue;
+
+                    if (!ocean.OceanMaterial.IsKeywordEnabled(keyword))
+                    {
+                        showMessage
+                        (
+                            $"Keyword {keyword} was enabled on the underwater material <i>{renderer.sharedMaterial.name}</i>"
+                            + $"but not on the ocean material <i>{ocean.OceanMaterial.name}</i>, underwater appearance "
+                            + "may not match ocean surface in standalone builds.",
+                            MessageType.Warning, this
+                        );
+                    }
+                }
+
+                // Check that enabled ocean material keywords are enabled on the underwater material.
+                keywords = ocean.OceanMaterial.shaderKeywords;
+                foreach (var keyword in keywords)
+                {
+                    if (keyword == "_COMPILESHADERWITHDEBUGINFO_ON") continue;
+                    if (!sharedKeywords.Contains(keyword)) continue;
+
+                    if (!renderer.sharedMaterial.IsKeywordEnabled(keyword))
+                    {
+                        showMessage
+                        (
+                            $"Keyword {keyword} is enabled on the ocean material <i>{ocean.OceanMaterial.name}</i> but "
+                            + $"not on the underwater material <i>{renderer.sharedMaterial.name}</i>, underwater "
+                            + "appearance may not match ocean surface in standalone builds.",
+                            MessageType.Warning, this
+                        );
+                    }
+                }
+            }
+
+            return isValid;
+        }
+    }
+
+    [CustomEditor(typeof(UnderwaterEffect)), CanEditMultipleObjects]
+    class UnderwaterEffectEditor : ValidatedEditor { }
+#endif
 }

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/UnderwaterEffect.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/UnderwaterEffect.cs
@@ -233,7 +233,7 @@ namespace Crest
 
                 isValid = false;
             }
-            else if (renderer.sharedMaterial.shader.name == "Crest/Underwater Curtain")
+            else if (renderer.sharedMaterial.shader.name == "Crest/Underwater Curtain" && ocean.OceanMaterial)
             {
                 // Check that enabled underwater material keywords are enabled on the ocean material.
                 var keywords = renderer.sharedMaterial.shaderKeywords;

--- a/crest/Assets/Crest/Crest/Scripts/Interaction/FloatingObjectBase.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Interaction/FloatingObjectBase.cs
@@ -35,7 +35,7 @@ namespace Crest
                 showMessage
                 (
                     "<i>Collision Source</i> in <i>Animated Waves Settings</i> is set to <i>None</i>. The floating objects in the scene will use a flat horizontal plane.",
-                    MessageType.Warning, ocean
+                    ValidatedHelper.MessageType.Warning, ocean
                 );
 
                 isValid = false;
@@ -47,7 +47,7 @@ namespace Crest
                 showMessage
                 (
                     $"Expected to have one rigidbody on floating object, currently has {rbs.Length} object(s).",
-                    MessageType.Error, this
+                    ValidatedHelper.MessageType.Error, this
                 );
             }
 

--- a/crest/Assets/Crest/Crest/Scripts/Interaction/FloatingObjectBase.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Interaction/FloatingObjectBase.cs
@@ -2,12 +2,16 @@
 
 using UnityEngine;
 
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
+
 namespace Crest
 {
     /// <summary>
     /// Base class for objects that float on water.
     /// </summary>
-    public abstract class FloatingObjectBase : MonoBehaviour
+    public abstract partial class FloatingObjectBase : MonoBehaviour
     {
         public abstract float ObjectWidth { get; }
         public abstract bool InWater { get; }
@@ -18,4 +22,40 @@ namespace Crest
         /// </summary>
         public abstract Vector3 CalculateDisplacementToObject();
     }
+
+#if UNITY_EDITOR
+    public abstract partial class FloatingObjectBase : IValidated
+    {
+        public bool Validate(OceanRenderer ocean, ValidatedHelper.ShowMessage showMessage)
+        {
+            var isValid = true;
+
+            if (ocean._simSettingsAnimatedWaves != null && ocean._simSettingsAnimatedWaves.CollisionSource == SimSettingsAnimatedWaves.CollisionSources.None)
+            {
+                showMessage
+                (
+                    "<i>Collision Source</i> in <i>Animated Waves Settings</i> is set to <i>None</i>. The floating objects in the scene will use a flat horizontal plane.",
+                    MessageType.Warning, ocean
+                );
+
+                isValid = false;
+            }
+
+            var rbs = GetComponentsInChildren<Rigidbody>();
+            if (rbs.Length != 1)
+            {
+                showMessage
+                (
+                    $"Expected to have one rigidbody on floating object, currently has {rbs.Length} object(s).",
+                    MessageType.Error, this
+                );
+            }
+
+            return isValid;
+        }
+    }
+
+    [CustomEditor(typeof(FloatingObjectBase), true), CanEditMultipleObjects]
+    class FloatingObjectBaseEditor : ValidatedEditor { }
+#endif
 }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
@@ -447,14 +447,30 @@ namespace Crest
                 isValid = false;
             }
 
-            var rend = GetComponentInChildren<Renderer>();
-            if (rend != null)
+            // Check that there are no renderers in descendants.
+            var renderers = GetComponentsInChildren<Renderer>();
+            if (renderers.Length > (Application.isPlaying ? 1 : 0))
             {
-                showMessage
-                (
-                    "It is not expected that a depth cache object has a Renderer component in its hierarchy. The cache is typically attached to an empty GameObject. Please refer to the example content.",
-                    ValidatedHelper.MessageType.Warning, rend
-                );
+                Renderer quadRenderer = null;
+                if (Application.isPlaying && _drawCacheQuad)
+                {
+                    quadRenderer = _drawCacheQuad.GetComponent<Renderer>();
+                }
+
+                foreach (var renderer in renderers)
+                {
+                    if (ReferenceEquals(renderer, quadRenderer)) continue;
+
+                    showMessage
+                    (
+                        "It is not expected that a depth cache object has a Renderer component in its hierarchy." +
+                        "The cache is typically attached to an empty GameObject. Please refer to the example content.",
+                        ValidatedHelper.MessageType.Warning, renderer
+                    );
+
+                    // Reporting only one renderer at a time will be enough to avoid overwhelming user and UI.
+                    break;
+                }
 
                 isValid = false;
             }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
@@ -353,7 +353,7 @@ namespace Crest
                     showMessage
                     (
                         "Depth cache type is 'Saved Cache' but no saved cache data is provided.",
-                        MessageType.Error, this
+                        ValidatedHelper.MessageType.Error, this
                     );
 
                     isValid = false;
@@ -367,7 +367,7 @@ namespace Crest
                     showMessage
                     (
                         "No layers specified for rendering into depth cache, and no geometries manually provided.",
-                        MessageType.Error, this
+                        ValidatedHelper.MessageType.Error, this
                     );
 
                     isValid = false;
@@ -378,7 +378,7 @@ namespace Crest
                     showMessage
                     (
                         $"<i>Force Always Update Debug</i> option is enabled on depth cache <i>{gameObject.name}</i>, which means it will render every frame instead of running from the cache.",
-                        MessageType.Warning, this
+                        ValidatedHelper.MessageType.Warning, this
                     );
 
                     isValid = false;
@@ -392,7 +392,7 @@ namespace Crest
                         showMessage
                         (
                             $"Invalid layer specified for objects/geometry providing the ocean depth: <i>{layerName}</i>. Does this layer need to be added to the project <i>Edit/Project Settings/Tags and Layers</i>?",
-                            MessageType.Error, this
+                            ValidatedHelper.MessageType.Error, this
                         );
 
                         isValid = false;
@@ -404,7 +404,7 @@ namespace Crest
                     showMessage
                     (
                         $"Cache resolution {_resolution} is very low. Is this intentional?",
-                        MessageType.Error, this
+                        ValidatedHelper.MessageType.Error, this
                     );
 
                     isValid = false;
@@ -419,7 +419,7 @@ namespace Crest
                 showMessage
                 (
                     "Ocean depth cache transform scale is small and will capture a small area of the world. The scale sets the size of the area that will be cached, and this cache is set to render a very small area.",
-                    MessageType.Warning, this
+                    ValidatedHelper.MessageType.Warning, this
                 );
 
                 isValid = false;
@@ -430,7 +430,7 @@ namespace Crest
                 showMessage
                 (
                     $"Ocean depth cache scale Y should be set to 1.0. Its current scale in the hierarchy is {transform.lossyScale.y}.",
-                    MessageType.Error, this
+                    ValidatedHelper.MessageType.Error, this
                 );
 
                 isValid = false;
@@ -441,7 +441,7 @@ namespace Crest
                 showMessage
                 (
                     "It is recommended that the cache is placed at the same height (y component of position) as the ocean, i.e. at the sea level. If the cache is created before the ocean is present, the cache height will inform the sea level.",
-                    MessageType.Warning, this
+                    ValidatedHelper.MessageType.Warning, this
                 );
 
                 isValid = false;
@@ -453,7 +453,7 @@ namespace Crest
                 showMessage
                 (
                     "It is not expected that a depth cache object has a Renderer component in its hierarchy. The cache is typically attached to an empty GameObject. Please refer to the example content.",
-                    MessageType.Warning, rend
+                    ValidatedHelper.MessageType.Warning, rend
                 );
 
                 isValid = false;

--- a/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
@@ -480,11 +480,7 @@ namespace Crest
             var renderers = GetComponentsInChildren<Renderer>();
             if (renderers.Length > (Application.isPlaying ? 1 : 0))
             {
-                Renderer quadRenderer = null;
-                if (Application.isPlaying && _drawCacheQuad)
-                {
-                    quadRenderer = _drawCacheQuad.GetComponent<Renderer>();
-                }
+                Renderer quadRenderer = _drawCacheQuad ? _drawCacheQuad.GetComponent<Renderer>() : null;
 
                 foreach (var renderer in renderers)
                 {

--- a/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
@@ -14,7 +14,7 @@ namespace Crest
     /// Renders terrain height / ocean depth once into a render target to cache this off and avoid rendering it every frame.
     /// This should be used for static geometry, dynamic objects should be tagged with the Render Ocean Depth component.
     /// </summary>
-    public class OceanDepthCache : MonoBehaviour
+    public partial class OceanDepthCache : MonoBehaviour
     {
         public enum OceanDepthCacheType
         {
@@ -81,7 +81,7 @@ namespace Crest
 #if UNITY_EDITOR
             if (_runValidationOnStart)
             {
-                Validate(OceanRenderer.Instance);
+                Validate(OceanRenderer.Instance, ValidatedHelper.DebugLog);
             }
 #endif
 
@@ -249,80 +249,19 @@ namespace Crest
                 Gizmos.DrawCube(Vector3.up * _cameraMaxTerrainHeight / transform.lossyScale.y, new Vector3(1f, 0f, 1f));
             }
         }
-
-        public void Validate(OceanRenderer ocean)
-        {
-            if (_type == OceanDepthCacheType.Baked)
-            {
-                if (_savedCache == null)
-                {
-                    Debug.LogError("Validation: Depth cache type is 'Saved Cache' but no saved cache data is provided. Click this message to highlight the cache in question.", this);
-                }
-            }
-            else
-            {
-                if ((_geometryToRenderIntoCache == null || _geometryToRenderIntoCache.Length == 0)
-                    && (_layerNames == null || _layerNames.Length == 0))
-                {
-                    Debug.LogError("Validation: No layers specified for rendering into depth cache, and no geometries manually provided. Click this message to highlight the cache in question.", this);
-                }
-
-                if (_forceAlwaysUpdateDebug)
-                {
-                    Debug.LogWarning("Validation: Force Always Update Debug option is enabled on depth cache " + gameObject.name + ", which means it will render every frame instead of running from the cache. Click this message to highlight the cache in question.", this);
-                }
-
-                foreach (var layerName in _layerNames)
-                {
-                    var layer = LayerMask.NameToLayer(layerName);
-                    if (layer == -1)
-                    {
-                        Debug.LogError("Invalid layer specified for objects/geometry providing the ocean depth: \"" + layerName +
-                            "\". Does this layer need to be added to the project (Edit/Project Settings/Tags and Layers)? Click this message to highlight the cache in question.", this);
-                    }
-                }
-
-                if (_resolution < 4)
-                {
-                    Debug.LogError("Cache resolution " + _resolution + " is very low. Is this intentional? Click this message to highlight the cache in question.", this);
-                }
-
-                // We used to test if nothing is present that would render into the cache, but these could probably come from other scenes, and AssignLayer means
-                // objects can be tagged up at run-time.
-            }
-
-            if (transform.lossyScale.magnitude < 5f)
-            {
-                Debug.LogWarning("Validation: Ocean depth cache transform scale is small and will capture a small area of the world. The scale sets the size of the area that will be cached, and this cache is set to render a very small area. Click this message to highlight the cache in question.", this);
-            }
-
-            if (transform.lossyScale.y < 0.001f || transform.localScale.y < 0.01f)
-            {
-                Debug.LogError($"Validation: Ocean depth cache scale Y should be set to 1.0. Its current scale in the hierarchy is {transform.lossyScale.y}.", this);
-            }
-
-            if (Mathf.Abs(transform.position.y - ocean.transform.position.y) > 0.00001f)
-            {
-                Debug.LogWarning("Validation: It is recommended that the cache is placed at the same height (y component of position) as the ocean, i.e. at the sea level. If the cache is created before the ocean is present, the cache height will inform the sea level. Click this message to highlight the cache in question.", this);
-            }
-
-            var rend = GetComponentInChildren<Renderer>();
-            if (rend != null)
-            {
-                Debug.LogWarning("Validation: It is not expected that a depth cache object has a Renderer component in its hierarchy. The cache is typically attached to an empty GameObject. Click this message to highlight the Renderer. Please refer to the example content.", rend);
-            }
-        }
 #endif
     }
 
 #if UNITY_EDITOR
     [CustomEditor(typeof(OceanDepthCache))]
-    public class OceanDepthCacheEditor : Editor
+    public class OceanDepthCacheEditor : ValidatedEditor
     {
         readonly string[] _propertiesToExclude = new string[] { "m_Script", "_type", "_refreshMode", "_savedCache", "_geometryToRenderIntoCache", "_layerNames", "_resolution", "_cameraMaxTerrainHeight", "_forceAlwaysUpdateDebug", "_checkTerrainDrawInstancedOption" };
 
         public override void OnInspectorGUI()
         {
+            ShowValidationMessages();
+
             // We won't just use default inspector because we want to show some of the params conditionally based on cache type
 
             // First show standard 'Script' field
@@ -398,6 +337,129 @@ namespace Crest
 
                 Debug.Log("Cache saved to " + path, AssetDatabase.LoadAssetAtPath<UnityEngine.Object>(path));
             }
+        }
+    }
+
+    public partial class OceanDepthCache : IValidated
+    {
+        public bool Validate(OceanRenderer ocean, ValidatedHelper.ShowMessage showMessage)
+        {
+            var isValid = true;
+
+            if (_type == OceanDepthCacheType.Baked)
+            {
+                if (_savedCache == null)
+                {
+                    showMessage
+                    (
+                        "Depth cache type is 'Saved Cache' but no saved cache data is provided.",
+                        MessageType.Error, this
+                    );
+
+                    isValid = false;
+                }
+            }
+            else
+            {
+                if ((_geometryToRenderIntoCache == null || _geometryToRenderIntoCache.Length == 0)
+                    && (_layerNames == null || _layerNames.Length == 0))
+                {
+                    showMessage
+                    (
+                        "No layers specified for rendering into depth cache, and no geometries manually provided.",
+                        MessageType.Error, this
+                    );
+
+                    isValid = false;
+                }
+
+                if (_forceAlwaysUpdateDebug)
+                {
+                    showMessage
+                    (
+                        $"<i>Force Always Update Debug</i> option is enabled on depth cache <i>{gameObject.name}</i>, which means it will render every frame instead of running from the cache.",
+                        MessageType.Warning, this
+                    );
+
+                    isValid = false;
+                }
+
+                foreach (var layerName in _layerNames)
+                {
+                    var layer = LayerMask.NameToLayer(layerName);
+                    if (layer == -1)
+                    {
+                        showMessage
+                        (
+                            $"Invalid layer specified for objects/geometry providing the ocean depth: <i>{layerName}</i>. Does this layer need to be added to the project <i>Edit/Project Settings/Tags and Layers</i>?",
+                            MessageType.Error, this
+                        );
+
+                        isValid = false;
+                    }
+                }
+
+                if (_resolution < 4)
+                {
+                    showMessage
+                    (
+                        $"Cache resolution {_resolution} is very low. Is this intentional?",
+                        MessageType.Error, this
+                    );
+
+                    isValid = false;
+                }
+
+                // We used to test if nothing is present that would render into the cache, but these could probably come from other scenes, and AssignLayer means
+                // objects can be tagged up at run-time.
+            }
+
+            if (transform.lossyScale.magnitude < 5f)
+            {
+                showMessage
+                (
+                    "Ocean depth cache transform scale is small and will capture a small area of the world. The scale sets the size of the area that will be cached, and this cache is set to render a very small area.",
+                    MessageType.Warning, this
+                );
+
+                isValid = false;
+            }
+
+            if (transform.lossyScale.y < 0.001f || transform.localScale.y < 0.01f)
+            {
+                showMessage
+                (
+                    $"Ocean depth cache scale Y should be set to 1.0. Its current scale in the hierarchy is {transform.lossyScale.y}.",
+                    MessageType.Error, this
+                );
+
+                isValid = false;
+            }
+
+            if (Mathf.Abs(transform.position.y - ocean.transform.position.y) > 0.00001f)
+            {
+                showMessage
+                (
+                    "It is recommended that the cache is placed at the same height (y component of position) as the ocean, i.e. at the sea level. If the cache is created before the ocean is present, the cache height will inform the sea level.",
+                    MessageType.Warning, this
+                );
+
+                isValid = false;
+            }
+
+            var rend = GetComponentInChildren<Renderer>();
+            if (rend != null)
+            {
+                showMessage
+                (
+                    "It is not expected that a depth cache object has a Renderer component in its hierarchy. The cache is typically attached to an empty GameObject. Please refer to the example content.",
+                    MessageType.Warning, rend
+                );
+
+                isValid = false;
+            }
+
+            return isValid;
         }
     }
 #endif

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
@@ -232,7 +232,7 @@ namespace Crest
                 return false;
             }
 
-            if (renderer.sharedMaterial && renderer.sharedMaterial.shader && !renderer.sharedMaterial.shader.name.StartsWith(ShaderPrefix))
+            if (!renderer.sharedMaterial || renderer.sharedMaterial.shader && !renderer.sharedMaterial.shader.name.StartsWith(ShaderPrefix))
             {
                 showMessage
                 (

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
@@ -41,8 +41,10 @@ namespace Crest
     /// </summary>
     public abstract partial class RegisterLodDataInputBase : MonoBehaviour, ILodDataInput
     {
+#if UNITY_EDITOR
         [SerializeField, Tooltip("Check that the shader applied to this object matches the input type (so e.g. an Animated Waves input object has an Animated Waves input shader.")]
         bool _checkShaderName = true;
+#endif
 
         public abstract float Wavelength { get; }
 

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
@@ -172,7 +172,7 @@ namespace Crest
 
         bool CheckShaderName(Renderer renderer, ValidatedHelper.ShowMessage showMessage)
         {
-            if (!_renderer)
+            if (!renderer)
             {
                 showMessage
                 (

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
@@ -7,6 +7,10 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Rendering;
 
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
+
 namespace Crest
 {
     using OceanInput = CrestSortedList<int, ILodDataInput>;
@@ -35,7 +39,7 @@ namespace Crest
     /// <summary>
     /// Base class for scripts that register input to the various LOD data types.
     /// </summary>
-    public abstract class RegisterLodDataInputBase : MonoBehaviour, ILodDataInput, IValidated
+    public abstract partial class RegisterLodDataInputBase : MonoBehaviour, ILodDataInput
     {
         [SerializeField, Tooltip("Check that the shader applied to this object matches the input type (so e.g. an Animated Waves input object has an Animated Waves input shader.")]
         bool _checkShaderName = true;
@@ -71,24 +75,16 @@ namespace Crest
 
             if (_renderer)
             {
+#if UNITY_EDITOR
                 if (_checkShaderName)
                 {
-                    CheckShaderName(_renderer);
+                    CheckShaderName(_renderer, ValidatedHelper.DebugLog);
                 }
+#endif
 
                 _materials[0] = _renderer.sharedMaterial;
                 _materials[1] = new Material(_renderer.sharedMaterial);
             }
-        }
-
-        bool CheckShaderName(Renderer renderer)
-        {
-            if (renderer.sharedMaterial && renderer.sharedMaterial.shader && !renderer.sharedMaterial.shader.name.StartsWith(ShaderPrefix))
-            {
-                Debug.LogError($"Shader assigned to ocean input expected to be of type <i>{ShaderPrefix}</i>. Click this error to highlight the input.", this);
-                return false;
-            }
-            return true;
         }
 
         public void Draw(CommandBuffer buf, float weight, int isTransition, int lodIdx)
@@ -113,11 +109,6 @@ namespace Crest
             // Init here from 2019.3 onwards
             s_registrar.Clear();
             sp_Weight = Shader.PropertyToID("_Weight");
-        }
-
-        public bool Validate(OceanRenderer ocean)
-        {
-            return CheckShaderName(GetComponent<Renderer>());
         }
     }
 
@@ -168,4 +159,33 @@ namespace Crest
             }
         }
     }
+
+#if UNITY_EDITOR
+    public abstract partial class RegisterLodDataInputBase : IValidated
+    {
+        public bool Validate(OceanRenderer ocean, ValidatedHelper.ShowMessage showMessage)
+        {
+            return CheckShaderName(GetComponent<Renderer>(), showMessage);
+        }
+
+        bool CheckShaderName(Renderer renderer, ValidatedHelper.ShowMessage showMessage)
+        {
+            if (renderer.sharedMaterial && renderer.sharedMaterial.shader && !renderer.sharedMaterial.shader.name.StartsWith(ShaderPrefix))
+            {
+                showMessage
+                (
+                    $"Shader assigned to ocean input expected to be of type <i>{ShaderPrefix}</i>.",
+                    MessageType.Error, this
+                );
+
+                return false;
+            }
+
+            return true;
+        }
+    }
+
+    [CustomEditor(typeof(RegisterLodDataInputBase), true), CanEditMultipleObjects]
+    class RegisterLodDataInputBaseEditor : ValidatedEditor { }
+#endif
 }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
@@ -81,7 +81,7 @@ namespace Crest
 #if UNITY_EDITOR
                 if (_checkShaderName && verifyShader)
                 {
-                    CheckShaderName(_renderer, ValidatedHelper.DebugLog);
+                    ValidatedHelper.ValidateRenderer(gameObject, ShaderPrefix, ValidatedHelper.DebugLog);
                 }
 #endif
 
@@ -216,34 +216,7 @@ namespace Crest
     {
         public bool Validate(OceanRenderer ocean, ValidatedHelper.ShowMessage showMessage)
         {
-            return CheckShaderName(GetComponent<Renderer>(), showMessage);
-        }
-
-        bool CheckShaderName(Renderer renderer, ValidatedHelper.ShowMessage showMessage)
-        {
-            if (!renderer)
-            {
-                showMessage
-                (
-                    "No renderer has been attached to ocean input. A renderer is required.",
-                    ValidatedHelper.MessageType.Error, this
-                );
-
-                return false;
-            }
-
-            if (!renderer.sharedMaterial || renderer.sharedMaterial.shader && !renderer.sharedMaterial.shader.name.StartsWith(ShaderPrefix))
-            {
-                showMessage
-                (
-                    $"Shader assigned to ocean input expected to be of type <i>{ShaderPrefix}</i>.",
-                    ValidatedHelper.MessageType.Error, this
-                );
-
-                return false;
-            }
-
-            return true;
+            return ValidatedHelper.ValidateRenderer(gameObject, ShaderPrefix, showMessage);
         }
     }
 

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
@@ -175,7 +175,7 @@ namespace Crest
                 showMessage
                 (
                     "No renderer has been attached to ocean input. A renderer is required.",
-                    MessageType.Error, this
+                    ValidatedHelper.MessageType.Error, this
                 );
 
                 return false;
@@ -186,7 +186,7 @@ namespace Crest
                 showMessage
                 (
                     $"Shader assigned to ocean input expected to be of type <i>{ShaderPrefix}</i>.",
-                    MessageType.Error, this
+                    ValidatedHelper.MessageType.Error, this
                 );
 
                 return false;

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
@@ -170,6 +170,17 @@ namespace Crest
 
         bool CheckShaderName(Renderer renderer, ValidatedHelper.ShowMessage showMessage)
         {
+            if (!_renderer)
+            {
+                showMessage
+                (
+                    "No renderer has been attached to ocean input. A renderer is required.",
+                    MessageType.Error, this
+                );
+
+                return false;
+            }
+
             if (renderer.sharedMaterial && renderer.sharedMaterial.shader && !renderer.sharedMaterial.shader.name.StartsWith(ShaderPrefix))
             {
                 showMessage

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsAnimatedWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsAnimatedWaves.cs
@@ -7,7 +7,7 @@ using UnityEngine;
 namespace Crest
 {
     [CreateAssetMenu(fileName = "SimSettingsAnimatedWaves", menuName = "Crest/Animated Waves Sim Settings", order = 10000)]
-    public class SimSettingsAnimatedWaves : SimSettingsBase
+    public partial class SimSettingsAnimatedWaves : SimSettingsBase
     {
         [Tooltip("How much waves are dampened in shallow water."), SerializeField, Range(0f, 1f)]
         float _attenuationInShallows = 0.95f;
@@ -60,4 +60,27 @@ namespace Crest
             return result;
         }
     }
+
+#if UNITY_EDITOR
+    public partial class SimSettingsAnimatedWaves : IValidated
+    {
+        public override bool Validate(OceanRenderer ocean, ValidatedHelper.ShowMessage showMessage)
+        {
+            var isValid = base.Validate(ocean, showMessage);
+
+            if (_collisionSource == CollisionSources.GerstnerWavesCPU)
+            {
+                showMessage
+                (
+                    "<i>Gerstner Waves CPU</i> has significant drawbacks. It does not include wave attenuation from " +
+                    "water depth or any custom rendered shape. It does not support multiple " +
+                    "<i>GerstnerWavesBatched</i> components including cross blending. Please read the user guide for more information.",
+                    ValidatedHelper.MessageType.Info, this
+                );
+            }
+
+            return isValid;
+        }
+    }
+#endif
 }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsBase.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsBase.cs
@@ -4,12 +4,26 @@
 
 using UnityEngine;
 
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
+
 namespace Crest
 {
     /// <summary>
     /// Base class for simulation settings.
     /// </summary>
-    public class SimSettingsBase : ScriptableObject
+    public partial class SimSettingsBase : ScriptableObject
     {
     }
+
+#if UNITY_EDITOR
+    public partial class SimSettingsBase : IValidated
+    {
+        public virtual bool Validate(OceanRenderer ocean, ValidatedHelper.ShowMessage showMessage) => true;
+    }
+
+    [CustomEditor(typeof(SimSettingsAnimatedWaves), true), CanEditMultipleObjects]
+    class SimSettingsBaseEditor : ValidatedEditor { }
+#endif
 }

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -922,7 +922,7 @@ namespace Crest
                 showMessage
                 (
                     "Base mesh density is lower than 8. There will be visible gaps in the ocean surface. " +
-                    "Increase the <i>LOD Data Resolution</i> or the <i>Geometry Down Sample Factor</i>.",
+                    "Increase the <i>LOD Data Resolution</i> or decrease the <i>Geometry Down Sample Factor</i>.",
                     ValidatedHelper.MessageType.Error, ocean
                 );
             }
@@ -931,7 +931,7 @@ namespace Crest
                 showMessage
                 (
                     "Base mesh density is lower than 16. There will be visible transitions when traversing the ocean surface. " +
-                    "Increase the <i>LOD Data Resolution</i> or the <i>Geometry Down Sample Factor</i>.",
+                    "Increase the <i>LOD Data Resolution</i> or decrease the <i>Geometry Down Sample Factor</i>.",
                     ValidatedHelper.MessageType.Warning, ocean
                 );
             }

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -563,9 +563,7 @@ namespace Crest
             return isValid;
         }
 
-        // NOTE: This was OnValidate and wasn't being called anywhere. Handling this with min/max ranged inputs, and 
-        // stepped ranged inputs in addition with validation might be a better solution.
-        public void ValidateAndRepairDetailParams()
+        void OnValidate()
         {
             // Must be at least 0.25, and must be on a power of 2
             _minScale = Mathf.Pow(2f, Mathf.Round(Mathf.Log(Mathf.Max(_minScale, 0.25f), 2f)));
@@ -612,11 +610,6 @@ namespace Crest
             if (GUILayout.Button("Validate Setup"))
             {
                 OceanRenderer.RunValidation(target);
-            }
-
-            if (GUILayout.Button("Validate and Repair Detail Params"))
-            {
-                target.ValidateAndRepairDetailParams();
             }
         }
     }

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -515,7 +515,7 @@ namespace Crest
                 showMessage
                 (
                     "A material for the ocean must be assigned on the Material property of the OceanRenderer.",
-                    MessageType.Error, ocean
+                    ValidatedHelper.MessageType.Error, ocean
                 );
 
                 isValid =  false;
@@ -535,7 +535,7 @@ namespace Crest
                     showMessage
                     (
                         "The ocean changes scale at runtime so may not be a good idea to store objects underneath it, especially if they are sensitive to scale.",
-                        MessageType.Warning, ocean
+                        ValidatedHelper.MessageType.Warning, ocean
                     );
                 }
             }
@@ -545,7 +545,7 @@ namespace Crest
                 showMessage
                 (
                     "Multiple OceanRenderer scripts detected in open scenes, this is not typical - usually only one OceanRenderer is expected to be present.",
-                    MessageType.Warning, ocean
+                    ValidatedHelper.MessageType.Warning, ocean
                 );
             }
 
@@ -556,7 +556,7 @@ namespace Crest
                 showMessage
                 (
                     "No ShapeGerstnerBatched script found, so ocean will appear flat (no waves).",
-                    MessageType.Info, ocean
+                    ValidatedHelper.MessageType.Info, ocean
                 );
             }
 

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -11,7 +11,7 @@ namespace Crest
     /// The main script for the ocean system. Attach this to a GameObject to create an ocean. This script initializes the various data types and systems
     /// and moves/scales the ocean based on the viewpoint. It also hosts a number of global settings that can be tweaked here.
     /// </summary>
-    public class OceanRenderer : MonoBehaviour
+    public partial class OceanRenderer : MonoBehaviour
     {
         [Tooltip("The viewpoint which drives the ocean detail. Defaults to main camera."), SerializeField]
         Transform _viewpoint;
@@ -188,6 +188,14 @@ namespace Crest
                 return;
             }
 
+#if UNITY_EDITOR
+            if (!Validate(this, ValidatedHelper.DebugLog))
+            {
+                enabled = false;
+                return;
+            }
+#endif
+
             Instance = this;
             Scale = Mathf.Clamp(Scale, _minScale, _maxScale);
 
@@ -217,11 +225,6 @@ namespace Crest
 
         bool VerifyRequirements()
         {
-            if (_material == null)
-            {
-                Debug.LogError("A material for the ocean must be assigned on the Material property of the OceanRenderer.", this);
-                return false;
-            }
             if (!SystemInfo.supportsComputeShaders)
             {
                 Debug.LogError("Crest requires graphics devices that support compute shaders.", this);
@@ -410,35 +413,6 @@ namespace Crest
         public ICollProvider CollisionProvider { get { return _collProvider != null ? _collProvider : (_collProvider = _simSettingsAnimatedWaves.CreateCollisionProvider()); } }
 
 #if UNITY_EDITOR
-        private void OnValidate()
-        {
-            // Must be at least 0.25, and must be on a power of 2
-            _minScale = Mathf.Pow(2f, Mathf.Round(Mathf.Log(Mathf.Max(_minScale, 0.25f), 2f)));
-
-            // Max can be -1 which means no maximum
-            if (_maxScale != -1f)
-            {
-                // otherwise must be at least 0.25, and must be on a power of 2
-                _maxScale = Mathf.Pow(2f, Mathf.Round(Mathf.Log(Mathf.Max(_maxScale, _minScale), 2f)));
-            }
-
-            // Gravity 0 makes waves freeze which is weird but doesn't seem to break anything so allowing this for now
-            _gravityMultiplier = Mathf.Max(_gravityMultiplier, 0f);
-
-            // LOD data resolution multiple of 2 for general GPU texture reasons (like pixel quads)
-            _lodDataResolution -= _lodDataResolution % 2;
-
-            _geometryDownSampleFactor = Mathf.ClosestPowerOfTwo(Mathf.Max(_geometryDownSampleFactor, 1));
-
-            var remGeo = _lodDataResolution % _geometryDownSampleFactor;
-            if (remGeo > 0)
-            {
-                var newLDR = _lodDataResolution - (_lodDataResolution % _geometryDownSampleFactor);
-                Debug.LogWarning("Adjusted Lod Data Resolution from " + _lodDataResolution + " to " + newLDR + " to ensure the Geometry Down Sample Factor is a factor (" + _geometryDownSampleFactor + ").", this);
-                _lodDataResolution = newLDR;
-            }
-        }
-
         [UnityEditor.Callbacks.DidReloadScripts]
         private static void OnReLoadScripts()
         {
@@ -479,4 +453,172 @@ namespace Crest
         }
 #endif
     }
+
+#if UNITY_EDITOR
+    public partial class OceanRenderer : IValidated
+    {
+        public static void RunValidation(OceanRenderer ocean)
+        {
+            ocean.Validate(ocean, ValidatedHelper.DebugLog);
+
+            // ShapeGerstnerBatched
+            var gerstners = FindObjectsOfType<ShapeGerstnerBatched>();
+            foreach (var gerstner in gerstners)
+            {
+                gerstner.Validate(ocean, ValidatedHelper.DebugLog);
+            }
+
+            // UnderwaterEffect
+            var underwaters = FindObjectsOfType<UnderwaterEffect>();
+            foreach (var underwater in underwaters)
+            {
+                underwater.Validate(ocean, ValidatedHelper.DebugLog);
+            }
+
+            // OceanDepthCache
+            var depthCaches = FindObjectsOfType<OceanDepthCache>();
+            foreach (var depthCache in depthCaches)
+            {
+                depthCache.Validate(ocean, ValidatedHelper.DebugLog);
+            }
+
+            // AssignLayer
+            var assignLayers = FindObjectsOfType<AssignLayer>();
+            foreach (var assign in assignLayers)
+            {
+                assign.Validate(ocean, ValidatedHelper.DebugLog);
+            }
+
+            // FloatingObjectBase
+            var floatingObjects = FindObjectsOfType<FloatingObjectBase>();
+            foreach (var floatingObject in floatingObjects)
+            {
+                floatingObject.Validate(ocean, ValidatedHelper.DebugLog);
+            }
+
+            // Inputs
+            var inputs = FindObjectsOfType<RegisterLodDataInputBase>();
+            foreach (var input in inputs)
+            {
+                input.Validate(ocean, ValidatedHelper.DebugLog);
+            }
+
+            Debug.Log("Validation complete!", ocean);
+        }
+
+        public bool Validate(OceanRenderer ocean, ValidatedHelper.ShowMessage showMessage)
+        {
+            var isValid = true;
+
+            if (_material == null)
+            {
+                showMessage
+                (
+                    "A material for the ocean must be assigned on the Material property of the OceanRenderer.",
+                    MessageType.Error, ocean
+                );
+
+                isValid =  false;
+            }
+
+            // We would have to take the tiles into account for this to work in play mode.
+            if (!EditorApplication.isPlaying)
+            {
+                var childCount = ocean.transform.childCount;
+                if (ocean._showProxyPlane)
+                {
+                    childCount -= 1;
+                }
+
+                if (childCount > 0)
+                {
+                    showMessage
+                    (
+                        "The ocean changes scale at runtime so may not be a good idea to store objects underneath it, especially if they are sensitive to scale.",
+                        MessageType.Warning, ocean
+                    );
+                }
+            }
+
+            if (FindObjectsOfType<OceanRenderer>().Length > 1)
+            {
+                showMessage
+                (
+                    "Multiple OceanRenderer scripts detected in open scenes, this is not typical - usually only one OceanRenderer is expected to be present.",
+                    MessageType.Warning, ocean
+                );
+            }
+
+            // ShapeGerstnerBatched
+            var gerstners = FindObjectsOfType<ShapeGerstnerBatched>();
+            if (gerstners.Length == 0)
+            {
+                showMessage
+                (
+                    "No ShapeGerstnerBatched script found, so ocean will appear flat (no waves).",
+                    MessageType.Info, ocean
+                );
+            }
+
+            return isValid;
+        }
+
+        // NOTE: This was OnValidate and wasn't being called anywhere. Handling this with min/max ranged inputs, and 
+        // stepped ranged inputs in addition with validation might be a better solution.
+        public void ValidateAndRepairDetailParams()
+        {
+            // Must be at least 0.25, and must be on a power of 2
+            _minScale = Mathf.Pow(2f, Mathf.Round(Mathf.Log(Mathf.Max(_minScale, 0.25f), 2f)));
+
+            // Max can be -1 which means no maximum
+            if (_maxScale != -1f)
+            {
+                // otherwise must be at least 0.25, and must be on a power of 2
+                _maxScale = Mathf.Pow(2f, Mathf.Round(Mathf.Log(Mathf.Max(_maxScale, _minScale), 2f)));
+            }
+
+            // Gravity 0 makes waves freeze which is weird but doesn't seem to break anything so allowing this for now
+            _gravityMultiplier = Mathf.Max(_gravityMultiplier, 0f);
+
+            // LOD data resolution multiple of 2 for general GPU texture reasons (like pixel quads)
+            _lodDataResolution -= _lodDataResolution % 2;
+
+            _geometryDownSampleFactor = Mathf.ClosestPowerOfTwo(Mathf.Max(_geometryDownSampleFactor, 1));
+
+            var remGeo = _lodDataResolution % _geometryDownSampleFactor;
+            if (remGeo > 0)
+            {
+                var newLDR = _lodDataResolution - (_lodDataResolution % _geometryDownSampleFactor);
+                Debug.LogWarning
+                (
+                    "Adjusted Lod Data Resolution from " + _lodDataResolution + " to " + newLDR + " to ensure the Geometry Down Sample Factor is a factor (" + _geometryDownSampleFactor + ").",
+                    this
+                );
+
+                _lodDataResolution = newLDR;
+            }
+        }
+    }
+
+    [CustomEditor(typeof(OceanRenderer))]
+    public class OceanRendererEditor : ValidatedEditor
+    {
+        public override void OnInspectorGUI()
+        {
+            base.OnInspectorGUI();
+
+            var target = this.target as OceanRenderer;
+
+            if (GUILayout.Button("Validate Setup"))
+            {
+                OceanRenderer.RunValidation(target);
+            }
+
+            if (GUILayout.Button("Validate and Repair Detail Params"))
+            {
+                target.ValidateAndRepairDetailParams();
+            }
+        }
+    }
+#endif
 }

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -560,6 +560,12 @@ namespace Crest
                 );
             }
 
+            // SimSettingsAnimatedWaves
+            if (_simSettingsAnimatedWaves)
+            {
+                _simSettingsAnimatedWaves.Validate(ocean, showMessage);
+            }
+
             return isValid;
         }
 

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -560,6 +560,28 @@ namespace Crest
                 );
             }
 
+            // Ocean Detail Parameters
+            var baseMeshDensity = _lodDataResolution * 0.25f / _geometryDownSampleFactor;
+
+            if (baseMeshDensity < 8)
+            {
+                showMessage
+                (
+                    "Base mesh density is lower than 8. There will be visible gaps in the ocean surface. " +
+                    "Increase the <i>LOD Data Resolution</i> or the <i>Geometry Down Sample Factor</i>.",
+                    ValidatedHelper.MessageType.Error, ocean
+                );
+            }
+            else if (baseMeshDensity < 16)
+            {
+                showMessage
+                (
+                    "Base mesh density is lower than 16. There will be visible transitions when traversing the ocean surface. " +
+                    "Increase the <i>LOD Data Resolution</i> or the <i>Geometry Down Sample Factor</i>.",
+                    ValidatedHelper.MessageType.Warning, ocean
+                );
+            }
+
             // Spherical Harmonics
             if (Lightmapping.giWorkflowMode != Lightmapping.GIWorkflowMode.Iterative && !Lightmapping.lightingDataAsset)
             {

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -560,6 +560,16 @@ namespace Crest
                 );
             }
 
+            // Spherical Harmonics
+            if (Lightmapping.giWorkflowMode != Lightmapping.GIWorkflowMode.Iterative && !Lightmapping.lightingDataAsset)
+            {
+                showMessage
+                (
+                    "Lighting data is missing. Ocean colour will be incorrect without baked spherical harmonics. Generate lighting or enable Auto Generate from the Lighting window.",
+                    ValidatedHelper.MessageType.Warning, ocean
+                );
+            }
+
             // SimSettingsAnimatedWaves
             if (_simSettingsAnimatedWaves)
             {

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -893,25 +893,6 @@ namespace Crest
                 isValid =  false;
             }
 
-            // We would have to take the tiles into account for this to work in play mode.
-            if (!EditorApplication.isPlaying)
-            {
-                var childCount = ocean.transform.childCount;
-                if (ocean._showOceanProxyPlane)
-                {
-                    childCount -= 1;
-                }
-
-                if (childCount > 0)
-                {
-                    showMessage
-                    (
-                        "The ocean changes scale at runtime so may not be a good idea to store objects underneath it, especially if they are sensitive to scale.",
-                        ValidatedHelper.MessageType.Warning, ocean
-                    );
-                }
-            }
-
             // OceanRenderer
             if (FindObjectsOfType<OceanRenderer>().Length > 1)
             {

--- a/crest/Assets/Crest/Crest/Scripts/OceanValidation.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanValidation.cs
@@ -29,15 +29,13 @@ namespace Crest
         }
 
         // This is a shared resource. It will be cleared before use. It is only used by the HelpBox delegate since we 
-        // want to group them by severity (MessageType).
+        // want to group them by severity (MessageType). Make sure length matches MessageType length.
         public static readonly List<string>[] messages = new []
         {
             new List<string>(),
             new List<string>(),
             new List<string>(),
         };
-
-        public static readonly int messageTypesLength = System.Enum.GetValues(typeof(MessageType)).Length;
 
         public delegate void ShowMessage(string message, MessageType type, Object @object = null);
 
@@ -84,7 +82,7 @@ namespace Crest
             var needsSpaceBelow = false;
 
             // We loop through in reverse order so errors appears at the top.
-            for (var messageTypeIndex = 0; messageTypeIndex < ValidatedHelper.messageTypesLength; messageTypeIndex++)
+            for (var messageTypeIndex = 0; messageTypeIndex < ValidatedHelper.messages.Length; messageTypeIndex++)
             {
                 var messages = ValidatedHelper.messages[messageTypeIndex];
 
@@ -111,7 +109,7 @@ namespace Crest
                     }
 
                     // Map Validated.MessageType to HelpBox.MessageType.
-                    var messageType = (MessageType)ValidatedHelper.messageTypesLength - messageTypeIndex;
+                    var messageType = (MessageType)ValidatedHelper.messages.Length - messageTypeIndex;
                     EditorGUILayout.HelpBox(joinedMessage, messageType);
                 }
             }

--- a/crest/Assets/Crest/Crest/Scripts/OceanValidation.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanValidation.cs
@@ -21,11 +21,17 @@ namespace Crest
     // Holds the shared list for messages
     public static class ValidatedHelper
     {
+        public enum MessageType
+        {
+            Error,
+            Warning,
+            Info,
+        }
+
         // This is a shared resource. It will be cleared before use. It is only used by the HelpBox delegate since we 
         // want to group them by severity (MessageType).
         public static readonly List<string>[] messages = new []
         {
-            new List<string>(),
             new List<string>(),
             new List<string>(),
             new List<string>(),
@@ -78,9 +84,10 @@ namespace Crest
             var needsSpaceBelow = false;
 
             // We loop through in reverse order so errors appears at the top.
-            for (var messageTypeIndex = ValidatedHelper.messageTypesLength - 1; messageTypeIndex >= 0; messageTypeIndex--)
+            for (var messageTypeIndex = 0; messageTypeIndex < ValidatedHelper.messageTypesLength; messageTypeIndex++)
             {
                 var messages = ValidatedHelper.messages[messageTypeIndex];
+
                 if (messages.Count > 0)
                 {
                     if (needsSpaceAbove)
@@ -103,7 +110,9 @@ namespace Crest
                         joinedMessage += $"\n- {messages[messageIndex]}";
                     }
 
-                    EditorGUILayout.HelpBox(joinedMessage, (MessageType)messageTypeIndex);
+                    // Map Validated.MessageType to HelpBox.MessageType.
+                    var messageType = (MessageType)ValidatedHelper.messageTypesLength - messageTypeIndex;
+                    EditorGUILayout.HelpBox(joinedMessage, messageType);
                 }
             }
 

--- a/crest/Assets/Crest/Crest/Scripts/OceanValidation.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanValidation.cs
@@ -32,6 +32,8 @@ namespace Crest
         // to group them by severity (MessageType).
         public static readonly List<ValidatedMessage> messages = new List<ValidatedMessage>();
 
+        public static readonly int messageTypesLength = System.Enum.GetValues(typeof(MessageType)).Length;
+
         public delegate void ShowMessage(string message, MessageType type, Object @object = null);
 
         public static void DebugLog(string message, MessageType type, Object @object = null)
@@ -61,8 +63,6 @@ namespace Crest
             // Enable rich text in help boxes.
             GUI.skin.GetStyle("HelpBox").richText = true;
 
-            var messageTypes = System.Enum.GetValues(typeof(MessageType));
-
             // This is a static list so we need to clear it before use. Not sure if this will ever be a threaded
             // operation which would be an issue.
             ValidatedHelper.messages.Clear();
@@ -76,7 +76,7 @@ namespace Crest
             var needsSpaceBelow = false;
 
             // We loop through in reverse order so errors appears at the top.
-            for (var messageTypeIndex = messageTypes.Length - 1; messageTypeIndex >= 0; messageTypeIndex--)
+            for (var messageTypeIndex = ValidatedHelper.messageTypesLength - 1; messageTypeIndex >= 0; messageTypeIndex--)
             {
                 var filtered = ValidatedHelper.messages.FindAll(x => (int) x.type == messageTypeIndex);
                 if (filtered.Count > 0)

--- a/crest/Assets/Crest/Crest/Scripts/OceanValidation.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanValidation.cs
@@ -59,6 +59,8 @@ namespace Crest
 
     public abstract class ValidatedEditor : Editor
     {
+        static readonly bool _groupMessages = false;
+
         public void ShowValidationMessages()
         {
             IValidated target = (IValidated)this.target;
@@ -99,19 +101,30 @@ namespace Crest
 
                     needsSpaceBelow = true;
 
-                    // We join the messages together to reduce vertical space since HelpBox has padding, borders etc.
-                    var joinedMessage = messages[0];
-                    // Format as list if we have more than one message.
-                    if (messages.Count > 1) joinedMessage = $"- {joinedMessage}";
-
-                    for (var messageIndex = 1; messageIndex < messages.Count; messageIndex++)
-                    {
-                        joinedMessage += $"\n- {messages[messageIndex]}";
-                    }
-
                     // Map Validated.MessageType to HelpBox.MessageType.
                     var messageType = (MessageType)ValidatedHelper.messages.Length - messageTypeIndex;
-                    EditorGUILayout.HelpBox(joinedMessage, messageType);
+
+                    if (_groupMessages)
+                    {
+                        // We join the messages together to reduce vertical space since HelpBox has padding, borders etc.
+                        var joinedMessage = messages[0];
+                        // Format as list if we have more than one message.
+                        if (messages.Count > 1) joinedMessage = $"- {joinedMessage}";
+
+                        for (var messageIndex = 1; messageIndex < messages.Count; messageIndex++)
+                        {
+                            joinedMessage += $"\n- {messages[messageIndex]}";
+                        }
+
+                        EditorGUILayout.HelpBox(joinedMessage, messageType);
+                    }
+                    else
+                    {
+                        foreach (var message in messages)
+                        {
+                            EditorGUILayout.HelpBox(message, messageType);
+                        }
+                    }
                 }
             }
 

--- a/crest/Assets/Crest/Crest/Scripts/OceanValidation.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanValidation.cs
@@ -118,7 +118,6 @@ namespace Crest
             {
                 EditorGUILayout.Space();
             }
-
         }
 
         public override void OnInspectorGUI()

--- a/crest/Assets/Crest/Crest/Scripts/OceanValidation.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanValidation.cs
@@ -63,7 +63,8 @@ namespace Crest
         {
             IValidated target = (IValidated)this.target;
 
-            // Enable rich text in help boxes.
+            // Enable rich text in help boxes. Store original so we can revert since this might be a "hack".
+            var styleRichText = GUI.skin.GetStyle("HelpBox").richText;
             GUI.skin.GetStyle("HelpBox").richText = true;
 
             // This is a static list so we need to clear it before use. Not sure if this will ever be a threaded
@@ -118,6 +119,9 @@ namespace Crest
             {
                 EditorGUILayout.Space();
             }
+
+            // Revert skin since it persists.
+            GUI.skin.GetStyle("HelpBox").richText = styleRichText;
         }
 
         public override void OnInspectorGUI()

--- a/crest/Assets/Crest/Crest/Scripts/OceanValidation.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanValidation.cs
@@ -55,6 +55,34 @@ namespace Crest
         {
             messages[(int) type].Add(message);
         }
+
+        public static bool ValidateRenderer(GameObject gameObject, string shaderPrefix, ShowMessage showMessage)
+        {
+            var renderer = gameObject.GetComponent<Renderer>();
+            if (!renderer)
+            {
+                showMessage
+                (
+                    "No renderer has been attached to ocean input. A renderer is required.",
+                    MessageType.Error, gameObject
+                );
+
+                return false;
+            }
+
+            if (!renderer.sharedMaterial || renderer.sharedMaterial.shader && !renderer.sharedMaterial.shader.name.StartsWith(shaderPrefix))
+            {
+                showMessage
+                (
+                    $"Shader assigned to ocean input expected to be of type <i>{shaderPrefix}</i>.",
+                    MessageType.Error, gameObject
+                );
+
+                return false;
+            }
+
+            return true;
+        }
     }
 
     public abstract class ValidatedEditor : Editor

--- a/crest/Assets/Crest/Crest/Scripts/OceanValidation.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanValidation.cs
@@ -68,9 +68,9 @@ namespace Crest
 
             // This is a static list so we need to clear it before use. Not sure if this will ever be a threaded
             // operation which would be an issue.
-            for (var messageTypeIndex = 0; messageTypeIndex < ValidatedHelper.messages.Length; messageTypeIndex++)
+            foreach (var messages in ValidatedHelper.messages)
             {
-                ValidatedHelper.messages[messageTypeIndex].Clear();
+                messages.Clear();
             }
 
             // OceanRenderer isn't a hard requirement for validation to work. Null needs to be handled in each

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
@@ -813,7 +813,11 @@ namespace Crest
         {
             var isValid = true;
 
-            isValid = ValidatedHelper.ValidateRenderer(gameObject, "Crest/Inputs/Animated Waves/Gerstner", showMessage);
+            // Renderer
+            if (_mode == GerstnerMode.Geometry)
+            {
+                isValid = ValidatedHelper.ValidateRenderer(gameObject, "Crest/Inputs/Animated Waves/Gerstner", showMessage);
+            }
 
             if (_componentsPerOctave == 0)
             {

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
@@ -807,7 +807,7 @@ namespace Crest
                 showMessage
                 (
                     "Components Per Octave set to 0 meaning this Gerstner component won't generate any waves.",
-                    MessageType.Warning, this
+                    ValidatedHelper.MessageType.Warning, this
                 );
 
                 isValid = false;

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
@@ -813,6 +813,8 @@ namespace Crest
         {
             var isValid = true;
 
+            isValid = ValidatedHelper.ValidateRenderer(gameObject, "Crest/Inputs/Animated Waves/Gerstner", showMessage);
+
             if (_componentsPerOctave == 0)
             {
                 showMessage

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
@@ -12,7 +12,7 @@ namespace Crest
     /// Support script for Gerstner wave ocean shapes.
     /// Generates a number of batches of Gerstner waves.
     /// </summary>
-    public class ShapeGerstnerBatched : MonoBehaviour, ICollProvider, IFloatingOrigin
+    public partial class ShapeGerstnerBatched : MonoBehaviour, ICollProvider, IFloatingOrigin
     {
         public enum GerstnerMode
         {
@@ -771,8 +771,8 @@ namespace Crest
     }
 
 #if UNITY_EDITOR
-    [CustomEditor(typeof(ShapeGerstnerBatched))]
-    public class ShapeGerstnerBatchedEditor : Editor
+    [CustomEditor(typeof(ShapeGerstnerBatched)), CanEditMultipleObjects]
+    public class ShapeGerstnerBatchedEditor : ValidatedEditor
     {
         public override void OnInspectorGUI()
         {
@@ -793,6 +793,27 @@ namespace Crest
                 }
             }
             GUI.enabled = true;
+        }
+    }
+
+    public partial class ShapeGerstnerBatched : IValidated
+    {
+        public bool Validate(OceanRenderer ocean, ValidatedHelper.ShowMessage showMessage)
+        {
+            var isValid = true;
+
+            if (_componentsPerOctave == 0)
+            {
+                showMessage
+                (
+                    "Components Per Octave set to 0 meaning this Gerstner component won't generate any waves.",
+                    MessageType.Warning, this
+                );
+
+                isValid = false;
+            }
+
+            return isValid;
         }
     }
 #endif


### PR DESCRIPTION
**Status**: Proposal. Do not merge

![Proposal](https://user-images.githubusercontent.com/5249806/80913079-1161a480-8d85-11ea-918a-47b4df0cd940.jpg)

The proposal is that the above would compliment current validation approach (_OceanValidation_) and possibly replace other forms of validation like logging on play.

The benefit is it gives instant feedback to the user and does not pollute the console which people are sensitive to.

~~There are two approaches to how we target an inspector, and three approaches on how we compose and presenting the help boxes (awkwardly worded but might make sense in a bit).~~

Being a proposal code quality, naming etc is pretty poor. So please forgive me for that. Mainly to demonstrate the idea to see if we want to pursue further.

## Targeting an Inspector

We are using an interface and unfortunately we cannot target interfaces (but we can target through inheritance which is better than nothing).

1. We target the inspector using a custom inspector. We have to create an empty class for each inspector. It is simply two lines which can be appended to _ValidatedInspectorEditor.cs_ (example at bottom of file)
2. ~~We target the inspector using a property drawer. Just by adding _ValidatedInspectorProperty_ (poorly named) as a property, we can target the inspector using a property drawer. See _ValidatedInspectorPropertyDrawer_.~~

~~I'm leaning on option 1 as I think polluting classes with properties for purposes such as this is probably not a good idea or clean.~~

UPDATE: Went with option 1. I have used the already defined _IValidated_ interface.

## Composing and Presenting Help Boxes

I was thinking of a way we could reuse validation code. The validation code should be the same with the only thing preventing it with the current code is `DebugLog` calls.

1. ~~Basic. We duplicate the validation code. No reuse~~
2. ~~Advanced. We return a list of structs which have the message and message type and use the appropriate approach (debug log or help box).~~
3. Functions. We pass a function which wraps either debug log or help box

~~I am leaning on option two. It allows reuse and works better with adding spaces (before and after help boxes) in the inspector.~~

~~Option three looks cleaner but since we have to combine strings for the help boxes but not for debug logs it doesn't work well currently. I would need to add code to collect strings so we can call the help box function once per message type. So it ends up being about the same in complexity as 2.~~

UPDATE: Went with option 3. Using a shared list since this operation appears to be synchronous. If this is an issue it could be fixed.

---

UPDATE: I have merged in the recent validation code from master. I also went with one approach. Older approaches are in previous commits.

I've used a partial class to help separate validation code from other code. Not necessary though.

Let me know if you think this is worth pursuing further.