### PR TITLE
WaterBody script for tile culling

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Helpers/UnderwaterEffect.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/UnderwaterEffect.cs
@@ -26,6 +26,9 @@ namespace Crest
         [Tooltip("Copy ocean material settings on each frame, to ensure consistent appearance between underwater effect and ocean surface. This should be turned off if you are not changing the ocean material values every frame."), SerializeField]
         bool _copyParamsEachFrame = true;
 
+        [SerializeField]
+        bool _turnOffOutsideWaterBodies = true;
+
         [Header("Advanced")]
 
         [Tooltip("This GameObject will be disabled when view height is more than this much above the water surface."), SerializeField]
@@ -95,7 +98,7 @@ namespace Crest
             }
 #endif
 
-            if (OceanRenderer.Instance == null)
+            if (OceanRenderer.Instance == null || !ShowEffect())
             {
                 _rend.enabled = false;
                 return;
@@ -156,6 +159,32 @@ namespace Crest
 
                 _rend.SetPropertyBlock(_mpb.materialPropertyBlock);
             }
+        }
+
+        bool ShowEffect()
+        {
+            if (_turnOffOutsideWaterBodies && OceanRenderer.Instance.WaterBodies.Count > 0)
+            {
+                var inOne = false;
+                float x = transform.position.x, z = transform.position.z;
+                foreach (var body in OceanRenderer.Instance.WaterBodies)
+                {
+                    var bounds = body.AABB;
+                    if (x >= bounds.min.x && x <= bounds.max.x &&
+                        z >= bounds.min.z && z <= bounds.max.z)
+                    {
+                        inOne = true;
+                        break;
+                    }
+                }
+
+                if (!inOne)
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         static Mesh Mesh2DGrid(int dim0, int dim1, float start0, float start1, float width0, float width1, int divs0, int divs1)

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/UnderwaterEffect.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/UnderwaterEffect.cs
@@ -26,9 +26,6 @@ namespace Crest
         [Tooltip("Copy ocean material settings on each frame, to ensure consistent appearance between underwater effect and ocean surface. This should be turned off if you are not changing the ocean material values every frame."), SerializeField]
         bool _copyParamsEachFrame = true;
 
-        [SerializeField]
-        bool _turnOffOutsideWaterBodies = true;
-
         [Header("Advanced")]
 
         [Tooltip("This GameObject will be disabled when view height is more than this much above the water surface."), SerializeField]
@@ -37,6 +34,8 @@ namespace Crest
         bool _overrideSortingOrder = false;
         [Tooltip("If the draw order override is enabled use this new order value."), SerializeField]
         int _overridenSortingOrder = 0;
+        [Tooltip("Disable underwater effect outside areas defined by WaterBody scripts, if such areas are present."), SerializeField]
+        bool _turnOffOutsideWaterBodies = true;
 
         // how many vertical edges to add to curtain geometry
         const int GEOM_HORIZ_DIVISIONS = 64;

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/UnderwaterEffect.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/UnderwaterEffect.cs
@@ -162,11 +162,11 @@ namespace Crest
 
         bool ShowEffect()
         {
-            if (_turnOffOutsideWaterBodies && OceanRenderer.Instance.WaterBodies.Count > 0)
+            if (_turnOffOutsideWaterBodies && WaterBody.WaterBodies.Count > 0)
             {
                 var inOne = false;
                 float x = transform.position.x, z = transform.position.z;
-                foreach (var body in OceanRenderer.Instance.WaterBodies)
+                foreach (var body in WaterBody.WaterBodies)
                 {
                     var bounds = body.AABB;
                     if (x >= bounds.min.x && x <= bounds.max.x &&

--- a/crest/Assets/Crest/Crest/Scripts/OceanBuilder.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanBuilder.cs
@@ -5,6 +5,7 @@
 //#define PROFILE_CONSTRUCTION
 
 using System.Collections;
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace Crest
@@ -126,7 +127,7 @@ namespace Crest
             Count,
         }
 
-        public static Transform GenerateMesh(OceanRenderer ocean, int lodDataResolution, int geoDownSampleFactor, int lodCount)
+        public static Transform GenerateMesh(OceanRenderer ocean, List<OceanChunkRenderer> tiles, int lodDataResolution, int geoDownSampleFactor, int lodCount)
         {
             if (lodCount < 1)
             {
@@ -155,7 +156,7 @@ namespace Crest
                 meshInsts[i] = BuildOceanPatch((PatchType)i, tileResolution);
             }
 
-            ClearOutTiles(ocean);
+            ClearOutTiles(ocean, tiles);
 
             var root = new GameObject("Root");
             root.hideFlags = ocean._hideOceanTileGameObjects ? HideFlags.HideAndDontSave : HideFlags.DontSave;
@@ -166,7 +167,7 @@ namespace Crest
 
             for (int i = 0; i < lodCount; i++)
             {
-                CreateLOD(ocean, root.transform, i, lodCount, meshInsts, lodDataResolution, geoDownSampleFactor, oceanLayer);
+                CreateLOD(ocean, tiles, root.transform, i, lodCount, meshInsts, lodDataResolution, geoDownSampleFactor, oceanLayer);
             }
 
 #if PROFILE_CONSTRUCTION
@@ -177,8 +178,10 @@ namespace Crest
             return root.transform;
         }
 
-        public static void ClearOutTiles(OceanRenderer ocean)
+        public static void ClearOutTiles(OceanRenderer ocean, List<OceanChunkRenderer> tiles)
         {
+            tiles.Clear();
+
             if (ocean.Root == null)
             {
                 return;
@@ -352,7 +355,7 @@ namespace Crest
             return mesh;
         }
 
-        static void CreateLOD(OceanRenderer ocean, Transform parent, int lodIndex, int lodCount, Mesh[] meshData, int lodDataResolution, int geoDownSampleFactor, int oceanLayer)
+        static void CreateLOD(OceanRenderer ocean, List<OceanChunkRenderer> tiles, Transform parent, int lodIndex, int lodCount, Mesh[] meshData, int lodDataResolution, int geoDownSampleFactor, int oceanLayer)
         {
             float horizScale = Mathf.Pow(2f, lodIndex);
 
@@ -440,8 +443,12 @@ namespace Crest
                 // scale only horizontally, otherwise culling bounding box will be scaled up in y
                 patch.transform.localScale = new Vector3(horizScale, 1f, horizScale);
 
-                patch.AddComponent<OceanChunkRenderer>().SetInstanceData(lodIndex, lodCount, lodDataResolution, geoDownSampleFactor);
-                patch.AddComponent<MeshFilter>().sharedMesh = meshData[(int)patchTypes[i]];
+                {
+                    var oceanChunkRenderer = patch.AddComponent<OceanChunkRenderer>();
+                    patch.AddComponent<MeshFilter>().sharedMesh = meshData[(int)patchTypes[i]];
+                    oceanChunkRenderer.SetInstanceData(lodIndex, lodCount, lodDataResolution, geoDownSampleFactor);
+                    tiles.Add(oceanChunkRenderer);
+                }
 
                 var mr = patch.AddComponent<MeshRenderer>();
 

--- a/crest/Assets/Crest/Crest/Scripts/OceanChunkRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanChunkRenderer.cs
@@ -185,7 +185,6 @@ namespace Crest
             RenderPipelineManager.beginCameraRendering += BeginCameraRendering;
         }
 
-
         private void OnDrawGizmos()
         {
             if (_drawRenderBounds)

--- a/crest/Assets/Crest/Crest/Scripts/OceanChunkRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanChunkRenderer.cs
@@ -17,7 +17,7 @@ namespace Crest
 
         Bounds _boundsLocal;
         Mesh _mesh;
-        Renderer _rend;
+        public Renderer Rend { get; private set; }
         PropertyWrapperMPB _mpb;
 
         // Cache these off to support regenerating ocean surface
@@ -34,7 +34,7 @@ namespace Crest
 
         void Start()
         {
-            _rend = GetComponent<Renderer>();
+            Rend = GetComponent<Renderer>();
             _mesh = GetComponent<MeshFilter>().sharedMesh;
             _boundsLocal = _mesh.bounds;
 
@@ -65,7 +65,7 @@ namespace Crest
         // Called when visible to a camera
         void OnWillRenderObject()
         {
-            if (OceanRenderer.Instance == null || _rend == null)
+            if (OceanRenderer.Instance == null || Rend == null)
             {
                 return;
             }
@@ -79,9 +79,9 @@ namespace Crest
             // Depth texture is used by ocean shader for transparency/depth fog, and for fading out foam at shoreline.
             _currentCamera.depthTextureMode |= DepthTextureMode.Depth;
 
-            if (_rend.sharedMaterial != OceanRenderer.Instance.OceanMaterial)
+            if (Rend.sharedMaterial != OceanRenderer.Instance.OceanMaterial)
             {
-                _rend.sharedMaterial = OceanRenderer.Instance.OceanMaterial;
+                Rend.sharedMaterial = OceanRenderer.Instance.OceanMaterial;
             }
 
             // per instance data
@@ -90,7 +90,7 @@ namespace Crest
             {
                 _mpb = new PropertyWrapperMPB();
             }
-            _rend.GetPropertyBlock(_mpb.materialPropertyBlock);
+            Rend.GetPropertyBlock(_mpb.materialPropertyBlock);
 
             // blend LOD 0 shape in/out to avoid pop, if the ocean might scale up later (it is smaller than its maximum scale)
             var needToBlendOutShape = _lodIndex == 0 && OceanRenderer.Instance.ScaleCouldIncrease;
@@ -146,11 +146,11 @@ namespace Crest
             var heightOffset = OceanRenderer.Instance.ViewerHeightAboveWater;
             _mpb.SetFloat(sp_ForceUnderwater, heightOffset < -2f ? 1f : 0f);
 
-            _rend.SetPropertyBlock(_mpb.materialPropertyBlock);
+            Rend.SetPropertyBlock(_mpb.materialPropertyBlock);
 
             if (_drawRenderBounds)
             {
-                _rend.bounds.DebugDraw();
+                Rend.bounds.DebugDraw();
             }
         }
 
@@ -217,6 +217,31 @@ namespace Crest
             Debug.DrawLine(new Vector3(xmin, ymin, zmin), new Vector3(xmin, ymax, zmin));
             Debug.DrawLine(new Vector3(xmax, ymin, zmin), new Vector3(xmax, ymax, zmin));
             Debug.DrawLine(new Vector3(xmin, ymax, zmax), new Vector3(xmin, ymin, zmax));
+        }
+
+        public static void GizmosDraw(this Bounds b)
+        {
+            var xmin = b.min.x;
+            var ymin = b.min.y;
+            var zmin = b.min.z;
+            var xmax = b.max.x;
+            var ymax = b.max.y;
+            var zmax = b.max.z;
+
+            Gizmos.DrawLine(new Vector3(xmin, ymin, zmin), new Vector3(xmin, ymin, zmax));
+            Gizmos.DrawLine(new Vector3(xmin, ymin, zmin), new Vector3(xmax, ymin, zmin));
+            Gizmos.DrawLine(new Vector3(xmax, ymin, zmax), new Vector3(xmin, ymin, zmax));
+            Gizmos.DrawLine(new Vector3(xmax, ymin, zmax), new Vector3(xmax, ymin, zmin));
+            
+            Gizmos.DrawLine(new Vector3(xmin, ymax, zmin), new Vector3(xmin, ymax, zmax));
+            Gizmos.DrawLine(new Vector3(xmin, ymax, zmin), new Vector3(xmax, ymax, zmin));
+            Gizmos.DrawLine(new Vector3(xmax, ymax, zmax), new Vector3(xmin, ymax, zmax));
+            Gizmos.DrawLine(new Vector3(xmax, ymax, zmax), new Vector3(xmax, ymax, zmin));
+            
+            Gizmos.DrawLine(new Vector3(xmax, ymax, zmax), new Vector3(xmax, ymin, zmax));
+            Gizmos.DrawLine(new Vector3(xmin, ymin, zmin), new Vector3(xmin, ymax, zmin));
+            Gizmos.DrawLine(new Vector3(xmax, ymin, zmin), new Vector3(xmax, ymax, zmin));
+            Gizmos.DrawLine(new Vector3(xmin, ymax, zmax), new Vector3(xmin, ymin, zmax));
         }
     }
 }

--- a/crest/Assets/Crest/Crest/Scripts/OceanChunkRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanChunkRenderer.cs
@@ -146,11 +146,6 @@ namespace Crest
             _mpb.SetFloat(sp_ForceUnderwater, heightOffset < -2f ? 1f : 0f);
 
             Rend.SetPropertyBlock(_mpb.materialPropertyBlock);
-
-            if (_drawRenderBounds)
-            {
-                Rend.bounds.DebugDraw();
-            }
         }
 
         // this is called every frame because the bounds are given in world space and depend on the transform scale, which
@@ -188,6 +183,15 @@ namespace Crest
         {
             RenderPipelineManager.beginCameraRendering -= BeginCameraRendering;
             RenderPipelineManager.beginCameraRendering += BeginCameraRendering;
+        }
+
+
+        private void OnDrawGizmos()
+        {
+            if (_drawRenderBounds)
+            {
+                Rend.bounds.GizmosDraw();
+            }
         }
     }
 

--- a/crest/Assets/Crest/Crest/Scripts/OceanChunkRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanChunkRenderer.cs
@@ -15,7 +15,7 @@ namespace Crest
     {
         public bool _drawRenderBounds = false;
 
-        Bounds _boundsLocal;
+        public Bounds _boundsLocal;
         Mesh _mesh;
         public Renderer Rend { get; private set; }
         PropertyWrapperMPB _mpb;
@@ -36,7 +36,6 @@ namespace Crest
         {
             Rend = GetComponent<Renderer>();
             _mesh = GetComponent<MeshFilter>().sharedMesh;
-            _boundsLocal = _mesh.bounds;
 
             UpdateMeshBounds();
         }

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -254,6 +254,8 @@ namespace Crest
         float _lodAlphaBlackPointFade;
         float _lodAlphaBlackPointWhitePointFade;
 
+        bool _canSkipCulling = false;
+
         readonly int sp_crestTime = Shader.PropertyToID("_CrestTime");
         readonly int sp_texelsPerWave = Shader.PropertyToID("_TexelsPerWave");
         readonly int sp_oceanCenterPosWorld = Shader.PropertyToID("_OceanCenterPosWorld");
@@ -335,6 +337,8 @@ namespace Crest
             {
                 lodData.OnEnable();
             }
+
+            _canSkipCulling = false;
         }
 
         private void OnDisable()
@@ -722,7 +726,10 @@ namespace Crest
         {
             // If there are local bodies of water, this will do overlap tests between the ocean tiles
             // and the water bodies and turn off any that don't overlap.
-            if (WaterBody.WaterBodies.Count == 0) return;
+            if (WaterBody.WaterBodies.Count == 0 && _canSkipCulling)
+            {
+                return;
+            }
 
             foreach (OceanChunkRenderer tile in _oceanChunkRenderers)
             {
@@ -748,8 +755,11 @@ namespace Crest
                     }
                 }
 
-                tile.Rend.enabled = overlappingOne;
+                tile.Rend.enabled = overlappingOne || WaterBody.WaterBodies.Count == 0;
             }
+
+            // Can skip culling next time around if water body count stays at 0
+            _canSkipCulling = WaterBody.WaterBodies.Count == 0;
         }
 
         /// <summary>

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -737,7 +737,6 @@ namespace Crest
                 var chunkBounds = tile.Rend.bounds;
 
                 var overlappingOne = false;
-                var overlappingY = 0f;
                 foreach (var body in _waterBodies)
                 {
                     var bounds = body.AABB;
@@ -747,7 +746,6 @@ namespace Crest
                         bounds.max.z > chunkBounds.min.z && bounds.min.z < chunkBounds.max.z;
                     if (overlapping)
                     {
-                        overlappingY = bounds.center.y;
                         overlappingOne = true;
                         break;
                     }

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -248,6 +248,7 @@ namespace Crest
 
         SampleHeightHelper _sampleHeightHelper = new SampleHeightHelper();
 
+        public List<WaterBody> WaterBodies => _waterBodies;
         List<WaterBody> _waterBodies = new List<WaterBody>();
 
         public static OceanRenderer Instance { get; private set; }

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -248,12 +248,9 @@ namespace Crest
 
         SampleHeightHelper _sampleHeightHelper = new SampleHeightHelper();
 
-        public List<WaterBody> WaterBodies => _waterBodies;
-        List<WaterBody> _waterBodies = new List<WaterBody>();
-
         public static OceanRenderer Instance { get; private set; }
 
-        // We are computing these values to be optimal based on the base mesh vertice density.
+        // We are computing these values to be optimal based on the base mesh vertex density.
         float _lodAlphaBlackPointFade;
         float _lodAlphaBlackPointWhitePointFade;
 
@@ -725,7 +722,7 @@ namespace Crest
         {
             // If there are local bodies of water, this will do overlap tests between the ocean tiles
             // and the water bodies and turn off any that don't overlap.
-            if (_waterBodies.Count == 0) return;
+            if (WaterBody.WaterBodies.Count == 0) return;
 
             foreach (OceanChunkRenderer tile in _oceanChunkRenderers)
             {
@@ -737,7 +734,7 @@ namespace Crest
                 var chunkBounds = tile.Rend.bounds;
 
                 var overlappingOne = false;
-                foreach (var body in _waterBodies)
+                foreach (var body in WaterBody.WaterBodies)
                 {
                     var bounds = body.AABB;
 
@@ -844,7 +841,6 @@ namespace Crest
             }
 
             _oceanChunkRenderers.Clear();
-            _waterBodies.Clear();
         }
 
 #if UNITY_EDITOR
@@ -892,15 +888,6 @@ namespace Crest
             }
         }
 #endif
-
-        public void RegisterWaterBody(WaterBody body)
-        {
-            _waterBodies.Add(body);
-        }
-        public void UnregisterWaterBody(WaterBody body)
-        {
-            _waterBodies.Remove(body);
-        }
     }
 
 #if UNITY_EDITOR

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -831,11 +831,17 @@ namespace Crest
             _lodDataSeaDepths = null;
             _lodDataShadow = null;
 
-            CollisionProvider.CleanUp();
-            CollisionProvider = null;
+            if (CollisionProvider != null)
+            {
+                CollisionProvider.CleanUp();
+                CollisionProvider = null;
+            }
 
-            FlowProvider.CleanUp();
-            FlowProvider = null;
+            if (FlowProvider != null)
+            {
+                FlowProvider.CleanUp();
+                FlowProvider = null;
+            }
 
             _oceanChunkRenderers.Clear();
             _waterBodies.Clear();

--- a/crest/Assets/Crest/Crest/Scripts/WaterBody.cs
+++ b/crest/Assets/Crest/Crest/Scripts/WaterBody.cs
@@ -59,11 +59,10 @@ namespace Crest
 
         private void OnDrawGizmos()
         {
-            Gizmos.color = Color.blue;
+            Gizmos.color = Color.white;
             // Required as we're not normally executing in edit mode
             CalculateBounds();
             AABB.GizmosDraw();
-            Gizmos.color = Color.white;
         }
 #endif
     }

--- a/crest/Assets/Crest/Crest/Scripts/WaterBody.cs
+++ b/crest/Assets/Crest/Crest/Scripts/WaterBody.cs
@@ -2,6 +2,7 @@
 
 // This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
 
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace Crest
@@ -18,22 +19,21 @@ namespace Crest
         bool _runValidationOnStart = true;
 #pragma warning restore 414
 
+        public static List<WaterBody> WaterBodies => _waterBodies;
+        static List<WaterBody> _waterBodies = new List<WaterBody>();
+
         public Bounds AABB { get; private set; }
 
         private void OnEnable()
         {
-            if (OceanRenderer.Instance == null) return;
-
             CalculateBounds();
 
-            OceanRenderer.Instance.RegisterWaterBody(this);
+            _waterBodies.Add(this);
         }
 
         private void OnDisable()
         {
-            if (OceanRenderer.Instance == null) return;
-
-            OceanRenderer.Instance.UnregisterWaterBody(this);
+            _waterBodies.Remove(this);
         }
 
         private void CalculateBounds()

--- a/crest/Assets/Crest/Crest/Scripts/WaterBody.cs
+++ b/crest/Assets/Crest/Crest/Scripts/WaterBody.cs
@@ -3,6 +3,9 @@
 // This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
 
 using System.Collections.Generic;
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
 using UnityEngine;
 
 namespace Crest
@@ -72,11 +75,11 @@ namespace Crest
     {
         public bool Validate(OceanRenderer ocean, ValidatedHelper.ShowMessage showMessage)
         {
-            if (transform.lossyScale.magnitude < 2f)
+            if (Mathf.Abs(transform.lossyScale.x) < 2f && Mathf.Abs(transform.lossyScale.z) < 2f)
             {
                 showMessage
                 (
-                    $"Water body {gameObject.name} has a very small size (the size is set by the scale of its transform). This will be a very small body of water. Is this intentional?",
+                    $"Water body {gameObject.name} has a very small size (the size is set by the X & Z scale of its transform). This will be a very small body of water. Is this intentional?",
                     ValidatedHelper.MessageType.Error, this
                 );
 
@@ -86,5 +89,8 @@ namespace Crest
             return true;
         }
     }
+
+    [CustomEditor(typeof(WaterBody), true), CanEditMultipleObjects]
+    class WaterBodyEditor : ValidatedEditor { }
 #endif
 }

--- a/crest/Assets/Crest/Crest/Scripts/WaterBody.cs
+++ b/crest/Assets/Crest/Crest/Scripts/WaterBody.cs
@@ -60,12 +60,20 @@ namespace Crest
             }
         }
 
-        private void OnDrawGizmos()
+        private void OnDrawGizmosSelected()
         {
-            Gizmos.color = Color.white;
             // Required as we're not normally executing in edit mode
             CalculateBounds();
-            AABB.GizmosDraw();
+
+            var oldColor = Gizmos.color;
+            Gizmos.color = new Color(1f, 1f, 1f, 0.5f);
+            var center = AABB.center;
+            if (OceanRenderer.Instance != null && OceanRenderer.Instance.Root != null)
+            {
+                center.y = OceanRenderer.Instance.Root.position.y;
+            }
+            Gizmos.DrawCube(center, new Vector3(AABB.extents.x, 1f, AABB.extents.z));
+            Gizmos.color = oldColor;
         }
 #endif
     }

--- a/crest/Assets/Crest/Crest/Scripts/WaterBody.cs
+++ b/crest/Assets/Crest/Crest/Scripts/WaterBody.cs
@@ -1,0 +1,91 @@
+﻿// Crest Ocean System
+
+// This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
+
+using UnityEngine;
+
+namespace Crest
+{
+    /// <summary>
+    /// Demarcates an area where water is present in the world. If present, ocean tiles will be
+    /// culled if they don't overlap any WaterBody.
+    /// </summary>
+    [ExecuteAlways]
+    public partial class WaterBody : MonoBehaviour
+    {
+#pragma warning disable 414
+        [Tooltip("Editor only: run validation checks on Start() to check for issues."), SerializeField]
+        bool _runValidationOnStart = true;
+#pragma warning restore 414
+
+        public Bounds AABB { get; private set; }
+
+        private void OnEnable()
+        {
+            if (OceanRenderer.Instance == null) return;
+
+            CalculateBounds();
+
+            OceanRenderer.Instance.RegisterWaterBody(this);
+        }
+
+        private void OnDisable()
+        {
+            if (OceanRenderer.Instance == null) return;
+
+            OceanRenderer.Instance.UnregisterWaterBody(this);
+        }
+
+        private void CalculateBounds()
+        {
+            var bounds = new Bounds();
+            bounds.center = transform.position;
+            bounds.Encapsulate(transform.TransformPoint(Vector3.right / 2f + Vector3.forward / 2f));
+            bounds.Encapsulate(transform.TransformPoint(Vector3.right / 2f - Vector3.forward / 2f));
+            bounds.Encapsulate(transform.TransformPoint(-Vector3.right / 2f + Vector3.forward / 2f));
+            bounds.Encapsulate(transform.TransformPoint(-Vector3.right / 2f - Vector3.forward / 2f));
+
+            AABB = bounds;
+        }
+
+#if UNITY_EDITOR
+        private void Start()
+        {
+            if (_runValidationOnStart)
+            {
+                Validate(OceanRenderer.Instance, ValidatedHelper.DebugLog);
+            }
+        }
+
+        private void OnDrawGizmos()
+        {
+            Gizmos.color = Color.blue;
+            // Required as we're not normally executing in edit mode
+            CalculateBounds();
+            AABB.GizmosDraw();
+            Gizmos.color = Color.white;
+        }
+#endif
+    }
+
+#if UNITY_EDITOR
+    public partial class WaterBody : IValidated
+    {
+        public bool Validate(OceanRenderer ocean, ValidatedHelper.ShowMessage showMessage)
+        {
+            if (transform.lossyScale.magnitude < 2f)
+            {
+                showMessage
+                (
+                    $"Water body {gameObject.name} has a very small size (the size is set by the scale of its transform). This will be a very small body of water. Is this intentional?",
+                    ValidatedHelper.MessageType.Error, this
+                );
+
+                return false;
+            }
+
+            return true;
+        }
+    }
+#endif
+}

--- a/crest/Assets/Crest/Crest/Scripts/WaterBody.cs
+++ b/crest/Assets/Crest/Crest/Scripts/WaterBody.cs
@@ -7,7 +7,7 @@ using UnityEngine;
 namespace Crest
 {
     /// <summary>
-    /// Demarcates an area where water is present in the world. If present, ocean tiles will be
+    /// Demarcates an AABB area where water is present in the world. If present, ocean tiles will be
     /// culled if they don't overlap any WaterBody.
     /// </summary>
     [ExecuteAlways]

--- a/crest/Assets/Crest/Crest/Scripts/WaterBody.cs.meta
+++ b/crest/Assets/Crest/Crest/Scripts/WaterBody.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b6285dcf56fc2b444ab28946f9efefd4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
**Status**: Ready for review

A piece of the local-water-bodies branch that can be merged in separately.

This change adds a `WaterBody` component which registers its AABB with the ocean. During update, if there is one or more water bodies present, bounding box overlap checks will be performed between each ocean tile and each water body. If there are no overlaps, the tile is turned off. Turning off a tile means OnWillRenderObject will not get called, no culling will be performed, no draw call, etc, so this is a nice early off-switch where water should not be present.

These changes unify the code a bit towards what is in HDRP. The HDRP version also loops over the tiles for underwater purposes and i expect we will be able to combine concerns nicely.

**Testing**:

Add WaterBody component to a gameobject. Set x&z scale to set the size. Water should cull outside of the aabb drawn by the gizmo.

**Issues**:

- [x] Recompiling code in edit mode seems to put it in an odd state (until entering play mode or doing something else to reset state). I wasn't able to figure out why yet. My debugger doesnt seem to want to attach these days and all my debug prints seemed to indicate things were fine.. Will try again later. Any testing/review would anyway be helpful. **FIXED**
- [ ] The 'Interior' tiles at lod0 seems to get too large bounds and i could not figure out why. This means they sometimes dont cull. This is annoying but hopefully not a blocker .. for now.
Thanks