### PR TITLE
Scale caustics strength by primary light and depth fog

### DIFF
--- a/crest/Assets/Crest/Crest/Shaders/OceanEmission.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanEmission.hlsl
@@ -151,7 +151,9 @@ void ApplyCaustics(in const half3 i_view, in const half3 i_lightDir, in const fl
 	float4 cuv1 = float4((surfacePosXZ / _CausticsTextureScale + 1.3 *causticN + float2(0.044*_CrestTime + 17.16, -0.169*_CrestTime)), 0., mipLod);
 	float4 cuv2 = float4((1.37*surfacePosXZ / _CausticsTextureScale + 1.77*causticN + float2(0.248*_CrestTime, 0.117*_CrestTime)), 0., mipLod);
 
-	half causticsStrength = _CausticsStrength;
+	// Scale caustics strength by primary light, depth fog density and scene depth.
+	half causticsStrength = lerp(_CausticsStrength * _LightColor0, 0.0, saturate(1.0 - exp(-_DepthFogDensity.xyz * sceneDepth)));
+
 #if _SHADOWS_ON
 	{
 		half2 causticShadow = 0.0;


### PR DESCRIPTION
Scales the caustics strength by primary light colour, depth fog density and scene depth.

Solves the problem of caustics showing up under underwater lights when they shouldn't. This solution works independently from the _UnderwaterEnvironmentalLighting_ component, but it is affected by it since it scales the primary light. But that is a separate problem.

I am not certain how they should co-exist with depth of field and focal depth, but right now they don't appear to conflict.

I plan to port this to HDRP to replace limiting caustics by scene depth, but it might be a bit more involved due to different lighting units.