### PR TITLE
Scale gerstner waves using vert colours

### DIFF
--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/AnimWavesGerstnerBatchGeometry.shader
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/AnimWavesGerstnerBatchGeometry.shader
@@ -3,11 +3,12 @@
 // This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
 
 // Renders gerstner waves from geometry. Allows localised wave areas. Can fade waves based on UVs - fades to 0
-// as U or V approach 0 or 1, with configurable feather width.
+// as U or V approach 0 or 1, with configurable feather width. Can also take weight from vertex colour (red channel).
 Shader "Crest/Inputs/Animated Waves/Gerstner Batch Geometry"
 {
 	Properties
 	{
+		[Toggle] _WeightFromVertexColourRed("Weight from vertex colour (red channel)", Float) = 0
 		[Toggle] _FeatherAtUVExtents("Feather at UV extents", Float) = 0
 		_FeatherWidth("Feather width", Range(0.001, 0.5)) = 0.1
 	}
@@ -25,6 +26,7 @@ Shader "Crest/Inputs/Animated Waves/Gerstner Batch Geometry"
 			#pragma vertex Vert
 			#pragma fragment Frag
 			#pragma multi_compile __ CREST_DIRECT_TOWARDS_POINT_INTERNAL
+			#pragma shader_feature _WEIGHTFROMVERTEXCOLOURRED_ON
 			#pragma shader_feature _FEATHERATUVEXTENTS_ON
 
 			#include "UnityCG.cginc"
@@ -43,6 +45,9 @@ Shader "Crest/Inputs/Animated Waves/Gerstner Batch Geometry"
 			{
 				float3 positionOS : POSITION;
 				float2 uv : TEXCOORD0;
+#if _WEIGHTFROMVERTEXCOLOURRED_ON
+				float3 colour : COLOR0;
+#endif
 			};
 
 			struct Varyings
@@ -50,11 +55,15 @@ Shader "Crest/Inputs/Animated Waves/Gerstner Batch Geometry"
 				float4 positionCS : SV_POSITION;
 				float4 worldPosXZ_uv : TEXCOORD0;
 				float4 uv_slice_wt : TEXCOORD1;
+#if _WEIGHTFROMVERTEXCOLOURRED_ON
+				float weight : TEXCOORD2;
+#endif
 			};
 
 			Varyings Vert(Attributes input)
 			{
 				Varyings o;
+				
 				o.positionCS = UnityObjectToClipPos(input.positionOS);
 
 				o.worldPosXZ_uv.xy = mul(unity_ObjectToWorld, float4(input.positionOS, 1.0)).xz;
@@ -62,6 +71,11 @@ Shader "Crest/Inputs/Animated Waves/Gerstner Batch Geometry"
 
 				o.uv_slice_wt.xyz = WorldToUV(o.worldPosXZ_uv.xy, _LD_SliceIndex);
 				o.uv_slice_wt.w = 1.0;
+
+#if _WEIGHTFROMVERTEXCOLOURRED_ON
+				o.weight = input.colour.x;
+#endif
+
 				return o;
 			}
 
@@ -69,10 +83,14 @@ Shader "Crest/Inputs/Animated Waves/Gerstner Batch Geometry"
 			{
 				float wt = 1.0;
 
+#if _WEIGHTFROMVERTEXCOLOURRED_ON
+				wt *= input.weight;
+#endif
+
 #if _FEATHERATUVEXTENTS_ON
 				float2 offset = abs(input.worldPosXZ_uv.zw - 0.5);
 				float r_l1 = max(offset.x, offset.y);
-				wt = saturate(1.0 - (r_l1 - (0.5 - _FeatherWidth)) / _FeatherWidth);
+				wt *= saturate(1.0 - (r_l1 - (0.5 - _FeatherWidth)) / _FeatherWidth);
 #endif
 
 				return wt * ComputeGerstner(input.worldPosXZ_uv.xy, input.uv_slice_wt.xyz);


### PR DESCRIPTION
Option to use vertex colour as weight to scale waves, when using the gerstner-from-geo shader. This was the ultimate intention but did not have test data before.

@EliGould tested this and indicated it works well.

