### PR TITLE
Depth cache populate on demand instead of every frame

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
@@ -343,7 +343,7 @@ namespace Crest
                 dc.PopulateCache();
             }
 
-            if (playing && isBakeable && GUILayout.Button("Save cache to file"))
+            if (isBakeable && GUILayout.Button("Save cache to file"))
             {
                 var rt = dc.CacheTexture;
                 RenderTexture.active = rt;

--- a/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
@@ -40,11 +40,6 @@ namespace Crest
         OceanDepthCacheRefreshMode _refreshMode = OceanDepthCacheRefreshMode.OnStart;
         public OceanDepthCacheRefreshMode RefreshMode => _refreshMode;
 
-        [Tooltip("In edit mode update every frame so that scene changes take effect immediately. Increases power usage in edit mode."), SerializeField]
-#pragma warning disable 414
-        bool _refreshEveryFrameInEditMode = true;
-#pragma warning restore 414
-
         [Tooltip("Renderers in scene to render into this depth cache. When provided this saves the code from doing an expensive FindObjectsOfType() call. If one or more renderers are specified, the layer setting is ignored."), SerializeField]
         Renderer[] _geometryToRenderIntoCache = new Renderer[0];
 
@@ -110,7 +105,7 @@ namespace Crest
 #if UNITY_EDITOR
         void Update()
         {
-            if (_forceAlwaysUpdateDebug || (!EditorApplication.isPlaying && _refreshEveryFrameInEditMode))
+            if (_forceAlwaysUpdateDebug)
             {
                 PopulateCache();
             }
@@ -316,7 +311,6 @@ namespace Crest
             {
                 // Only expose the following if real-time cache type
                 EditorGUILayout.PropertyField(serializedObject.FindProperty("_refreshMode"));
-                EditorGUILayout.PropertyField(serializedObject.FindProperty("_refreshEveryFrameInEditMode"));
                 EditorGUILayout.PropertyField(serializedObject.FindProperty("_geometryToRenderIntoCache"), true);
                 EditorGUILayout.PropertyField(serializedObject.FindProperty("_layerNames"), true);
                 EditorGUILayout.PropertyField(serializedObject.FindProperty("_resolution"));
@@ -344,7 +338,7 @@ namespace Crest
             var isBakeable = cacheType == OceanDepthCache.OceanDepthCacheType.Realtime &&
                 (!isOnDemand || dc.CacheTexture != null);
 
-            if (playing && isOnDemand && GUILayout.Button("Populate cache"))
+            if ((!playing || isOnDemand) && dc.Type != OceanDepthCache.OceanDepthCacheType.Baked && GUILayout.Button("Populate cache"))
             {
                 dc.PopulateCache();
             }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
@@ -259,7 +259,7 @@ namespace Crest
 
             if (_type == OceanDepthCacheType.Baked)
             {
-                qr.material.mainTexture = _savedCache;
+                qr.sharedMaterial.mainTexture = _savedCache;
             }
             else
             {


### PR DESCRIPTION
**Status**: Ready to merge

Part of the ocean-in-edit-mode changes included having the depth cache automatically populate itself every frame when in edit mode. This was to have the ocean automatically respond to changes in the terrain/sea floor depth.

In 4.4 we fixed a bug where the cache was always populating every frame, and it was found because populating the cache is a significant cost for realistic scenes which users noticed.

I regret making the depth caches update every frame - I feel automatically responding to changes in terrain is not worth the significant performance/power cost of populating the cache every frame. This PR disables that behaviour and instead ensures the that *Populate cache* button is visible in the inspector so that users can populate it themselves if they change the terrain.

Additionally, this PR also enables the "save to texture" command in edit mode; this was previously only available in play mode.

Let me know what you think.