### PR TITLE
Bail early when ocean instance is null

### DIFF
--- a/crest/Assets/Crest/Crest-Examples/BoatDev/Scripts/LerpCam.cs
+++ b/crest/Assets/Crest/Crest-Examples/BoatDev/Scripts/LerpCam.cs
@@ -15,7 +15,10 @@ public class LerpCam : MonoBehaviour
 
     void Update()
     {
-        if (OceanRenderer.Instance == null) return;
+        if (OceanRenderer.Instance == null)
+        {
+            return;
+        }
 
         _sampleHeightHelper.Init(transform.position, 0f);
         float h = 0f;

--- a/crest/Assets/Crest/Crest-Examples/BoatDev/Scripts/RippleGenerator.cs
+++ b/crest/Assets/Crest/Crest-Examples/BoatDev/Scripts/RippleGenerator.cs
@@ -33,6 +33,11 @@ public class RippleGenerator : MonoBehaviour
 
     void Update()
     {
+        if (OceanRenderer.Instance == null)
+        {
+            return;
+        }
+
         if (_animate)
         {
             float t = OceanRenderer.Instance.CurrentTime;

--- a/crest/Assets/Crest/Crest-Examples/Shared/Scripts/Interaction/InteractCapsule.cs
+++ b/crest/Assets/Crest/Crest-Examples/Shared/Scripts/Interaction/InteractCapsule.cs
@@ -24,6 +24,11 @@ public class InteractCapsule : MonoBehaviour
 
     void Update()
     {
+        if (OceanRenderer.Instance == null)
+        {
+            return;
+        }
+
         float dy = _lastY - transform.position.y;
 
         float a = transform.lossyScale.x / 2f;

--- a/crest/Assets/Crest/Crest-Examples/Shared/Scripts/UnderwaterEnvironmentalLighting.cs
+++ b/crest/Assets/Crest/Crest-Examples/Shared/Scripts/UnderwaterEnvironmentalLighting.cs
@@ -25,6 +25,12 @@ namespace Crest
 
         void Start()
         {
+            if (OceanRenderer.Instance == null)
+            {
+                enabled = false;
+                return;
+            }
+
             _primaryLight = OceanRenderer.Instance._primaryLight;
 
             // Store lighting settings
@@ -61,6 +67,11 @@ namespace Crest
 
         void LateUpdate()
         {
+            if (OceanRenderer.Instance == null)
+            {
+                return;
+            }
+
             float depthMultiplier = Mathf.Exp(_averageDensity * 
                 Mathf.Min(OceanRenderer.Instance.ViewerHeightAboveWater * DEPTH_OUTSCATTER_CONSTANT, 0f));
 

--- a/crest/Assets/Crest/Crest-Examples/Whirlpool/Scripts/Whirlpool.cs
+++ b/crest/Assets/Crest/Crest-Examples/Whirlpool/Scripts/Whirlpool.cs
@@ -79,6 +79,11 @@ namespace Crest
 
         void Update()
         {
+            if (OceanRenderer.Instance == null)
+            {
+                return;
+            }
+
             OceanRenderer.Instance.ReportMaxDisplacementFromShape(0f, _amplitude, 0f);
 
             UpdateMaterials();

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/RenderAlphaOnSurface.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/RenderAlphaOnSurface.cs
@@ -33,7 +33,7 @@ namespace Crest
 
         private void LateUpdate()
         {
-            if(OceanRenderer.Instance == null)
+            if (OceanRenderer.Instance == null)
             {
                 return;
             }

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/UnderwaterEffect.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/UnderwaterEffect.cs
@@ -253,7 +253,7 @@ namespace Crest
 
                 isValid = false;
             }
-            else if (renderer.sharedMaterial.shader.name == "Crest/Underwater Curtain" && ocean.OceanMaterial
+            else if (renderer.sharedMaterial.shader.name == "Crest/Underwater Curtain" && ocean != null && ocean.OceanMaterial
                 && (!_copyParamsEachFrame && !_copyParamsOnStartup || EditorApplication.isPlaying && !_copyParamsEachFrame))
             {
                 // Check that enabled underwater material keywords are enabled on the ocean material.

--- a/crest/Assets/Crest/Crest/Scripts/Interaction/BoatProbes.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Interaction/BoatProbes.cs
@@ -103,6 +103,11 @@ namespace Crest
             CalcTotalWeight();
 #endif
 
+            if (OceanRenderer.Instance == null)
+            {
+                return;
+            }
+
             var collProvider = OceanRenderer.Instance.CollisionProvider;
 
             // Do queries

--- a/crest/Assets/Crest/Crest/Scripts/Interaction/ObjectWaterInteraction.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Interaction/ObjectWaterInteraction.cs
@@ -78,6 +78,11 @@ namespace Crest
 
         void LateUpdate()
         {
+            if (OceanRenderer.Instance == null)
+            {
+                return;
+            }
+
             // which lod is this object in (roughly)?
             var thisRect = new Rect(new Vector2(transform.position.x, transform.position.z), Vector3.zero);
             var minLod = LodDataMgrAnimWaves.SuggestDataLOD(thisRect);

--- a/crest/Assets/Crest/Crest/Scripts/Interaction/ObjectWaterInteractionAdaptor.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Interaction/ObjectWaterInteractionAdaptor.cs
@@ -32,6 +32,11 @@ namespace Crest
 
         private void Update()
         {
+            if (OceanRenderer.Instance == null)
+            {
+                return;
+            }
+
             _queryPoints[0] = transform.position;
             var result = OceanRenderer.Instance.CollisionProvider.Query(GetHashCode(), ObjectWidth, _queryPoints, _resultDisps, null, null);
             if (OceanRenderer.Instance.CollisionProvider.RetrieveSucceeded(result))

--- a/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
@@ -484,7 +484,7 @@ namespace Crest
                 isValid = false;
             }
 
-            if (Mathf.Abs(transform.position.y - ocean.Root.position.y) > 0.00001f)
+            if (ocean != null && ocean.Root != null && Mathf.Abs(transform.position.y - ocean.Root.position.y) > 0.00001f)
             {
                 showMessage
                 (

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterAnimWavesInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterAnimWavesInput.cs
@@ -41,6 +41,11 @@ namespace Crest
         {
             base.Update();
 
+            if (OceanRenderer.Instance == null)
+            {
+                return;
+            }
+
             var maxDispVert = 0f;
 
             // let ocean system know how far from the sea level this shape may displace the surface

--- a/crest/Assets/Crest/Crest/Scripts/Reflection/OceanPlanarReflection.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Reflection/OceanPlanarReflection.cs
@@ -119,6 +119,12 @@ namespace Crest
 
         private void Start()
         {
+            if (OceanRenderer.Instance == null)
+            {
+                enabled = false;
+                return;
+            }
+
             _camViewpoint = GetComponent<Camera>();
             if (!_camViewpoint)
             {
@@ -156,6 +162,11 @@ namespace Crest
         {
             if (!RequestRefresh(Time.renderedFrameCount))
                 return; // Skip if not need to refresh on this frame
+
+            if (OceanRenderer.Instance == null)
+            {
+                return;
+            }
 
             CreateWaterObjects(_camViewpoint);
 


### PR DESCRIPTION
I just when through and added null checks for a few more components. It might seem excessive, but we have already received a support request this issue.