### PR TITLE
Fix ShapeGerstnerBatched mode not applying when changed

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
@@ -137,6 +137,8 @@ namespace Crest
         // IMPORTANT - this mirrors the constant with the same name in ShapeGerstnerBatch.shader, both must be updated together!
         const int BATCH_SIZE = 32;
 
+        GameObject _renderProxy;
+
         // scratch data used by batching code
         struct UpdateBatchScratchData
         {
@@ -150,18 +152,36 @@ namespace Crest
 
         private void OnEnable()
         {
+#if UNITY_EDITOR
+            // Initialise with spectrum
             if (_spectrum == null)
             {
                 _spectrum = ScriptableObject.CreateInstance<OceanWaveSpectrum>();
                 _spectrum.name = "Default Waves (auto)";
             }
 
-#if UNITY_EDITOR
+            if (EditorApplication.isPlaying && !Validate(OceanRenderer.Instance, ValidatedHelper.DebugLog))
+            {
+                enabled = false;
+                return;
+            }
+
             _spectrum.Upgrade();
 #endif
 
             InitBatches();
         }
+
+#if UNITY_EDITOR
+        void Update()
+        {
+            // We are using the render proxy to hold state since we need to anyway.
+            if (_renderProxy != null ? _mode == GerstnerMode.Geometry : _mode == GerstnerMode.Global)
+            {
+                InitBatches();
+            }
+        }
+#endif
 
         void InitPhases()
         {
@@ -268,55 +288,62 @@ namespace Crest
         void InitBatches()
         {
             // Get the wave
-            MeshRenderer rend = null;
+            MeshRenderer rend = GetComponent<MeshRenderer>();
             if (_mode == GerstnerMode.Geometry)
             {
-                rend = GetComponent<MeshRenderer>();
-
-                if (!rend)
-                {
-                    Debug.LogError($"Gerstner input '{gameObject.name}' has Mode set to Geometry, but no MeshRenderer component is attached. Please attach a MeshRenderer to provide the geometry for rendering the Gerstner waves.", this);
-                    enabled = false;
-                    return;
-                }
-                if (!rend.sharedMaterial)
-                {
-                    Debug.LogError($"Gerstner input '{gameObject.name}' has Mode set to Geometry, but the geometry has no material assigned. Please assign a material that uses one of the Gerstner input shaders.", this);
-                    enabled = false;
-                    return;
-                }
-
                 rend.enabled = false;
+#if UNITY_EDITOR
+                // Cleanup render proxy used for global mode after switching.
+                if (_renderProxy != null)
+                {
+                    DestroyImmediate(_renderProxy);
+                }
+#endif
             }
             else if (_mode == GerstnerMode.Global)
             {
-                if (GetComponent<MeshRenderer>() != null)
+                // Create render proxy only if we don't already have one.
+                if (_renderProxy == null)
                 {
-                    Debug.LogWarning($"Gerstner input '{gameObject.name}' has MeshRenderer component that will be ignored because the Mode is set to Global.", this);
-                }
-
-                // Create a proxy MeshRenderer to feed the rendering
-                var renderProxy = GameObject.CreatePrimitive(PrimitiveType.Quad);
+                    // Create a proxy MeshRenderer to feed the rendering
+                    _renderProxy = GameObject.CreatePrimitive(PrimitiveType.Quad);
 #if UNITY_EDITOR
-                DestroyImmediate(renderProxy.GetComponent<Collider>());
+                    DestroyImmediate(_renderProxy.GetComponent<Collider>());
 #else
-                Destroy(renderProxy.GetComponent<Collider>());
+                    Destroy(_renderProxy.GetComponent<Collider>());
 #endif
-                renderProxy.hideFlags = HideFlags.HideAndDontSave;
-                renderProxy.transform.parent = transform;
-                rend = renderProxy.GetComponent<MeshRenderer>();
-                rend.enabled = false;
+                    _renderProxy.hideFlags = HideFlags.HideAndDontSave;
+                    _renderProxy.transform.parent = transform;
+                    rend = _renderProxy.GetComponent<MeshRenderer>();
+                    rend.enabled = false;
+                    var waveShader = Shader.Find("Hidden/Crest/Inputs/Animated Waves/Gerstner Batch Global");
+                    Debug.Assert(waveShader, "Could not load Gerstner wave shader, make sure it is packaged in the build.");
+                    if (waveShader == null)
+                    {
+                        enabled = false;
+                        return;
+                    }
 
-                var waveShader = Shader.Find("Hidden/Crest/Inputs/Animated Waves/Gerstner Batch Global");
-                Debug.Assert(waveShader, "Could not load Gerstner wave shader, make sure it is packaged in the build.");
-                if (waveShader == null)
-                {
-                    enabled = false;
-                    return;
+                    rend.material = new Material(waveShader);
                 }
-
-                rend.material = new Material(waveShader);
+                else
+                {
+                    rend = _renderProxy.GetComponent<MeshRenderer>();
+                }
             }
+
+            var registered = RegisterLodDataInputBase.GetRegistrar(typeof(LodDataMgrAnimWaves));
+
+#if UNITY_EDITOR
+            // Unregister after switching modes in the editor.
+            if (_batches != null)
+            {
+                foreach (var batch in _batches)
+                {
+                    registered.Remove(batch);
+                }
+            }
+#endif
 
             _batches = new GerstnerBatch[LodDataMgr.MAX_LOD_COUNT];
             for (int i = 0; i < _batches.Length; i++)
@@ -328,7 +355,6 @@ namespace Crest
             // in the biggest lod, or too big for the biggest lod, are rendered into both of the last two LODs N-1 and N-2, as this allows us to
             // move these waves between LODs without pops when the camera changes heights and the LODs need to change scale.
 
-            var registered = RegisterLodDataInputBase.GetRegistrar(typeof(LodDataMgrAnimWaves));
             foreach (var batch in _batches)
             {
                 registered.Add(0, batch);
@@ -836,6 +862,14 @@ namespace Crest
             if (_mode == GerstnerMode.Geometry)
             {
                 isValid = ValidatedHelper.ValidateRenderer(gameObject, "Crest/Inputs/Animated Waves/Gerstner", showMessage);
+            }
+            else if (_mode == GerstnerMode.Global && GetComponent<MeshRenderer>() != null)
+            {
+                showMessage
+                (
+                    "The MeshRenderer component will be ignored because the Mode is set to Global.",
+                    ValidatedHelper.MessageType.Warning, this
+                );
             }
 
             if (_spectrum == null)


### PR DESCRIPTION
When changing the mode (global or geometry) on the _ShapeGerstnerBatched_, it would not be applied because the initialisation steps were already done.

This also fixes the render proxy duplicating every time _InitBatches_ is
called (which is enter/exit play mode).

And lastly moves validation code into _Validated_.

It was sort of all tied together... o_o'