### PR TITLE
Zero horizon safety margin multiplier if in doubt

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterPostProcess.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterPostProcess.cs
@@ -38,12 +38,14 @@ namespace Crest
         private RenderTexture _depthBuffer;
         private CommandBuffer _maskCommandBuffer;
         private CommandBuffer _postProcessCommandBuffer;
+        private readonly SampleHeightHelper _sampleHeightHelper = new SampleHeightHelper();
 
         private Plane[] _cameraFrustumPlanes;
 
         private Material _oceanMaskMaterial = null;
 
         private PropertyWrapperMaterial _underwaterPostProcessMaterialWrapper;
+
 
         private const string SHADER_OCEAN_MASK = "Crest/Underwater/Ocean Mask";
 
@@ -205,6 +207,7 @@ namespace Crest
                 _mainCamera,
                 _underwaterPostProcessMaterialWrapper,
                 _sphericalHarmonicsData,
+                _sampleHeightHelper,
                 _firstRender || _copyOceanMaterialParamsEachFrame,
                 _viewPostProcessMask,
                 _horizonSafetyMarginMultiplier


### PR DESCRIPTION
Only apply the horizon safety margin multiplier to horizon if and only
if concrete height of the camera relative to the water and the height of
the camera relative to the sea-level are the same. This ensures that in
incredibly turbulent water - if in doubt - use the neutral horizon.

Fixes #520 

I tested this in the three boats scene in HDRP, the incredibly localised water spike caused by the ocean liner was causing trouble, so this change makes the horizon-safety-margin multipler much more conservative and has worked really well in testing. 

Justification: the check that I have added essentially checks to see if the camera is inside a swell or a dip - in that case there is no need to apply the horizon safety margin multipler is counter-productive (and with time we might find that applying it inverted might be the most stable option - I just want to slowly iterate to a solution that means we no longer get any horizon-line issues).