### PR TITLE
Gracefully fail if segment registrar scratch exchausted

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Collision/QueryBase.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Collision/QueryBase.cs
@@ -87,10 +87,20 @@ namespace Crest
             {
                 var lastIndex = _segmentAcquire;
 
-                _segmentAcquire = (_segmentAcquire + 1) % _segments.Length;
+                var newSegmentAcquire = (_segmentAcquire + 1) % _segments.Length;
 
-                // The last index should never increment and land on the first index - it should only happen the other way around.
-                Debug.Assert(_segmentAcquire != _segmentRelease, "Segment registrar scratch exhausted.");
+                if (newSegmentAcquire == _segmentRelease)
+                {
+                    // The last index has incremented and landed on the first index. This shouldn't happen normally, but
+                    // can happen if the Scene and Game view are not visible, in which case async readbacks dont get processed
+                    // and the pipeline blocks up.
+#if !UNITY_EDITOR
+                    Debug.LogError("Query ring buffer exhausted. Please report this to developers.", this);
+#endif
+                    return;
+                }
+
+                _segmentAcquire = newSegmentAcquire;
 
                 _segments[_segmentAcquire]._numQueries = 0;
                 _segments[_segmentAcquire]._segments.Clear();


### PR DESCRIPTION
Issue reported in #539 

This seems to happen if no view of the game is rendering, then the async readbacks do not return and things get clogged up. I've never heard of this occuring 'in the wild' in normal circumstances.

With this change, queries will stop getting sent off, and new queries will just overwrite old queries in place until things start up again.