### PR TITLE
Support persistent queries (reverts #496), and add deregistration

### DIFF
--- a/crest/Assets/Crest/Crest-Examples/BoatDev/Scripts/BoatAlignNormal.cs
+++ b/crest/Assets/Crest/Crest-Examples/BoatDev/Scripts/BoatAlignNormal.cs
@@ -74,6 +74,13 @@ public class BoatAlignNormal : FloatingObjectBase
         }
     }
 
+    private void OnDisable()
+    {
+        _sampleHeightHelper.StopQueries();
+        _sampleHeightHelperLengthwise.StopQueries();
+        _sampleFlowHelper.StopQueries();
+    }
+
     void FixedUpdate()
     {
         if (OceanRenderer.Instance == null)

--- a/crest/Assets/Crest/Crest-Examples/BoatDev/Scripts/LerpCam.cs
+++ b/crest/Assets/Crest/Crest-Examples/BoatDev/Scripts/LerpCam.cs
@@ -30,4 +30,9 @@ public class LerpCam : MonoBehaviour
         transform.position = Vector3.Lerp(transform.position, targetPos, _lerpAlpha * OceanRenderer.Instance.DeltaTime * 60f);
         transform.LookAt(_targetLookatPos.position + _lookatOffset * Vector3.up);
     }
+
+    void OnDisable()
+    {
+        _sampleHeightHelper.StopQueries();
+    }
 }

--- a/crest/Assets/Crest/Crest-Examples/Shared/Scripts/Collision/OceanSampleHeightDemo.cs
+++ b/crest/Assets/Crest/Crest-Examples/Shared/Scripts/Collision/OceanSampleHeightDemo.cs
@@ -24,4 +24,9 @@ public class OceanSampleHeightDemo : MonoBehaviour
             transform.position = pos;
         }
     }
+
+    void OnDisable()
+    {
+        _sampleHeightHelper.StopQueries();
+    }
 }

--- a/crest/Assets/Crest/Crest/Scripts/Collision/CollProvider.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Collision/CollProvider.cs
@@ -34,6 +34,13 @@ namespace Crest
         int Query(int i_ownerHash, float i_minSpatialLength, Vector3[] i_queryPoints, Vector3[] o_resultDisps, Vector3[] o_resultNorms, Vector3[] o_resultVels);
 
         /// <summary>
+        /// Remove queries from this owner. In order to support making queries from FixedUpdate() (which can be called irregularly),
+        /// queries are persistent by default and need to be manually removed to stop processing. If this function is not called
+        /// queries will be 'leaked' and increase in number over time. The debug menu reports the number of query GUIDs.
+        /// </summary>
+        void RemoveQueries(int i_ownerHash);
+
+        /// <summary>
         /// Check if query results could be retrieved successfully using return code from Query() function
         /// </summary>
         bool RetrieveSucceeded(int queryStatus);

--- a/crest/Assets/Crest/Crest/Scripts/Collision/CollProviderNull.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Collision/CollProviderNull.cs
@@ -82,6 +82,10 @@ namespace Crest
         {
         }
 
+        public void RemoveQueries(int i_ownerHash)
+        {
+        }
+
         public readonly static CollProviderNull Instance = new CollProviderNull();
     }
 }

--- a/crest/Assets/Crest/Crest/Scripts/Collision/QueryBase.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Collision/QueryBase.cs
@@ -96,7 +96,7 @@ namespace Crest
                         // can happen if the Scene and Game view are not visible, in which case async readbacks dont get processed
                         // and the pipeline blocks up.
 #if !UNITY_EDITOR
-                    Debug.LogError("Query ring buffer exhausted. Please report this to developers.");
+                        Debug.LogError("Query ring buffer exhausted. Please report this to developers.");
 #endif
                         return;
                     }
@@ -104,17 +104,18 @@ namespace Crest
                     _segmentAcquire = newSegmentAcquire;
                 }
 
-                _segments[_segmentAcquire]._segments.Clear();
-
-#if false
-                _segments[_segmentAcquire]._numQueries = 0;
-#else
-                _segments[_segmentAcquire]._numQueries = _segments[lastIndex]._numQueries;
-                foreach (var segment in _segments[lastIndex]._segments)
+                // Copy the registrations across from the previous frame. This makes queries persistent. This is needed because
+                // queries are often made from FixedUpdate(), and at high framerates this may not be called, which would mean
+                // the query would get lost and this leads to stuttering and other artifacts.
                 {
-                    _segments[_segmentAcquire]._segments.Add(segment.Key, segment.Value);
+                    _segments[_segmentAcquire]._numQueries = _segments[lastIndex]._numQueries;
+
+                    _segments[_segmentAcquire]._segments.Clear();
+                    foreach (var segment in _segments[lastIndex]._segments)
+                    {
+                        _segments[_segmentAcquire]._segments.Add(segment.Key, segment.Value);
+                    }
                 }
-#endif
             }
 
             public void ReleaseLast()

--- a/crest/Assets/Crest/Crest/Scripts/Collision/SamplingHelpers.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Collision/SamplingHelpers.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using System;
+using UnityEngine;
 
 namespace Crest
 {
@@ -6,7 +7,7 @@ namespace Crest
     /// Helper to obtain the ocean surface height at a single location per frame. This is not particularly efficient to sample a single height,
     /// but is a fairly common case.
     /// </summary>
-    public class SampleHeightHelper
+    public class SampleHeightHelper : IDisposable
     {
         Vector3[] _queryPos = new Vector3[1];
         Vector3[] _queryResult = new Vector3[1];
@@ -115,13 +116,29 @@ namespace Crest
 
             return true;
         }
+
+        public void Dispose()
+        {
+            StopQueries();
+        }
+
+        /// <summary>
+        /// Stop running queries. This must be called to stop processing the queries for this object. It is fine
+        /// to start using this object again later by calling Init()/Query() as before.
+        /// </summary>
+        public void StopQueries()
+        {
+            var collProvider = OceanRenderer.Instance?.CollisionProvider;
+            if (collProvider == null) return;
+            collProvider.RemoveQueries(GetHashCode());
+        }
     }
 
     /// <summary>
     /// Helper to obtain the flow data (horizontal water motion) at a single location. This is not particularly efficient to sample a single height,
     /// but is a fairly common case.
     /// </summary>
-    public class SampleFlowHelper
+    public class SampleFlowHelper : IDisposable
     {
         Vector3[] _queryPos = new Vector3[1];
         Vector3[] _queryResult = new Vector3[1];
@@ -159,6 +176,22 @@ namespace Crest
             o_flow.y = _queryResult[0].z;
 
             return true;
+        }
+
+        public void Dispose()
+        {
+            StopQueries();
+        }
+
+        /// <summary>
+        /// Stop running queries. This must be called to stop processing the queries for this object. It is fine
+        /// to start using this object again later by calling Init()/Query() as before.
+        /// </summary>
+        public void StopQueries()
+        {
+            var collProvider = OceanRenderer.Instance?.CollisionProvider;
+            if (collProvider == null) return;
+            collProvider.RemoveQueries(GetHashCode());
         }
     }
 }

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/UnderwaterEffect.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/UnderwaterEffect.cs
@@ -77,6 +77,11 @@ namespace Crest
             ConfigureMaterial();
         }
 
+        void OnDisable()
+        {
+            _sampleWaterHeight.StopQueries();
+        }
+
         void ConfigureMaterial()
         {
             if (OceanRenderer.Instance == null) return;

--- a/crest/Assets/Crest/Crest/Scripts/Interaction/BoatProbes.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Interaction/BoatProbes.cs
@@ -87,6 +87,17 @@ namespace Crest
             _queryResultVels = new Vector3[_forcePoints.Length + 1];
         }
 
+        private void OnDisable()
+        {
+            _sampleFlowHelper.StopQueries();
+
+            var collProvider = OceanRenderer.Instance?.CollisionProvider;
+            if (collProvider != null)
+            {
+                collProvider.RemoveQueries(GetHashCode());
+            }
+        }
+
         void CalcTotalWeight()
         {
             _totalWeight = 0f;

--- a/crest/Assets/Crest/Crest/Scripts/Interaction/SimpleFloatingObject.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Interaction/SimpleFloatingObject.cs
@@ -60,6 +60,12 @@ namespace Crest
             }
         }
 
+        void OnDisable()
+        {
+            _sampleHeightHelper.StopQueries();
+            _sampleFlowHelper.StopQueries();
+        }
+
         void FixedUpdate()
         {
             UnityEngine.Profiling.Profiler.BeginSample("SimpleFloatingObject.FixedUpdate");

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterClipSurfaceInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterClipSurfaceInput.cs
@@ -34,6 +34,13 @@ namespace Crest
 
         static int sp_DisplacementSamplingIterations = Shader.PropertyToID("_DisplacementSamplingIterations");
 
+        protected override void OnDisable()
+        {
+            base.OnDisable();
+
+            _sampleHeightHelper.StopQueries();
+        }
+
         private void LateUpdate()
         {
             if (OceanRenderer.Instance == null)

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -861,6 +861,8 @@ namespace Crest
             }
 
             _oceanChunkRenderers.Clear();
+
+            _sampleHeightHelper.StopQueries();
         }
 
 #if UNITY_EDITOR

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
@@ -824,6 +824,10 @@ namespace Crest
         public void CleanUp()
         {
         }
+
+        public void RemoveQueries(int i_ownerHash)
+        {
+        }
     }
 
 #if UNITY_EDITOR


### PR DESCRIPTION
**Status**: Not worth reviewing - does not solve problem after all. GUIDs are not leaked, but the query array length does not change. This effectively creates bubbles in the query array, but the bubbles are still processed by the compute shader. Probably needs a compaction pass

---

This means queries can be made irregularly (e.g. from FixedUpdate), but are not leaked over time.

This fixes #523 - queries not working when vsync disabled, which was due to FixedUpdate being called infrequently and query guids were being lost.

This effectively reverts #496 which was a fix for leaking guids. To combat the leaking, deregistration of the queries is now mandatory. I don't think this can be avoided so is necessary complexity.

@skaughtx0r - would you be able to test this branch?

Thanks