### PR TITLE
Un-monobehaviour compute query system

### DIFF
--- a/crest/Assets/Crest/Crest-Examples/BoatDev/Scripts/BoatAlignNormal.cs
+++ b/crest/Assets/Crest/Crest-Examples/BoatDev/Scripts/BoatAlignNormal.cs
@@ -96,14 +96,13 @@ public class BoatAlignNormal : FloatingObjectBase
         // height = base sea level + surface displacement y
         height += _displacementToObject.y;
 
-        //if (QueryFlow.Instance)
-        //{
-        //    _sampleFlowHelper.Init(transform.position, _boatWidth);
+        {
+            _sampleFlowHelper.Init(transform.position, _boatWidth);
 
-        //    Vector2 surfaceFlow = Vector2.zero;
-        //    _sampleFlowHelper.Sample(ref surfaceFlow);
-        //    waterSurfaceVel += new Vector3(surfaceFlow.x, 0, surfaceFlow.y);
-        //}
+            Vector2 surfaceFlow = Vector2.zero;
+            _sampleFlowHelper.Sample(ref surfaceFlow);
+            waterSurfaceVel += new Vector3(surfaceFlow.x, 0, surfaceFlow.y);
+        }
 
         // I could filter the surface vel as the min of the last 2 frames. theres a hard case where a wavelength is turned on/off
         // which generates single frame vel spikes - because the surface legitimately moves very fast.

--- a/crest/Assets/Crest/Crest-Examples/BoatDev/Scripts/BoatAlignNormal.cs
+++ b/crest/Assets/Crest/Crest-Examples/BoatDev/Scripts/BoatAlignNormal.cs
@@ -96,14 +96,14 @@ public class BoatAlignNormal : FloatingObjectBase
         // height = base sea level + surface displacement y
         height += _displacementToObject.y;
 
-        if (QueryFlow.Instance)
-        {
-            _sampleFlowHelper.Init(transform.position, _boatWidth);
+        //if (QueryFlow.Instance)
+        //{
+        //    _sampleFlowHelper.Init(transform.position, _boatWidth);
 
-            Vector2 surfaceFlow = Vector2.zero;
-            _sampleFlowHelper.Sample(ref surfaceFlow);
-            waterSurfaceVel += new Vector3(surfaceFlow.x, 0, surfaceFlow.y);
-        }
+        //    Vector2 surfaceFlow = Vector2.zero;
+        //    _sampleFlowHelper.Sample(ref surfaceFlow);
+        //    waterSurfaceVel += new Vector3(surfaceFlow.x, 0, surfaceFlow.y);
+        //}
 
         // I could filter the surface vel as the min of the last 2 frames. theres a hard case where a wavelength is turned on/off
         // which generates single frame vel spikes - because the surface legitimately moves very fast.

--- a/crest/Assets/Crest/Crest/Scripts/Collision/CollProvider.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Collision/CollProvider.cs
@@ -38,6 +38,14 @@ namespace Crest
         /// </summary>
         bool RetrieveSucceeded(int queryStatus);
 
+        /// <summary>
+        /// Per frame update callback
+        /// </summary>
+        void UpdateQueries();
+
+        /// <summary>
+        /// On destroy, to cleanup resources
+        /// </summary>
         void CleanUp();
     }
 }

--- a/crest/Assets/Crest/Crest/Scripts/Collision/CollProvider.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Collision/CollProvider.cs
@@ -37,5 +37,7 @@ namespace Crest
         /// Check if query results could be retrieved successfully using return code from Query() function
         /// </summary>
         bool RetrieveSucceeded(int queryStatus);
+
+        void CleanUp();
     }
 }

--- a/crest/Assets/Crest/Crest/Scripts/Collision/CollProviderNull.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Collision/CollProviderNull.cs
@@ -74,6 +74,10 @@ namespace Crest
             return true;
         }
 
+        public void UpdateQueries()
+        {
+        }
+
         public void CleanUp()
         {
         }

--- a/crest/Assets/Crest/Crest/Scripts/Collision/CollProviderNull.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Collision/CollProviderNull.cs
@@ -74,6 +74,10 @@ namespace Crest
             return true;
         }
 
+        public void CleanUp()
+        {
+        }
+
         public readonly static CollProviderNull Instance = new CollProviderNull();
     }
 }

--- a/crest/Assets/Crest/Crest/Scripts/Collision/FlowProvider.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Collision/FlowProvider.cs
@@ -1,0 +1,38 @@
+﻿// Crest Ocean System
+
+// This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
+
+using UnityEngine;
+
+namespace Crest
+{
+    /// <summary>
+    /// Interface for an object that returns ocean surface displacement and height.
+    /// </summary>
+    public interface IFlowProvider
+    {
+        /// <summary>
+        /// Query water flow data (horizontal motion) at a set of points.
+        /// </summary>
+        /// <param name="i_ownerHash">Unique ID for calling code. Typically acquired by calling GetHashCode().</param>
+        /// <param name="i_minSpatialLength">The min spatial length of the object, such as the width of a boat. Useful for filtering out detail when not needed. Set to 0 to get full available detail.</param>
+        /// <param name="i_queryPoints">The world space points that will be queried.</param>
+        /// <param name="o_resultVels">Water surface flow velocities at the query positions.</param>
+        int Query(int i_ownerHash, float i_minSpatialLength, Vector3[] i_queryPoints, Vector3[] o_resultFlows);
+
+        /// <summary>
+        /// Check if query results could be retrieved successfully using return code from Query() function
+        /// </summary>
+        bool RetrieveSucceeded(int queryStatus);
+
+        /// <summary>
+        /// Per frame update callback
+        /// </summary>
+        void UpdateQueries();
+
+        /// <summary>
+        /// On destroy, to cleanup resources
+        /// </summary>
+        void CleanUp();
+    }
+}

--- a/crest/Assets/Crest/Crest/Scripts/Collision/FlowProvider.cs.meta
+++ b/crest/Assets/Crest/Crest/Scripts/Collision/FlowProvider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 17401218df04cdc4baa28fb05d60a018
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/crest/Assets/Crest/Crest/Scripts/Collision/FlowProviderNull.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Collision/FlowProviderNull.cs
@@ -1,0 +1,42 @@
+﻿// Crest Ocean System
+
+// This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
+
+using UnityEngine;
+
+namespace Crest
+{
+    /// <summary>
+    /// Gives a stationary ocean (no horizontal flow).
+    /// </summary>
+    public class FlowProviderNull : IFlowProvider
+    {
+        public int Query(int i_ownerHash, float i_minSpatialLength, Vector3[] i_queryPoints, Vector3[] o_resultFlows)
+        {
+            if (o_resultFlows != null)
+            {
+                for (int i = 0; i < o_resultFlows.Length; i++)
+                {
+                    o_resultFlows[i] = Vector3.zero;
+                }
+            }
+
+            return 0;
+        }
+
+        public bool RetrieveSucceeded(int queryStatus)
+        {
+            return true;
+        }
+
+        public void UpdateQueries()
+        {
+        }
+
+        public void CleanUp()
+        {
+        }
+
+        public readonly static CollProviderNull Instance = new CollProviderNull();
+    }
+}

--- a/crest/Assets/Crest/Crest/Scripts/Collision/FlowProviderNull.cs.meta
+++ b/crest/Assets/Crest/Crest/Scripts/Collision/FlowProviderNull.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e0543fd894ee3f34da68cf3d18633339
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/crest/Assets/Crest/Crest/Scripts/Collision/QueryBase.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Collision/QueryBase.cs
@@ -18,7 +18,7 @@ namespace Crest
     /// the data and then transferring back the results asynchronously. An exception to this is water surface velocities - these can
     /// not be computed on the GPU and are instead computed on the CPU by retaining last frames' query results and computing finite diffs.
     /// </summary>
-    public abstract class QueryBase : MonoBehaviour
+    public abstract class QueryBase
     {
         protected int _kernelHandle;
 
@@ -179,6 +179,11 @@ namespace Crest
             InvalidDtForVelocity = 16,
         }
 
+        public QueryBase()
+        {
+            OnEnable();
+        }
+
         protected abstract void BindInputsAndOutputs(PropertyWrapperComputeStandalone wrapper, ComputeBuffer resultsBuffer);
 
         /// <summary>
@@ -218,7 +223,7 @@ namespace Crest
             {
                 if (_segmentRegistrarRingBuffer.Current._segments.Count >= s_maxGuids)
                 {
-                    Debug.LogError("Too many guids registered with CollProviderCompute. Increase s_maxGuids.", this);
+                    Debug.LogError("Too many guids registered with CollProviderCompute. Increase s_maxGuids.");
                     return false;
                 }
 
@@ -238,7 +243,7 @@ namespace Crest
 
             if (countPts + segment.x > _queryPosXZ_minGridSize.Length)
             {
-                Debug.LogError("Too many wave height queries. Increase Max Query Count in the Animated Waves Settings.", this);
+                Debug.LogError("Too many wave height queries. Increase Max Query Count in the Animated Waves Settings.");
                 return false;
             }
 
@@ -500,14 +505,14 @@ namespace Crest
             _shaderProcessQueries = ComputeShaderHelpers.LoadShader(QueryShaderName);
             if (_shaderProcessQueries == null)
             {
-                enabled = false;
+                Debug.LogError($"Could not load Query compute shader {QueryShaderName}");
                 return;
             }
             _kernelHandle = _shaderProcessQueries.FindKernel(QueryKernelName);
             _wrapper = new PropertyWrapperComputeStandalone(_shaderProcessQueries, _kernelHandle);
         }
 
-        protected virtual void OnDisable()
+        public void CleanUp()
         {
             _computeBufQueries.Dispose();
             _computeBufResults.Dispose();

--- a/crest/Assets/Crest/Crest/Scripts/Collision/QueryDisplacements.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Collision/QueryDisplacements.cs
@@ -17,23 +17,6 @@ namespace Crest
         protected override string QueryShaderName => "QueryDisplacements";
         protected override string QueryKernelName => "CSMain";
 
-        //public static QueryDisplacements Instance { get; private set; }
-
-        //protected override void OnEnable()
-        //{
-        //    Instance = this;
-
-        //    base.OnEnable();
-        //}
-
-        //protected override void OnDisable()
-        //{
-        //    // We don't set Instance to null here because it breaks exiting play mode, as OnDisable is called but no matching call to OnEnable :/.
-        //    // This would probably be better if the Query system did not inherit from MonoBehaviour and was built up by the OceanRenderer..
-
-        //    base.OnDisable();
-        //}
-
         protected override void BindInputsAndOutputs(PropertyWrapperComputeStandalone wrapper, ComputeBuffer resultsBuffer)
         {
             OceanRenderer.Instance._lodDataAnimWaves.BindResultData(wrapper);
@@ -62,14 +45,5 @@ namespace Crest
 
             return result;
         }
-
-//#if UNITY_2019_3_OR_NEWER
-//        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
-//#endif
-//        static void InitStatics()
-//        {
-//            // Init here from 2019.3 onwards
-//            Instance = null;
-//        }
     }
 }

--- a/crest/Assets/Crest/Crest/Scripts/Collision/QueryDisplacements.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Collision/QueryDisplacements.cs
@@ -17,22 +17,22 @@ namespace Crest
         protected override string QueryShaderName => "QueryDisplacements";
         protected override string QueryKernelName => "CSMain";
 
-        public static QueryDisplacements Instance { get; private set; }
+        //public static QueryDisplacements Instance { get; private set; }
 
-        protected override void OnEnable()
-        {
-            Instance = this;
+        //protected override void OnEnable()
+        //{
+        //    Instance = this;
 
-            base.OnEnable();
-        }
+        //    base.OnEnable();
+        //}
 
-        protected override void OnDisable()
-        {
-            // We don't set Instance to null here because it breaks exiting play mode, as OnDisable is called but no matching call to OnEnable :/.
-            // This would probably be better if the Query system did not inherit from MonoBehaviour and was built up by the OceanRenderer..
+        //protected override void OnDisable()
+        //{
+        //    // We don't set Instance to null here because it breaks exiting play mode, as OnDisable is called but no matching call to OnEnable :/.
+        //    // This would probably be better if the Query system did not inherit from MonoBehaviour and was built up by the OceanRenderer..
 
-            base.OnDisable();
-        }
+        //    base.OnDisable();
+        //}
 
         protected override void BindInputsAndOutputs(PropertyWrapperComputeStandalone wrapper, ComputeBuffer resultsBuffer)
         {
@@ -63,13 +63,13 @@ namespace Crest
             return result;
         }
 
-#if UNITY_2019_3_OR_NEWER
-        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
-#endif
-        static void InitStatics()
-        {
-            // Init here from 2019.3 onwards
-            Instance = null;
-        }
+//#if UNITY_2019_3_OR_NEWER
+//        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+//#endif
+//        static void InitStatics()
+//        {
+//            // Init here from 2019.3 onwards
+//            Instance = null;
+//        }
     }
 }

--- a/crest/Assets/Crest/Crest/Scripts/Collision/QueryFlow.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Collision/QueryFlow.cs
@@ -17,23 +17,6 @@ namespace Crest
         protected override string QueryShaderName => "QueryFlow";
         protected override string QueryKernelName => "CSMain";
 
-        public static QueryFlow Instance { get; private set; }
-
-        protected override void OnEnable()
-        {
-            Instance = this;
-
-            base.OnEnable();
-        }
-
-        //protected override void OnDisable()
-        //{
-        //    // We don't set Instance to null here because it breaks exiting play mode, as OnDisable is called but no matching call to OnEnable :/.
-        //    // This would probably be better if the Query system did not inherit from MonoBehaviour and was built up by the OceanRenderer..
-
-        //    base.OnDisable();
-        //}
-
         protected override void BindInputsAndOutputs(PropertyWrapperComputeStandalone wrapper, ComputeBuffer resultsBuffer)
         {
             if (OceanRenderer.Instance._lodDataFlow != null)
@@ -47,15 +30,6 @@ namespace Crest
         public int Query(int i_ownerHash, float i_minSpatialLength, Vector3[] i_queryPoints, Vector3[] o_resultFlows)
         {
             return Query(i_ownerHash, i_minSpatialLength, i_queryPoints, o_resultFlows, null, null);
-        }
-
-#if UNITY_2019_3_OR_NEWER
-        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
-#endif
-        static void InitStatics()
-        {
-            // Init here from 2019.3 onwards
-            Instance = null;
         }
     }
 }

--- a/crest/Assets/Crest/Crest/Scripts/Collision/QueryFlow.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Collision/QueryFlow.cs
@@ -9,7 +9,7 @@ namespace Crest
     /// <summary>
     /// Samples horizontal motion of water volume
     /// </summary>
-    public class QueryFlow : QueryBase
+    public class QueryFlow : QueryBase, IFlowProvider
     {
         readonly int sp_LD_TexArray_Flow = Shader.PropertyToID("_LD_TexArray_Flow");
         readonly int sp_ResultFlows = Shader.PropertyToID("_ResultFlows");

--- a/crest/Assets/Crest/Crest/Scripts/Collision/QueryFlow.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Collision/QueryFlow.cs
@@ -24,6 +24,11 @@ namespace Crest
                 OceanRenderer.Instance._lodDataFlow.BindResultData(wrapper);
                 ShaderProcessQueries.SetTexture(_kernelHandle, sp_LD_TexArray_Flow, OceanRenderer.Instance._lodDataFlow.DataTexture);
             }
+            else
+            {
+                LodDataMgrFlow.BindNull(wrapper);
+            }
+
             ShaderProcessQueries.SetBuffer(_kernelHandle, sp_ResultFlows, resultsBuffer);
         }
 

--- a/crest/Assets/Crest/Crest/Scripts/Collision/QueryFlow.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Collision/QueryFlow.cs
@@ -26,13 +26,13 @@ namespace Crest
             base.OnEnable();
         }
 
-        protected override void OnDisable()
-        {
-            // We don't set Instance to null here because it breaks exiting play mode, as OnDisable is called but no matching call to OnEnable :/.
-            // This would probably be better if the Query system did not inherit from MonoBehaviour and was built up by the OceanRenderer..
+        //protected override void OnDisable()
+        //{
+        //    // We don't set Instance to null here because it breaks exiting play mode, as OnDisable is called but no matching call to OnEnable :/.
+        //    // This would probably be better if the Query system did not inherit from MonoBehaviour and was built up by the OceanRenderer..
 
-            base.OnDisable();
-        }
+        //    base.OnDisable();
+        //}
 
         protected override void BindInputsAndOutputs(PropertyWrapperComputeStandalone wrapper, ComputeBuffer resultsBuffer)
         {

--- a/crest/Assets/Crest/Crest/Scripts/Collision/SamplingHelpers.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Collision/SamplingHelpers.cs
@@ -145,18 +145,19 @@ namespace Crest
         /// </summary>
         public bool Sample(ref Vector2 o_flow)
         {
-            if (QueryFlow.Instance == null) return false;
+            // TODO
+            //if (QueryFlow.Instance == null) return false;
 
-            var status = QueryFlow.Instance.Query(GetHashCode(), _minLength, _queryPos, _queryResult);
+            //var status = QueryFlow.Instance.Query(GetHashCode(), _minLength, _queryPos, _queryResult);
 
-            if (!QueryFlow.Instance.RetrieveSucceeded(status))
-            {
-                return false;
-            }
+            //if (!QueryFlow.Instance.RetrieveSucceeded(status))
+            //{
+            //    return false;
+            //}
 
-            // We don't support float2 queries unfortunately, so unpack from float3
-            o_flow.x = _queryResult[0].x;
-            o_flow.y = _queryResult[0].z;
+            //// We don't support float2 queries unfortunately, so unpack from float3
+            //o_flow.x = _queryResult[0].x;
+            //o_flow.y = _queryResult[0].z;
 
             return true;
         }

--- a/crest/Assets/Crest/Crest/Scripts/Collision/SamplingHelpers.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Collision/SamplingHelpers.cs
@@ -145,19 +145,18 @@ namespace Crest
         /// </summary>
         public bool Sample(ref Vector2 o_flow)
         {
-            // TODO
-            //if (QueryFlow.Instance == null) return false;
+            var flowProvider = OceanRenderer.Instance?.FlowProvider;
+            if (flowProvider == null) return false;
+            var status = flowProvider.Query(GetHashCode(), _minLength, _queryPos, _queryResult);
 
-            //var status = QueryFlow.Instance.Query(GetHashCode(), _minLength, _queryPos, _queryResult);
+            if (!flowProvider.RetrieveSucceeded(status))
+            {
+                return false;
+            }
 
-            //if (!QueryFlow.Instance.RetrieveSucceeded(status))
-            //{
-            //    return false;
-            //}
-
-            //// We don't support float2 queries unfortunately, so unpack from float3
-            //o_flow.x = _queryResult[0].x;
-            //o_flow.y = _queryResult[0].z;
+            // We don't support float2 queries unfortunately, so unpack from float3
+            o_flow.x = _queryResult[0].x;
+            o_flow.y = _queryResult[0].z;
 
             return true;
         }

--- a/crest/Assets/Crest/Crest/Scripts/Interaction/BoatProbes.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Interaction/BoatProbes.cs
@@ -114,14 +114,12 @@ namespace Crest
 
             var waterSurfaceVel = _queryResultVels[_forcePoints.Length];
 
-            //// TODO
-            //if(QueryFlow.Instance)
-            //{
-            //    _sampleFlowHelper.Init(transform.position, _minSpatialLength);
-            //    Vector2 surfaceFlow = Vector2.zero;
-            //    _sampleFlowHelper.Sample(ref surfaceFlow);
-            //    waterSurfaceVel += new Vector3(surfaceFlow.x, 0, surfaceFlow.y);
-            //}
+            {
+                _sampleFlowHelper.Init(transform.position, _minSpatialLength);
+                Vector2 surfaceFlow = Vector2.zero;
+                _sampleFlowHelper.Sample(ref surfaceFlow);
+                waterSurfaceVel += new Vector3(surfaceFlow.x, 0, surfaceFlow.y);
+            }
 
             // Buoyancy
             FixedUpdateBuoyancy(collProvider);

--- a/crest/Assets/Crest/Crest/Scripts/Interaction/BoatProbes.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Interaction/BoatProbes.cs
@@ -114,13 +114,14 @@ namespace Crest
 
             var waterSurfaceVel = _queryResultVels[_forcePoints.Length];
 
-            if(QueryFlow.Instance)
-            {
-                _sampleFlowHelper.Init(transform.position, _minSpatialLength);
-                Vector2 surfaceFlow = Vector2.zero;
-                _sampleFlowHelper.Sample(ref surfaceFlow);
-                waterSurfaceVel += new Vector3(surfaceFlow.x, 0, surfaceFlow.y);
-            }
+            //// TODO
+            //if(QueryFlow.Instance)
+            //{
+            //    _sampleFlowHelper.Init(transform.position, _minSpatialLength);
+            //    Vector2 surfaceFlow = Vector2.zero;
+            //    _sampleFlowHelper.Sample(ref surfaceFlow);
+            //    waterSurfaceVel += new Vector3(surfaceFlow.x, 0, surfaceFlow.y);
+            //}
 
             // Buoyancy
             FixedUpdateBuoyancy(collProvider);
@@ -193,14 +194,6 @@ namespace Crest
 
                 Gizmos.color = Color.red;
                 Gizmos.DrawCube(transformedPoint, Vector3.one * 0.5f);
-            }
-        }
-
-        private void OnDisable()
-        {
-            if (QueryDisplacements.Instance)
-            {
-                QueryDisplacements.Instance.RemoveQueryPoints(GetHashCode());
             }
         }
     }

--- a/crest/Assets/Crest/Crest/Scripts/Interaction/ObjectWaterInteraction.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Interaction/ObjectWaterInteraction.cs
@@ -126,13 +126,14 @@ namespace Crest
                 vel = Vector3.zero;
             }
 
-            if (QueryFlow.Instance)
-            {
-                _sampleFlowHelper.Init(transform.position, _boat.ObjectWidth);
-                Vector2 surfaceFlow = Vector2.zero;
-                _sampleFlowHelper.Sample(ref surfaceFlow);
-                vel -= new Vector3(surfaceFlow.x, 0, surfaceFlow.y);
-            }
+            // TODO
+            //if (QueryFlow.Instance)
+            //{
+            //    _sampleFlowHelper.Init(transform.position, _boat.ObjectWidth);
+            //    Vector2 surfaceFlow = Vector2.zero;
+            //    _sampleFlowHelper.Sample(ref surfaceFlow);
+            //    vel -= new Vector3(surfaceFlow.x, 0, surfaceFlow.y);
+            //}
             vel.y *= _weightUpDownMul;
 
             var speedKmh = vel.magnitude * 3.6f;

--- a/crest/Assets/Crest/Crest/Scripts/Interaction/ObjectWaterInteraction.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Interaction/ObjectWaterInteraction.cs
@@ -116,14 +116,12 @@ namespace Crest
                 vel = Vector3.zero;
             }
 
-            // TODO
-            //if (QueryFlow.Instance)
-            //{
-            //    _sampleFlowHelper.Init(transform.position, _boat.ObjectWidth);
-            //    Vector2 surfaceFlow = Vector2.zero;
-            //    _sampleFlowHelper.Sample(ref surfaceFlow);
-            //    vel -= new Vector3(surfaceFlow.x, 0, surfaceFlow.y);
-            //}
+            {
+                _sampleFlowHelper.Init(transform.position, _boat.ObjectWidth);
+                Vector2 surfaceFlow = Vector2.zero;
+                _sampleFlowHelper.Sample(ref surfaceFlow);
+                vel -= new Vector3(surfaceFlow.x, 0, surfaceFlow.y);
+            }
             vel.y *= _weightUpDownMul;
 
             var speedKmh = vel.magnitude * 3.6f;

--- a/crest/Assets/Crest/Crest/Scripts/Interaction/SimpleFloatingObject.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Interaction/SimpleFloatingObject.cs
@@ -82,14 +82,15 @@ namespace Crest
 
             if (_debugDraw) VisualiseCollisionArea.DebugDrawCross(undispPos, 1f, Color.red);
 
-            if (QueryFlow.Instance)
-            {
-                _sampleFlowHelper.Init(transform.position, ObjectWidth);
+            // TODO
+            //if (QueryFlow.Instance)
+            //{
+            //    _sampleFlowHelper.Init(transform.position, ObjectWidth);
 
-                Vector2 surfaceFlow = Vector2.zero;
-                _sampleFlowHelper.Sample(ref surfaceFlow);
-                waterSurfaceVel += new Vector3(surfaceFlow.x, 0, surfaceFlow.y);
-            }
+            //    Vector2 surfaceFlow = Vector2.zero;
+            //    _sampleFlowHelper.Sample(ref surfaceFlow);
+            //    waterSurfaceVel += new Vector3(surfaceFlow.x, 0, surfaceFlow.y);
+            //}
 
             if (_debugDraw)
             {

--- a/crest/Assets/Crest/Crest/Scripts/Interaction/SimpleFloatingObject.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Interaction/SimpleFloatingObject.cs
@@ -82,15 +82,13 @@ namespace Crest
 
             if (_debugDraw) VisualiseCollisionArea.DebugDrawCross(undispPos, 1f, Color.red);
 
-            // TODO
-            //if (QueryFlow.Instance)
-            //{
-            //    _sampleFlowHelper.Init(transform.position, ObjectWidth);
+            {
+                _sampleFlowHelper.Init(transform.position, ObjectWidth);
 
-            //    Vector2 surfaceFlow = Vector2.zero;
-            //    _sampleFlowHelper.Sample(ref surfaceFlow);
-            //    waterSurfaceVel += new Vector3(surfaceFlow.x, 0, surfaceFlow.y);
-            //}
+                Vector2 surfaceFlow = Vector2.zero;
+                _sampleFlowHelper.Sample(ref surfaceFlow);
+                waterSurfaceVel += new Vector3(surfaceFlow.x, 0, surfaceFlow.y);
+            }
 
             if (_debugDraw)
             {

--- a/crest/Assets/Crest/Crest/Scripts/Interaction/SphereWaterInteraction.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Interaction/SphereWaterInteraction.cs
@@ -189,13 +189,14 @@ namespace Crest
                 vel = Vector3.zero;
             }
 
-            if (QueryFlow.Instance)
-            {
-                _sampleFlowHelper.Init(transform.position, _object.ObjectWidth);
-                Vector2 surfaceFlow = Vector2.zero;
-                _sampleFlowHelper.Sample(ref surfaceFlow);
-                vel -= new Vector3(surfaceFlow.x, 0, surfaceFlow.y);
-            }
+            // TODO
+            //if (QueryFlow.Instance)
+            //{
+            //    _sampleFlowHelper.Init(transform.position, _object.ObjectWidth);
+            //    Vector2 surfaceFlow = Vector2.zero;
+            //    _sampleFlowHelper.Sample(ref surfaceFlow);
+            //    vel -= new Vector3(surfaceFlow.x, 0, surfaceFlow.y);
+            //}
             vel.y *= _weightUpDownMul;
 
             var speedKmh = vel.magnitude * 3.6f;

--- a/crest/Assets/Crest/Crest/Scripts/Interaction/SphereWaterInteraction.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Interaction/SphereWaterInteraction.cs
@@ -179,14 +179,12 @@ namespace Crest
                 vel = Vector3.zero;
             }
 
-            // TODO
-            //if (QueryFlow.Instance)
-            //{
-            //    _sampleFlowHelper.Init(transform.position, _object.ObjectWidth);
-            //    Vector2 surfaceFlow = Vector2.zero;
-            //    _sampleFlowHelper.Sample(ref surfaceFlow);
-            //    vel -= new Vector3(surfaceFlow.x, 0, surfaceFlow.y);
-            //}
+            {
+                _sampleFlowHelper.Init(transform.position, _object.ObjectWidth);
+                Vector2 surfaceFlow = Vector2.zero;
+                _sampleFlowHelper.Sample(ref surfaceFlow);
+                vel -= new Vector3(surfaceFlow.x, 0, surfaceFlow.y);
+            }
             vel.y *= _weightUpDownMul;
 
             var speedKmh = vel.magnitude * 3.6f;

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsAnimatedWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsAnimatedWaves.cs
@@ -61,10 +61,10 @@ namespace Crest
             return result;
         }
 
-        public IFlowProvider CreateFlowProvider()
+        public IFlowProvider CreateFlowProvider(OceanRenderer ocean)
         {
             // Flow is GPU only, and can only be queried using the compute path
-            if (_collisionSource == CollisionSources.ComputeShaderQueries)
+            if (ocean._lodDataFlow != null)
             {
                 return new QueryFlow();
             }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsAnimatedWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsAnimatedWaves.cs
@@ -44,7 +44,7 @@ namespace Crest
                     result = FindObjectOfType<ShapeGerstnerBatched>();
                     break;
                 case CollisionSources.ComputeShaderQueries:
-                    result = QueryDisplacements.Instance;
+                    result = new QueryDisplacements();
                     break;
             }
 

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsAnimatedWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsAnimatedWaves.cs
@@ -60,6 +60,17 @@ namespace Crest
 
             return result;
         }
+
+        public IFlowProvider CreateFlowProvider()
+        {
+            // Flow is GPU only, and can only be queried using the compute path
+            if (_collisionSource == CollisionSources.ComputeShaderQueries)
+            {
+                return new QueryFlow();
+            }
+
+            return new FlowProviderNull();
+        }
     }
 
 #if UNITY_EDITOR

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -316,6 +316,8 @@ namespace Crest
 
             CreateDestroyLodDatas();
 
+            _collProvider = _lodDataAnimWaves.Settings.CreateCollisionProvider();
+
             //// Add any required GPU readbacks
             //{
             //    if (_lodDataAnimWaves.Settings.CollisionSource == SimSettingsAnimatedWaves.CollisionSources.ComputeShaderQueries && gameObject.GetComponent<QueryDisplacements>() == null)
@@ -578,6 +580,9 @@ namespace Crest
 
         void RunUpdate()
         {
+            // Do this *before* changing the ocean position, as it needs the current LOD positions to associate with the current queries
+            _collProvider.UpdateQueries();
+
             // set global shader params
             Shader.SetGlobalFloat(sp_texelsPerWave, MinTexelsPerWave);
             Shader.SetGlobalFloat(sp_crestTime, CurrentTime);
@@ -746,8 +751,6 @@ namespace Crest
         {
             get
             {
-                if (_collProvider != null) return _collProvider;
-                _collProvider = _lodDataAnimWaves?.Settings?.CreateCollisionProvider();
                 return _collProvider;
             }
         }

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -311,18 +311,18 @@ namespace Crest
 
             CreateDestroyLodDatas();
 
-            // Add any required GPU readbacks
-            {
-                if (_lodDataAnimWaves.Settings.CollisionSource == SimSettingsAnimatedWaves.CollisionSources.ComputeShaderQueries && gameObject.GetComponent<QueryDisplacements>() == null)
-                {
-                    gameObject.AddComponent<QueryDisplacements>().hideFlags = HideFlags.DontSave;
-                }
+            //// Add any required GPU readbacks
+            //{
+            //    if (_lodDataAnimWaves.Settings.CollisionSource == SimSettingsAnimatedWaves.CollisionSources.ComputeShaderQueries && gameObject.GetComponent<QueryDisplacements>() == null)
+            //    {
+            //        gameObject.AddComponent<QueryDisplacements>().hideFlags = HideFlags.DontSave;
+            //    }
 
-                if (CreateFlowSim && gameObject.GetComponent<QueryFlow>() == null)
-                {
-                    gameObject.AddComponent<QueryFlow>().hideFlags = HideFlags.DontSave;
-                }
-            }
+            //    if (CreateFlowSim && gameObject.GetComponent<QueryFlow>() == null)
+            //    {
+            //        gameObject.AddComponent<QueryFlow>().hideFlags = HideFlags.DontSave;
+            //    }
+            //}
 
             _commandbufferBuilder = new BuildCommandBuffer();
 
@@ -777,6 +777,9 @@ namespace Crest
             _lodDataFoam = null;
             _lodDataSeaDepths = null;
             _lodDataShadow = null;
+
+            _collProvider.CleanUp();
+            _collProvider = null;
         }
 
 #if UNITY_EDITOR

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -317,19 +317,7 @@ namespace Crest
             CreateDestroyLodDatas();
 
             CollisionProvider = _lodDataAnimWaves.Settings.CreateCollisionProvider();
-
-            //// Add any required GPU readbacks
-            //{
-            //    if (_lodDataAnimWaves.Settings.CollisionSource == SimSettingsAnimatedWaves.CollisionSources.ComputeShaderQueries && gameObject.GetComponent<QueryDisplacements>() == null)
-            //    {
-            //        gameObject.AddComponent<QueryDisplacements>().hideFlags = HideFlags.DontSave;
-            //    }
-
-            //    if (CreateFlowSim && gameObject.GetComponent<QueryFlow>() == null)
-            //    {
-            //        gameObject.AddComponent<QueryFlow>().hideFlags = HideFlags.DontSave;
-            //    }
-            //}
+            FlowProvider = _lodDataAnimWaves.Settings.CreateFlowProvider();
 
             _commandbufferBuilder = new BuildCommandBuffer();
 
@@ -582,6 +570,7 @@ namespace Crest
         {
             // Do this *before* changing the ocean position, as it needs the current LOD positions to associate with the current queries
             CollisionProvider.UpdateQueries();
+            FlowProvider.UpdateQueries();
 
             // set global shader params
             Shader.SetGlobalFloat(sp_texelsPerWave, MinTexelsPerWave);
@@ -746,6 +735,7 @@ namespace Crest
         /// Provides ocean shape to CPU.
         /// </summary>
         public ICollProvider CollisionProvider { get; private set; }
+        public IFlowProvider FlowProvider { get; private set; }
 
         private void CleanUp()
         {
@@ -780,6 +770,9 @@ namespace Crest
 
             CollisionProvider.CleanUp();
             CollisionProvider = null;
+
+            FlowProvider.CleanUp();
+            FlowProvider = null;
         }
 
 #if UNITY_EDITOR

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -316,7 +316,7 @@ namespace Crest
 
             CreateDestroyLodDatas();
 
-            _collProvider = _lodDataAnimWaves.Settings.CreateCollisionProvider();
+            CollisionProvider = _lodDataAnimWaves.Settings.CreateCollisionProvider();
 
             //// Add any required GPU readbacks
             //{
@@ -581,7 +581,7 @@ namespace Crest
         void RunUpdate()
         {
             // Do this *before* changing the ocean position, as it needs the current LOD positions to associate with the current queries
-            _collProvider.UpdateQueries();
+            CollisionProvider.UpdateQueries();
 
             // set global shader params
             Shader.SetGlobalFloat(sp_texelsPerWave, MinTexelsPerWave);
@@ -745,15 +745,7 @@ namespace Crest
         /// <summary>
         /// Provides ocean shape to CPU.
         /// </summary>
-        ICollProvider _collProvider;
-
-        public ICollProvider CollisionProvider
-        {
-            get
-            {
-                return _collProvider;
-            }
-        }
+        public ICollProvider CollisionProvider { get; private set; }
 
         private void CleanUp()
         {
@@ -786,8 +778,8 @@ namespace Crest
             _lodDataSeaDepths = null;
             _lodDataShadow = null;
 
-            _collProvider.CleanUp();
-            _collProvider = null;
+            CollisionProvider.CleanUp();
+            CollisionProvider = null;
         }
 
 #if UNITY_EDITOR

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -444,7 +444,7 @@ namespace Crest
                     _lodDatas.Add(_lodDataFlow);
                 }
 
-                if (!(FlowProvider is QueryFlow))
+                if (FlowProvider != null && !(FlowProvider is QueryFlow))
                 {
                     FlowProvider.CleanUp();
                     FlowProvider = null;
@@ -459,7 +459,7 @@ namespace Crest
                     _lodDataFlow = null;
                 }
 
-                if (FlowProvider is QueryFlow)
+                if (FlowProvider != null && FlowProvider is QueryFlow)
                 {
                     FlowProvider.CleanUp();
                     FlowProvider = null;

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -314,10 +314,7 @@ namespace Crest
 
             Root = OceanBuilder.GenerateMesh(this, _lodDataResolution, _geometryDownSampleFactor, _lodCount);
 
-            CreateDestroyLodDatas();
-
-            CollisionProvider = _lodDataAnimWaves.Settings.CreateCollisionProvider();
-            FlowProvider = _lodDataAnimWaves.Settings.CreateFlowProvider();
+            CreateDestroySubSystems();
 
             _commandbufferBuilder = new BuildCommandBuffer();
 
@@ -393,7 +390,7 @@ namespace Crest
             }
         }
 
-        void CreateDestroyLodDatas()
+        void CreateDestroySubSystems()
         {
             {
                 if (_lodDataAnimWaves == null)
@@ -446,6 +443,12 @@ namespace Crest
                     _lodDataFlow = new LodDataMgrFlow(this);
                     _lodDatas.Add(_lodDataFlow);
                 }
+
+                if (!(FlowProvider is QueryFlow))
+                {
+                    FlowProvider.CleanUp();
+                    FlowProvider = null;
+                }
             }
             else
             {
@@ -455,6 +458,16 @@ namespace Crest
                     _lodDatas.Remove(_lodDataFlow);
                     _lodDataFlow = null;
                 }
+
+                if (FlowProvider is QueryFlow)
+                {
+                    FlowProvider.CleanUp();
+                    FlowProvider = null;
+                }
+            }
+            if (FlowProvider == null)
+            {
+                FlowProvider = _lodDataAnimWaves.Settings.CreateFlowProvider(this);
             }
 
             if (CreateFoamSim)
@@ -509,6 +522,12 @@ namespace Crest
                     _lodDatas.Remove(_lodDataShadow);
                     _lodDataShadow = null;
                 }
+            }
+
+            // Potential extension - add 'type' field to collprovider and change provider if settings have changed - this would support runtime changes.
+            if (CollisionProvider == null)
+            {
+                CollisionProvider = _lodDataAnimWaves.Settings.CreateCollisionProvider();
             }
         }
 
@@ -603,7 +622,7 @@ namespace Crest
                 LateUpdateViewerHeight();
             }
 
-            CreateDestroyLodDatas();
+            CreateDestroySubSystems();
 
             LateUpdateLods();
 

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
@@ -784,6 +784,10 @@ namespace Crest
             return queryStatus == 0;
         }
 
+        public void UpdateQueries()
+        {
+        }
+
         public void CleanUp()
         {
         }

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
@@ -779,6 +779,10 @@ namespace Crest
         {
             return queryStatus == 0;
         }
+
+        public void CleanUp()
+        {
+        }
     }
 
 #if UNITY_EDITOR


### PR DESCRIPTION
**Status**: Ready to merge

This was something that I didn't get to as part of the ocean-in-edit-mode changes - making the query system standalone objects rather than monobehaviours, as there is no advantage to having them that way. Further i discovered that disabling scene reload broke the system, so i decided to move it away from behaviours now.

The resulting code in this PR is simpler, and more direct/explicit, and less stateful.

I'm not aware of any issues.

I tested in win64 editor and a standalone build.
