### PR TITLE
Add dynamic horizon line safety margin prevent artifacting

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterPostProcess.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterPostProcess.cs
@@ -26,8 +26,9 @@ namespace Crest
         [SerializeField, Tooltip("Assign this to a material that uses shader `Crest/Underwater/Post Process`, with the same features enabled as the ocean surface material(s).")]
         Material _underwaterPostProcessMaterial;
 
-        [Header("Debug Options"), SerializeField]
-        bool _viewOceanMask = false;
+        [Header("Debug Options")]
+        [SerializeField] bool _viewOceanMask = false;
+        [SerializeField] bool _disableOceanMask = false;
         // end public debug options
 
         private Camera _mainCamera;
@@ -162,8 +163,10 @@ namespace Crest
             PopulateOceanMask(
                 _maskCommandBuffer, _mainCamera, OceanBuilder.OceanChunkRenderers, _cameraFrustumPlanes,
                 _textureMask, _depthBuffer,
-                _oceanMaskMaterial
+                _oceanMaskMaterial,
+                _disableOceanMask
             );
+
         }
 
         void OnRenderImage(RenderTexture source, RenderTexture target)

--- a/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterPostProcess.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterPostProcess.cs
@@ -27,8 +27,10 @@ namespace Crest
         Material _underwaterPostProcessMaterial;
 
         [Header("Debug Options")]
-        [SerializeField] bool _viewOceanMask = false;
+        [SerializeField] bool _viewPostProcessMask = false;
         [SerializeField] bool _disableOceanMask = false;
+        [SerializeField, Tooltip("A safety margin multiplier to adjust horizon line based on camera position to avoid minor artifacts caused by floating point precision issues, the default value has been chosen based on careful experimentation."), Range(0f, 1f)]
+        float _safetyMarginMultiplier = UnderwaterPostProcessUtils.DefaultSafetyMarginMultiplier;
         // end public debug options
 
         private Camera _mainCamera;
@@ -204,7 +206,8 @@ namespace Crest
                 _underwaterPostProcessMaterialWrapper,
                 _sphericalHarmonicsData,
                 _firstRender || _copyOceanMaterialParamsEachFrame,
-                _viewOceanMask
+                _viewPostProcessMask,
+                _safetyMarginMultiplier
             );
 
             _postProcessCommandBuffer.Blit(source, target, _underwaterPostProcessMaterial);

--- a/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterPostProcess.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterPostProcess.cs
@@ -30,7 +30,7 @@ namespace Crest
         [SerializeField] bool _viewPostProcessMask = false;
         [SerializeField] bool _disableOceanMask = false;
         [SerializeField, Tooltip("A safety margin multiplier to adjust horizon line based on camera position to avoid minor artifacts caused by floating point precision issues, the default value has been chosen based on careful experimentation."), Range(0f, 1f)]
-        float _safetyMarginMultiplier = UnderwaterPostProcessUtils.DefaultSafetyMarginMultiplier;
+        float _horizonSafetyMarginMultiplier = UnderwaterPostProcessUtils.DefaultHorizonSafetyMarginMultiplier;
         // end public debug options
 
         private Camera _mainCamera;
@@ -207,7 +207,7 @@ namespace Crest
                 _sphericalHarmonicsData,
                 _firstRender || _copyOceanMaterialParamsEachFrame,
                 _viewPostProcessMask,
-                _safetyMarginMultiplier
+                _horizonSafetyMarginMultiplier
             );
 
             _postProcessCommandBuffer.Blit(source, target, _underwaterPostProcessMaterial);

--- a/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterPostProcessUtils.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterPostProcessUtils.cs
@@ -27,7 +27,7 @@ namespace Crest
         // A magic number found after a small-amount of iteration that is used to deal with horizon-line floating-point
         // issues. It allows us to give it a small *nudge* in the right direction based on whether the camera is above
         // or below the horizon line itself already.
-        public const float DefaultSafetyMarginMultiplier = 0.01f;
+        public const float DefaultHorizonSafetyMarginMultiplier = 0.01f;
 
         internal class UnderwaterSphericalHarmonicsData
         {
@@ -110,7 +110,7 @@ namespace Crest
             UnderwaterSphericalHarmonicsData sphericalHarmonicsData,
             bool copyParamsFromOceanMaterial,
             bool debugViewPostProcessMask,
-            float safetyMarginMultiplier
+            float horizonSafetyMarginMultiplier
         )
         {
             Material underwaterPostProcessMaterial = underwaterPostProcessMaterialWrapper.material;
@@ -201,7 +201,7 @@ namespace Crest
                 underwaterPostProcessMaterial.SetMatrix(sp_InvViewProjection, inverseViewProjectionMatrix);
 
                 {
-                    GetHorizonPosNormal(camera, Camera.MonoOrStereoscopicEye.Mono, seaLevel, safetyMarginMultiplier, out Vector2 pos, out Vector2 normal);
+                    GetHorizonPosNormal(camera, Camera.MonoOrStereoscopicEye.Mono, seaLevel, horizonSafetyMarginMultiplier, out Vector2 pos, out Vector2 normal);
                     underwaterPostProcessMaterial.SetVector(sp_HorizonPosNormal, new Vector4(pos.x, pos.y, normal.x, normal.y));
                 }
             }
@@ -211,7 +211,7 @@ namespace Crest
                 underwaterPostProcessMaterial.SetMatrix(sp_InvViewProjection, inverseViewProjectionMatrix);
 
                 {
-                    GetHorizonPosNormal(camera, Camera.MonoOrStereoscopicEye.Left, seaLevel, safetyMarginMultiplier, out Vector2 pos, out Vector2 normal);
+                    GetHorizonPosNormal(camera, Camera.MonoOrStereoscopicEye.Left, seaLevel, horizonSafetyMarginMultiplier, out Vector2 pos, out Vector2 normal);
                     underwaterPostProcessMaterial.SetVector(sp_HorizonPosNormal, new Vector4(pos.x, pos.y, normal.x, normal.y));
                 }
 
@@ -219,7 +219,7 @@ namespace Crest
                 underwaterPostProcessMaterial.SetMatrix(sp_InvViewProjectionRight, inverseViewProjectionMatrixRightEye);
 
                 {
-                    GetHorizonPosNormal(camera, Camera.MonoOrStereoscopicEye.Right, seaLevel, safetyMarginMultiplier, out Vector2 pos, out Vector2 normal);
+                    GetHorizonPosNormal(camera, Camera.MonoOrStereoscopicEye.Right, seaLevel, horizonSafetyMarginMultiplier, out Vector2 pos, out Vector2 normal);
                     underwaterPostProcessMaterial.SetVector(sp_HorizonPosNormalRight, new Vector4(pos.x, pos.y, normal.x, normal.y));
                 }
             }
@@ -247,7 +247,7 @@ namespace Crest
         /// <summary>
         /// Compute intersection between the frustum far plane and the ocean plane, and return screen space pos and normal for this horizon line
         /// </summary>
-        static void GetHorizonPosNormal(Camera camera, Camera.MonoOrStereoscopicEye eye, float seaLevel, float safetyMarginMultiplier, out Vector2 resultPos, out Vector2 resultNormal)
+        static void GetHorizonPosNormal(Camera camera, Camera.MonoOrStereoscopicEye eye, float seaLevel, float horizonSafetyMarginMultiplier, out Vector2 resultPos, out Vector2 resultNormal)
         {
             // Set up back points of frustum
             NativeArray<Vector3> v_screenXY_viewZ = new NativeArray<Vector3>(4, Allocator.Temp);
@@ -340,7 +340,7 @@ namespace Crest
                         }
                     }
 
-                    resultPos.y += (seaLevel - camera.transform.position.y) * safetyMarginMultiplier;
+                    resultPos.y += (seaLevel - camera.transform.position.y) * horizonSafetyMarginMultiplier;
                 }
                 finally
                 {

--- a/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterPostProcessUtils.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterPostProcessUtils.cs
@@ -75,7 +75,8 @@ namespace Crest
         internal static void PopulateOceanMask(
             CommandBuffer commandBuffer, Camera camera, List<OceanChunkRenderer> chunksToRender, Plane[] frustumPlanes,
             RenderTexture colorBuffer, RenderTexture depthBuffer,
-            Material oceanMaskMaterial
+            Material oceanMaskMaterial,
+            bool debugDisableOceanMask
         )
         {
             // Get all ocean chunks and render them using cmd buffer, but with mask shader
@@ -83,14 +84,17 @@ namespace Crest
             commandBuffer.ClearRenderTarget(true, true, Color.white * UNDERWATER_MASK_NO_MASK);
             commandBuffer.SetViewProjectionMatrices(camera.worldToCameraMatrix, camera.projectionMatrix);
 
-            // Spends approx 0.2-0.3ms here on dell laptop
-            foreach (OceanChunkRenderer chunk in chunksToRender)
+            if (!debugDisableOceanMask)
             {
-                Renderer renderer = chunk.Renderer;
-                Bounds bounds = renderer.bounds;
-                if (GeometryUtility.TestPlanesAABB(frustumPlanes, bounds))
+                // Spends approx 0.2-0.3ms here on dell laptop
+                foreach (OceanChunkRenderer chunk in chunksToRender)
                 {
-                    commandBuffer.DrawRenderer(renderer, oceanMaskMaterial);
+                    Renderer renderer = chunk.Renderer;
+                    Bounds bounds = renderer.bounds;
+                    if (GeometryUtility.TestPlanesAABB(frustumPlanes, bounds))
+                    {
+                        commandBuffer.DrawRenderer(renderer, oceanMaskMaterial);
+                    }
                 }
             }
 


### PR DESCRIPTION
Shimmies the horizon-line up and down based on the camera position. It's a hack but it's pretty-robust. This commit also takes into account the world space height of the camera frustum for determining wether or not to force the post-process shader to run full-screen, fixing an issue where this would kick-in prematurely if the ocean didn't have any waves which I was using to test the horizon-line fudge.

Will fix #456 when it's merged into HDRP.