### PR TITLE
Use local shader keywords

### DIFF
--- a/crest/Assets/Crest/Crest/Shaders/Ocean.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Ocean.shader
@@ -215,29 +215,29 @@ Shader "Crest/Ocean"
 			#pragma multi_compile_fog
 			#pragma multi_compile_instancing
 
-			#pragma shader_feature _APPLYNORMALMAPPING_ON
-			#pragma shader_feature _COMPUTEDIRECTIONALLIGHT_ON
-			#pragma shader_feature _DIRECTIONALLIGHTVARYROUGHNESS_ON
-			#pragma shader_feature _SUBSURFACESCATTERING_ON
-			#pragma shader_feature _SUBSURFACESHALLOWCOLOUR_ON
-			#pragma shader_feature _TRANSPARENCY_ON
-			#pragma shader_feature _CAUSTICS_ON
-			#pragma shader_feature _FOAM_ON
-			#pragma shader_feature _FOAM3DLIGHTING_ON
-			#pragma shader_feature _PLANARREFLECTIONS_ON
-			#pragma shader_feature _OVERRIDEREFLECTIONCUBEMAP_ON
+			#pragma shader_feature_local _APPLYNORMALMAPPING_ON
+			#pragma shader_feature_local _COMPUTEDIRECTIONALLIGHT_ON
+			#pragma shader_feature_local _DIRECTIONALLIGHTVARYROUGHNESS_ON
+			#pragma shader_feature_local _SUBSURFACESCATTERING_ON
+			#pragma shader_feature_local _SUBSURFACESHALLOWCOLOUR_ON
+			#pragma shader_feature_local _TRANSPARENCY_ON
+			#pragma shader_feature_local _CAUSTICS_ON
+			#pragma shader_feature_local _FOAM_ON
+			#pragma shader_feature_local _FOAM3DLIGHTING_ON
+			#pragma shader_feature_local _PLANARREFLECTIONS_ON
+			#pragma shader_feature_local _OVERRIDEREFLECTIONCUBEMAP_ON
 
-			#pragma shader_feature _PROCEDURALSKY_ON
-			#pragma shader_feature _UNDERWATER_ON
-			#pragma shader_feature _FLOW_ON
-			#pragma shader_feature _SHADOWS_ON
-			#pragma shader_feature _CLIPSURFACE_ON
+			#pragma shader_feature_local _PROCEDURALSKY_ON
+			#pragma shader_feature_local _UNDERWATER_ON
+			#pragma shader_feature_local _FLOW_ON
+			#pragma shader_feature_local _SHADOWS_ON
+			#pragma shader_feature_local _CLIPSURFACE_ON
 
-			#pragma shader_feature _DEBUGDISABLESHAPETEXTURES_ON
-			#pragma shader_feature _DEBUGVISUALISESHAPESAMPLE_ON
-			#pragma shader_feature _DEBUGVISUALISEFLOW_ON
-			#pragma shader_feature _DEBUGDISABLESMOOTHLOD_ON
-			#pragma shader_feature _COMPILESHADERWITHDEBUGINFO_ON
+			#pragma shader_feature_local _DEBUGDISABLESHAPETEXTURES_ON
+			#pragma shader_feature_local _DEBUGVISUALISESHAPESAMPLE_ON
+			#pragma shader_feature_local _DEBUGVISUALISEFLOW_ON
+			#pragma shader_feature_local _DEBUGDISABLESMOOTHLOD_ON
+			#pragma shader_feature_local _COMPILESHADERWITHDEBUGINFO_ON
 
 			#if _COMPILESHADERWITHDEBUGINFO_ON
 			#pragma enable_d3d11_debug_symbols

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/AnimWavesAddFromTex.shader
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/AnimWavesAddFromTex.shader
@@ -26,8 +26,8 @@ Shader "Crest/Inputs/Animated Waves/Add From Texture"
 			#pragma vertex Vert
 			#pragma fragment Frag
 
-			#pragma shader_feature _HEIGHTSONLY_ON
-			#pragma shader_feature _SSSFROMALPHA_ON
+			#pragma shader_feature_local _HEIGHTSONLY_ON
+			#pragma shader_feature_local _SSSFROMALPHA_ON
 
 			#include "UnityCG.cginc"
 

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/AnimWavesGerstnerBatchGeometry.shader
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/AnimWavesGerstnerBatchGeometry.shader
@@ -25,9 +25,9 @@ Shader "Crest/Inputs/Animated Waves/Gerstner Batch Geometry"
 			CGPROGRAM
 			#pragma vertex Vert
 			#pragma fragment Frag
-			#pragma multi_compile __ CREST_DIRECT_TOWARDS_POINT_INTERNAL
-			#pragma shader_feature _WEIGHTFROMVERTEXCOLOURRED_ON
-			#pragma shader_feature _FEATHERATUVEXTENTS_ON
+			#pragma multi_compile_local __ CREST_DIRECT_TOWARDS_POINT_INTERNAL
+			#pragma shader_feature_local _WEIGHTFROMVERTEXCOLOURRED_ON
+			#pragma shader_feature_local _FEATHERATUVEXTENTS_ON
 
 			#include "UnityCG.cginc"
 

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/AnimWavesGerstnerBatch.shader
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/AnimWavesGerstnerBatch.shader
@@ -17,7 +17,7 @@ Shader "Hidden/Crest/Inputs/Animated Waves/Gerstner Batch Global"
 			CGPROGRAM
 			#pragma vertex Vert
 			#pragma fragment Frag
-			#pragma multi_compile __ CREST_DIRECT_TOWARDS_POINT_INTERNAL
+			#pragma multi_compile_local __ CREST_DIRECT_TOWARDS_POINT_INTERNAL
 
 			#include "UnityCG.cginc"
 

--- a/crest/Assets/Crest/Crest/Shaders/Underwater/UnderwaterCurtain.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Underwater/UnderwaterCurtain.shader
@@ -39,12 +39,12 @@ Shader "Crest/Underwater Curtain"
 
 			#pragma multi_compile_instancing
 
-			#pragma shader_feature _SUBSURFACESCATTERING_ON
-			#pragma shader_feature _SUBSURFACESHALLOWCOLOUR_ON
-			#pragma shader_feature _TRANSPARENCY_ON
-			#pragma shader_feature _CAUSTICS_ON
-			#pragma shader_feature _SHADOWS_ON
-			#pragma shader_feature _COMPILESHADERWITHDEBUGINFO_ON
+			#pragma shader_feature_local _SUBSURFACESCATTERING_ON
+			#pragma shader_feature_local _SUBSURFACESHALLOWCOLOUR_ON
+			#pragma shader_feature_local _TRANSPARENCY_ON
+			#pragma shader_feature_local _CAUSTICS_ON
+			#pragma shader_feature_local _SHADOWS_ON
+			#pragma shader_feature_local _COMPILESHADERWITHDEBUGINFO_ON
 
 			#if _COMPILESHADERWITHDEBUGINFO_ON
 			#pragma enable_d3d11_debug_symbols


### PR DESCRIPTION
Required no scripting changes. I haven't tested everything yet, but I am confident it works fine. Providing we enable keywords on the material instead using Shader.EnableKeyword (which we do. Other than for the compute shaders where I think we need them for the moment at least).

This might break someone's project if they need global keywords with Crest. But I don't really see why they would.