### PR TITLE
Initiliase chunks for ocean mask even if it's disabled in the scene hiearchy

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/OceanChunkRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanChunkRenderer.cs
@@ -71,8 +71,16 @@ namespace Crest
             _currentCamera = camera;
         }
 
+        // Used by the ocean mask system if we need to render the ocean mask in situations
+        // where the ocean itself doesn't need to be rendered or has otherwise been disabled
+        internal void BindOceanData(Camera camera)
+        {
+            _currentCamera = camera;
+            OnWillRenderObject();
+        }
+
         // Called when visible to a camera
-        internal void OnWillRenderObject()
+        void OnWillRenderObject()
         {
             // check if built-in pipeline being used
             if (Camera.current != null)

--- a/crest/Assets/Crest/Crest/Scripts/OceanChunkRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanChunkRenderer.cs
@@ -72,7 +72,7 @@ namespace Crest
         }
 
         // Called when visible to a camera
-        void OnWillRenderObject()
+        internal void OnWillRenderObject()
         {
             // check if built-in pipeline being used
             if (Camera.current != null)

--- a/crest/Assets/Crest/Crest/Scripts/OceanChunkRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanChunkRenderer.cs
@@ -75,22 +75,6 @@ namespace Crest
         // where the ocean itself doesn't need to be rendered or has otherwise been disabled
         internal void BindOceanData(Camera camera)
         {
-            _currentCamera = camera;
-            OnWillRenderObject();
-        }
-
-        // Called when visible to a camera
-        void OnWillRenderObject()
-        {
-            // check if built-in pipeline being used
-            if (Camera.current != null)
-            {
-                _currentCamera = Camera.current;
-            }
-
-            // Depth texture is used by ocean shader for transparency/depth fog, and for fading out foam at shoreline.
-            _currentCamera.depthTextureMode |= DepthTextureMode.Depth;
-
             if (_rend.sharedMaterial != OceanRenderer.Instance.OceanMaterial)
             {
                 _rend.sharedMaterial = OceanRenderer.Instance.OceanMaterial;
@@ -141,7 +125,7 @@ namespace Crest
             if (ldclip) ldclip.BindResultData(_mpb); else LodDataMgrClipSurface.BindNull(_mpb);
             if (ldshadows) ldshadows.BindResultData(_mpb); else LodDataMgrShadow.BindNull(_mpb);
 
-            var reflTex = PreparedReflections.GetRenderTexture(_currentCamera.GetHashCode());
+            var reflTex = PreparedReflections.GetRenderTexture(camera.GetHashCode());
             if (reflTex)
             {
                 _mpb.SetTexture(sp_ReflectionTex, reflTex);
@@ -159,6 +143,21 @@ namespace Crest
             _mpb.SetFloat(sp_ForceUnderwater, heightOffset < -2f ? 1f : 0f);
 
             _rend.SetPropertyBlock(_mpb.materialPropertyBlock);
+        }
+
+        // Called when visible to a camera
+        void OnWillRenderObject()
+        {
+            // check if built-in pipeline being used
+            if (Camera.current != null)
+            {
+                _currentCamera = Camera.current;
+            }
+
+            // Depth texture is used by ocean shader for transparency/depth fog, and for fading out foam at shoreline.
+            _currentCamera.depthTextureMode |= DepthTextureMode.Depth;
+
+            BindOceanData(_currentCamera);
 
             if (_drawRenderBounds)
             {

--- a/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterPostProcessUtils.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterPostProcessUtils.cs
@@ -95,7 +95,7 @@ namespace Crest
                     Bounds bounds = renderer.bounds;
                     if (GeometryUtility.TestPlanesAABB(frustumPlanes, bounds))
                     {
-                        if(!chunk.gameObject.activeInHierarchy && chunk.enabled)
+                        if((!chunk.gameObject.activeInHierarchy || !renderer.enabled) && chunk.enabled)
                         {
                             chunk.OnWillRenderObject();
                         }

--- a/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterPostProcessUtils.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterPostProcessUtils.cs
@@ -97,7 +97,7 @@ namespace Crest
                     {
                         if((!chunk.gameObject.activeInHierarchy || !renderer.enabled) && chunk.enabled)
                         {
-                            chunk.OnWillRenderObject();
+                            chunk.BindOceanData(camera);
                         }
                         commandBuffer.DrawRenderer(renderer, oceanMaskMaterial);
                     }

--- a/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterPostProcessUtils.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterPostProcessUtils.cs
@@ -95,6 +95,10 @@ namespace Crest
                     Bounds bounds = renderer.bounds;
                     if (GeometryUtility.TestPlanesAABB(frustumPlanes, bounds))
                     {
+                        if(!chunk.gameObject.activeInHierarchy && chunk.enabled)
+                        {
+                            chunk.OnWillRenderObject();
+                        }
                         commandBuffer.DrawRenderer(renderer, oceanMaskMaterial);
                     }
                 }


### PR DESCRIPTION
This ensures that for when we disable chunk rendering in the scene
hiearchy for things like local water bodies or other optimisations, if
they will still be correclty renderered as part of the ocean mask which
assumes that chunks will always form a continous surface for the post
process effect to work accurately.