### PR TITLE
Reduce min wave power to avoid persistent small waves

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Shapes/OceanWaveSpectrum.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/OceanWaveSpectrum.cs
@@ -22,7 +22,7 @@ namespace Crest
         [HideInInspector]
         public float _fetch = 500000f;
 
-        public static readonly float MIN_POWER_LOG = -6f;
+        public static readonly float MIN_POWER_LOG = -7f;
         public static readonly float MAX_POWER_LOG = 5f;
 
         [Tooltip("Variance of wave directions, in degrees"), Range(0f, 180f)]


### PR DESCRIPTION
Fix for issue #542 

This was actually a pretty bad bug - disabled octaves use the min power
value, and it was not small enough, so the gerstner was always generating
waves (even with octaves disabled or turned down to '0').

Tested that this was low enough to remove all waves in current spectrum
wavelength range.

This should not break existing data.