### PR TITLE
Fix terrain with more than four layers being black in planar reflections

### DIFF
--- a/crest/Assets/Crest/Crest/Shaders/OceanReflection.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanReflection.hlsl
@@ -31,7 +31,9 @@ void PlanarReflection(in const half4 i_screenPos, in const half3 i_n_pixel, inou
 	half4 screenPos = i_screenPos;
 	screenPos.xy += _PlanarReflectionNormalsStrength * i_n_pixel.xz;
 	half4 refl = tex2Dproj(_ReflectionTex, UNITY_PROJ_COORD(screenPos));
-	io_colour = lerp(io_colour, refl.rgb, _PlanarReflectionIntensity * refl.a);
+	// If more than four layers are used on terrain, they will appear black if HDR is enabled on the planar reflection
+	// camera. Reflection alpha is probably a negative value.
+	io_colour = lerp(io_colour, refl.rgb, _PlanarReflectionIntensity * saturate(refl.a));
 }
 #endif // _PLANARREFLECTIONS_ON
 


### PR DESCRIPTION
![1](https://user-images.githubusercontent.com/5249806/82727159-1a161c80-9d2c-11ea-8f5f-d18c461e5072.jpg)

Reported by jRocket on Discord. If more than four layers is used on terrain, these layers will appear black in planar reflections.

If I disable HDR on the planar reflection script, it works as expected. So it appears that Unity is packing the alpha channel to achieve layering.

Saturating the alpha fixed this. I don't think this is an issue for anything else. Not sure if there are any negative implications of taking this route.