### PR TITLE
Predicate enabled/disabled state of GUI based on a named property

### DIFF
--- a/crest/Assets/Crest/Crest-Examples/BoatDev/Scripts/BoatAlignNormal.cs
+++ b/crest/Assets/Crest/Crest-Examples/BoatDev/Scripts/BoatAlignNormal.cs
@@ -29,7 +29,7 @@ public class BoatAlignNormal : FloatingObjectBase
 
     [SerializeField, Tooltip("Computes a separate normal based on boat length to get more accurate orientations, at the cost of an extra collision sample.")]
     bool _useBoatLength = false;
-    [Tooltip("Length dimension of boat. Only used if Use Boat Length is enabled."), SerializeField]
+    [Tooltip("Length dimension of boat. Only used if Use Boat Length is enabled."), SerializeField, PredicatedField("_useBoatLength")]
     float _boatLength = 3f;
 
     [Header("Drag")]

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/PredicatedFieldAttribute.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/PredicatedFieldAttribute.cs
@@ -8,20 +8,60 @@ using UnityEngine;
 
 namespace Crest
 {
-    /// <summary>
-    /// The field with this attribute will be drawn enabled/disabled based on another field. For example can be used
-    /// to disable a field if a toggle is false. Limitation - conflicts with other property drawers such as Range().
-    /// </summary>
     [AttributeUsage(AttributeTargets.Field, AllowMultiple = false)]
     public class PredicatedFieldAttribute : PropertyAttribute
     {
         public readonly string _propertyName;
         public readonly bool _inverted;
+        public readonly int _disableIfValueIs;
 
-        public PredicatedFieldAttribute(string propertyName, bool inverted = false)
+        /// <summary>
+        /// The field with this attribute will be drawn enabled/disabled based on another field. For example can be used
+        /// to disable a field if a toggle is false. Limitation - conflicts with other property drawers such as Range().
+        /// </summary>
+        /// <param name="propertyName">The name of the other property whose value dictates whether this field is enabled or not.</param>
+        /// <param name="inverted">Flip behaviour - for example disable if a bool field is set to true (instead of false).</param>
+        /// <param name="disableIfValueIs">If the field has this value, disable the GUI (or enable if inverted is true).</param>
+        public PredicatedFieldAttribute(string propertyName, bool inverted = false, int disableIfValueIs = 0)
         {
             _propertyName = propertyName;
             _inverted = inverted;
+            _disableIfValueIs = disableIfValueIs;
+        }
+
+        public bool GUIEnabled(SerializedProperty prop)
+        {
+            bool result;
+
+            if (prop.type == "int")
+            {
+                // Enable GUI if int value of field is not equal to 0, or whatever the disable-value is set to
+                result = prop.intValue != _disableIfValueIs;
+            }
+            else if (prop.type == "bool")
+            {
+                // Enable GUI if disable-value is 0 and field is true, or disable-value is not 0 and field is false
+                result = prop.boolValue ^ (_disableIfValueIs != 0);
+            }
+            else if (prop.type == "float")
+            {
+                result = prop.floatValue != _disableIfValueIs;
+            }
+            else if (prop.type == "Enum")
+            {
+                result = prop.enumValueIndex != _disableIfValueIs;
+            }
+            else if (prop.type.StartsWith("PPtr"))
+            {
+                result = prop.objectReferenceValue != null;
+            }
+            else
+            {
+                Debug.LogError($"PredicatedFieldAttributePropertyDrawer - property type not implemented yet: {prop.type}.", prop.serializedObject.targetObject);
+                return true;
+            }
+
+            return _inverted ? !result : result;
         }
     }
 
@@ -38,7 +78,7 @@ namespace Crest
             var before = GUI.enabled;
             if (prop != null)
             {
-                GUI.enabled = attrib._inverted ? !Predicate(prop) : Predicate(prop);
+                GUI.enabled = attrib.GUIEnabled(prop);
             }
             else
             {
@@ -48,31 +88,6 @@ namespace Crest
             EditorGUI.PropertyField(position, property, label);
 
             GUI.enabled = before;
-        }
-
-        bool Predicate(SerializedProperty prop)
-        {
-            if (prop.type == "bool")
-            {
-                return prop.boolValue;
-            }
-            else if (prop.type == "int")
-            {
-                return prop.intValue > 0;
-            }
-            else if (prop.type == "float")
-            {
-                return prop.floatValue > 0f;
-            }
-            else if (prop.type.StartsWith("PPtr"))
-            {
-                return prop.objectReferenceValue != null;
-            }
-            else
-            {
-                Debug.LogError($"PredicatedFieldAttributePropertyDrawer - property type not implemented yet: {prop.type}.", prop.serializedObject.targetObject);
-                return true;
-            }
         }
     }
 #endif

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/PredicatedFieldAttribute.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/PredicatedFieldAttribute.cs
@@ -1,0 +1,79 @@
+﻿// Crest Ocean System
+
+// This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
+
+using System;
+using UnityEditor;
+using UnityEngine;
+
+namespace Crest
+{
+    /// <summary>
+    /// The field with this attribute will be drawn enabled/disabled based on another field. For example can be used
+    /// to disable a field if a toggle is false. Limitation - conflicts with other property drawers such as Range().
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Field, AllowMultiple = false)]
+    public class PredicatedFieldAttribute : PropertyAttribute
+    {
+        public readonly string _propertyName;
+        public readonly bool _inverted;
+
+        public PredicatedFieldAttribute(string propertyName, bool inverted = false)
+        {
+            _propertyName = propertyName;
+            _inverted = inverted;
+        }
+    }
+
+#if UNITY_EDITOR
+    [CustomPropertyDrawer(typeof(PredicatedFieldAttribute))]
+    public class PredicatedFieldAttributePropertyDrawer : PropertyDrawer
+    {
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        {
+            var attrib = (attribute as PredicatedFieldAttribute);
+            var propName = attrib._propertyName;
+            var prop = property.serializedObject.FindProperty(propName);
+
+            var before = GUI.enabled;
+            if (prop != null)
+            {
+                GUI.enabled = attrib._inverted ? !Predicate(prop) : Predicate(prop);
+            }
+            else
+            {
+                Debug.LogError($"PredicatedFieldAttributePropertyDrawer - field '{propName}' not found.");
+            }
+
+            EditorGUI.PropertyField(position, property, label);
+
+            GUI.enabled = before;
+        }
+
+        bool Predicate(SerializedProperty prop)
+        {
+            if (prop.type == "bool")
+            {
+                return prop.boolValue;
+            }
+            else if (prop.type == "int")
+            {
+                return prop.intValue > 0;
+            }
+            else if (prop.type == "float")
+            {
+                return prop.floatValue > 0f;
+            }
+            else if (prop.type.StartsWith("PPtr"))
+            {
+                return prop.objectReferenceValue != null;
+            }
+            else
+            {
+                Debug.LogError($"PredicatedFieldAttributePropertyDrawer - property type not implemented yet: {prop.type}.", prop.serializedObject.targetObject);
+                return true;
+            }
+        }
+    }
+#endif
+}

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/PredicatedFieldAttribute.cs.meta
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/PredicatedFieldAttribute.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d4ba201b4d406be4da146f0520e5718f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsAnimatedWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsAnimatedWaves.cs
@@ -24,7 +24,8 @@ namespace Crest
         CollisionSources _collisionSource = CollisionSources.ComputeShaderQueries;
         public CollisionSources CollisionSource { get { return _collisionSource; } }
 
-        [Tooltip("Maximum number of wave queries that can be performed when using ComputeShaderQueries."), SerializeField]
+        [Tooltip("Maximum number of wave queries that can be performed when using ComputeShaderQueries.")]
+        [PredicatedField("_collisionSource", true, (int)CollisionSources.ComputeShaderQueries), SerializeField]
         int _maxQueryCount = QueryBase.MAX_QUERY_COUNT_DEFAULT;
         public int MaxQueryCount { get { return _maxQueryCount; } }
 

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -90,7 +90,8 @@ namespace Crest
 
         [Tooltip("The primary directional light. Required if shadowing is enabled.")]
         public Light _primaryLight;
-        [SerializeField, Tooltip("If Primary Light is not set, search the scene for all directional lights and pick the brightest to use as the sun light.")]
+        [Tooltip("If Primary Light is not set, search the scene for all directional lights and pick the brightest to use as the sun light.")]
+        [SerializeField, PredicatedField("_primaryLight", true)]
         bool _searchForPrimaryLightOnStartup = true;
 
         [Header("Ocean Params")]
@@ -146,21 +147,25 @@ namespace Crest
         [Tooltip("Simulation of foam created in choppy water and dissipating over time."), SerializeField]
         bool _createFoamSim = true;
         public bool CreateFoamSim { get { return _createFoamSim; } }
+        [PredicatedField("_createFoamSim")]
         public SimSettingsFoam _simSettingsFoam;
 
         [Tooltip("Dynamic waves generated from interactions with objects such as boats."), SerializeField]
         bool _createDynamicWaveSim = false;
         public bool CreateDynamicWaveSim { get { return _createDynamicWaveSim; } }
+        [PredicatedField("_createDynamicWaveSim")]
         public SimSettingsWave _simSettingsDynamicWaves;
 
         [Tooltip("Horizontal motion of water body, akin to water currents."), SerializeField]
         bool _createFlowSim = false;
         public bool CreateFlowSim { get { return _createFlowSim; } }
+        [PredicatedField("_createFlowSim")]
         public SimSettingsFlow _simSettingsFlow;
 
         [Tooltip("Shadow information used for lighting water."), SerializeField]
         bool _createShadowData = false;
         public bool CreateShadowData { get { return _createShadowData; } }
+        [PredicatedField("_createShadowData")]
         public SimSettingsShadow _simSettingsShadow;
 
         [Tooltip("Clip surface information for clipping the ocean surface."), SerializeField]
@@ -183,7 +188,7 @@ namespace Crest
         float _editModeFPS = 30f;
 #pragma warning restore 414
 
-        [Tooltip("Move ocean with Scene view camera if Scene window is focused."), SerializeField]
+        [Tooltip("Move ocean with Scene view camera if Scene window is focused."), SerializeField, PredicatedField("_showOceanProxyPlane", true)]
 #pragma warning disable 414
         bool _followSceneCamera = true;
 #pragma warning restore 414
@@ -890,7 +895,7 @@ namespace Crest
                     ValidatedHelper.MessageType.Error, ocean
                 );
 
-                isValid =  false;
+                isValid = false;
             }
 
             // OceanRenderer

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
@@ -102,9 +102,13 @@ namespace Crest
         // Data for all components
         [Header("Wave data (usually populated at runtime)")]
         public bool _evaluateSpectrumAtRuntime = true;
+        [PredicatedField("_evaluateSpectrumAtRuntime", true)]
         public float[] _wavelengths;
+        [PredicatedField("_evaluateSpectrumAtRuntime", true)]
         public float[] _amplitudes;
+        [PredicatedField("_evaluateSpectrumAtRuntime", true)]
         public float[] _angleDegs;
+        [PredicatedField("_evaluateSpectrumAtRuntime", true)]
         public float[] _phases;
 
         [SerializeField, Tooltip("Make waves converge towards a point. Must be set at edit time only, applied on startup."), Header("Direct towards point")]


### PR DESCRIPTION
**Status**: Ready to merge

Thought i'd try a fun experiment - give a easy way to enable/disable GUI fields based on other fields. Example:

![image](https://user-images.githubusercontent.com/939901/84578552-3f8fc680-adbe-11ea-98ce-65affecd525f.png)

Here the 'search..' option is disabled because a Light is provided in the reference field above it (so no search will be done).

I find this kind of behaviour useful to know what parameters are active, and to help understand how a system works.

Issue: When multiple property drawers are provided, only the first one takes effect. Unforunately this means this feature can not be used in conjunction with another drawn attribute like `Range()`.

Let me know what you guys think.