### PR TITLE
Reduce far plane distance to 10000

### DIFF
--- a/crest/Assets/Crest/Crest-Examples/Shared/Prefabs/Internal/DemoCameraCore.prefab
+++ b/crest/Assets/Crest/Crest-Examples/Shared/Prefabs/Internal/DemoCameraCore.prefab
@@ -57,7 +57,7 @@ Camera:
     width: 1
     height: 1
   near clip plane: 1
-  far clip plane: 100000
+  far clip plane: 10000
   field of view: 60
   orthographic: 0
   orthographic size: 5


### PR DESCRIPTION
**Status:** Ready to merge

It was set to 100k which is huge, much bigger than previous projects i've worked on.

This large distance meant the ocean (with default settings) was not covering the frustum, messing up the ocean mask.

I think this is a good change and safe. Tested demo scenes and they look fine to me in editor. 
