### PR TITLE
Bind Ocean Mask Data for ocean chunks not rendered due to occlusion culling

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/OceanChunkRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanChunkRenderer.cs
@@ -24,6 +24,11 @@ namespace Crest
         PropertyWrapperMPB _mpb;
 
         public Renderer Renderer => _rend;
+        // We need to ensure that all ocean data has been bound for the mask to
+        // render properly - this is something that needs to happen irrespective
+        // of occlusion culling because we need the mask to render as a
+        // contiguous surface.
+        internal bool OceanDataHasBeenBound = true;
 
         // Cache these off to support regenerating ocean surface
         int _lodIndex = -1;
@@ -75,6 +80,7 @@ namespace Crest
         // where the ocean itself doesn't need to be rendered or has otherwise been disabled
         internal void BindOceanData(Camera camera)
         {
+            OceanDataHasBeenBound = true;
             if (_rend.sharedMaterial != OceanRenderer.Instance.OceanMaterial)
             {
                 _rend.sharedMaterial = OceanRenderer.Instance.OceanMaterial;

--- a/crest/Assets/Crest/Crest/Scripts/OceanChunkRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanChunkRenderer.cs
@@ -28,7 +28,7 @@ namespace Crest
         // render properly - this is something that needs to happen irrespective
         // of occlusion culling because we need the mask to render as a
         // contiguous surface.
-        internal bool OceanDataHasBeenBound = true;
+        internal bool _oceanDataHasBeenBound = true;
 
         // Cache these off to support regenerating ocean surface
         int _lodIndex = -1;
@@ -80,7 +80,7 @@ namespace Crest
         // where the ocean itself doesn't need to be rendered or has otherwise been disabled
         internal void BindOceanData(Camera camera)
         {
-            OceanDataHasBeenBound = true;
+            _oceanDataHasBeenBound = true;
             if (_rend.sharedMaterial != OceanRenderer.Instance.OceanMaterial)
             {
                 _rend.sharedMaterial = OceanRenderer.Instance.OceanMaterial;

--- a/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterPostProcessUtils.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterPostProcessUtils.cs
@@ -95,12 +95,13 @@ namespace Crest
                     Bounds bounds = renderer.bounds;
                     if (GeometryUtility.TestPlanesAABB(frustumPlanes, bounds))
                     {
-                        if((!chunk.gameObject.activeInHierarchy || !renderer.enabled) && chunk.enabled)
+                        if ((!chunk.OceanDataHasBeenBound) && chunk.enabled)
                         {
                             chunk.BindOceanData(camera);
                         }
                         commandBuffer.DrawRenderer(renderer, oceanMaskMaterial);
                     }
+                    chunk.OceanDataHasBeenBound = false;
                 }
             }
 

--- a/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterPostProcessUtils.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterPostProcessUtils.cs
@@ -95,13 +95,13 @@ namespace Crest
                     Bounds bounds = renderer.bounds;
                     if (GeometryUtility.TestPlanesAABB(frustumPlanes, bounds))
                     {
-                        if ((!chunk.OceanDataHasBeenBound) && chunk.enabled)
+                        if ((!chunk._oceanDataHasBeenBound) && chunk.enabled)
                         {
                             chunk.BindOceanData(camera);
                         }
                         commandBuffer.DrawRenderer(renderer, oceanMaskMaterial);
                     }
-                    chunk.OceanDataHasBeenBound = false;
+                    chunk._oceanDataHasBeenBound = false;
                 }
             }
 


### PR DESCRIPTION
Manually set a bool on each ocean chunk that checks if the data is bound, a simpler and more general solution anyway. 

Fixes #479, the repro was harder as we were rendering the mask chunks even if culled in the latest release, but this was causing gaps to appear which now seem to be fixed.