### PR TITLE
Fix wave directions which were 180deg off. Gulp.

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
@@ -583,7 +583,7 @@ namespace Crest
                 float k = 2f * Mathf.PI / _wavelengths[j];
 
                 float x = Vector2.Dot(D, pos);
-                float t = k * (x + C * mytime) + _phases[j];
+                float t = k * (x - C * mytime) + _phases[j];
                 float disp = -_spectrum._chop * k * C * Mathf.Cos(t);
                 o_surfaceVel += _amplitudes[j] * new Vector3(
                     D.x * disp,
@@ -666,7 +666,7 @@ namespace Crest
                 float k = 2f * Mathf.PI / _wavelengths[j];
 
                 float x = Vector2.Dot(D, pos);
-                float t = k * (x + C * mytime) + _phases[j];
+                float t = k * (x - C * mytime) + _phases[j];
                 float disp = k * -_spectrum._chop * Mathf.Cos(t);
                 float dispx = D.x * disp;
                 float dispz = D.y * disp;
@@ -708,7 +708,7 @@ namespace Crest
                 float k = 2f * Mathf.PI / _wavelengths[j];
 
                 float x = Vector2.Dot(D, pos);
-                float t = k * (x + C * mytime) + _phases[j];
+                float t = k * (x - C * mytime) + _phases[j];
                 float disp = -_spectrum._chop * Mathf.Sin(t);
                 o_displacement += _amplitudes[j] * new Vector3(
                     D.x * disp,

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/GerstnerShared.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/GerstnerShared.hlsl
@@ -68,7 +68,7 @@ half4 ComputeGerstner(float2 worldPosXZ, float3 uv_slice)
 		half4 k = _TwoPiOverWavelengths[vi];
 		// spatial location
 		half4 x = Dx * worldPosXZ.x + Dz * worldPosXZ.y;
-		half4 angle = k * x + _Phases[vi];
+		half4 angle = k * x - _Phases[vi];
 
 		// dx and dz could be baked into _ChopAmps
 		half4 disp = _ChopAmps[vi] * sin(angle);


### PR DESCRIPTION
As pointed out on discord, the waves are rotated 180 degrees. This is due to a sign error in the gerstner code.

My first thought was to leave it as is - however im hoping we have more flexible wave distributions in the future where the wave directions can vary freely in the world, and Tom's shoreline stuff may also utilise this, so i think i'd rather address the problem instead of adding more and more hacks that compensate for it.

Users will have to rotate the waves 180deg to compensate for this fix. If we're happy going for this then i'll fixup the example content.

What do you guys think?
