### PR TITLE
Improved wave spectrum inspector

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Shapes/OceanWaveSpectrum.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/OceanWaveSpectrum.cs
@@ -60,7 +60,9 @@ namespace Crest
 
 
 #if UNITY_EDITOR
+#pragma warning disable 414
         [SerializeField] bool _showAdvancedControls = false;
+#pragma warning restore 414
 
         public enum SpectrumModel
         {

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/OceanWaveSpectrum.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/OceanWaveSpectrum.cs
@@ -309,9 +309,14 @@ namespace Crest
         private static GUIStyle ToggleButtonStyleNormal = null;
         private static GUIStyle ToggleButtonStyleToggled = null;
 
-        static GUIContent s_labelPhillips = new GUIContent("Phillips", "Base of modern parametric wave spectra");
-        static GUIContent s_labelPiersonMoskowitz = new GUIContent("Pierson-Moskowitz", "Fully developed sea with infinite fetch");
-        static GUIContent s_labelJONSWAP = new GUIContent("JONSWAP", "Fetch limited sea where waves continue to grow");
+        readonly static string[] modelDescriptions = new string[]
+        {
+            "Select an option to author waves using a spectrum model.",
+            "Base of modern parametric wave spectra.",
+            "Fully developed sea with infinite fetch.",
+            "Fetch limited sea where waves continue to grow.",
+        };
+
         static GUIContent s_labelSWM = new GUIContent("Small wavelength multiplier", "Modifies parameters for the empirical spectra, tends to boost smaller wavelengths");
         static GUIContent s_labelFetch = new GUIContent("Fetch", "Length of area that wind excites waves. Applies only to JONSWAP");
 
@@ -428,6 +433,10 @@ namespace Crest
             EditorGUILayout.BeginHorizontal();
             spec.Model = (OceanWaveSpectrum.SpectrumModel)EditorGUILayout.EnumPopup(spec.Model);
             EditorGUILayout.EndHorizontal();
+
+            EditorGUILayout.Space();
+            EditorGUILayout.HelpBox(modelDescriptions[(int)spec.Model], MessageType.Info);
+            EditorGUILayout.Space();
 
             if (spec.Model == OceanWaveSpectrum.SpectrumModel.None)
             {

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/OceanWaveSpectrum.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/OceanWaveSpectrum.cs
@@ -310,9 +310,6 @@ namespace Crest
     [CustomEditor(typeof(OceanWaveSpectrum))]
     public class OceanWaveSpectrumEditor : Editor
     {
-        private static GUIStyle ToggleButtonStyleNormal = null;
-        private static GUIStyle ToggleButtonStyleToggled = null;
-
         readonly static string[] modelDescriptions = new string[]
         {
             "Select an option to author waves using a spectrum model.",
@@ -363,15 +360,6 @@ namespace Crest
 
             var spSpectrumModel = serializedObject.FindProperty("_model");
             var spectrumModel = (OceanWaveSpectrum.SpectrumModel)serializedObject.FindProperty("_model").enumValueIndex;
-
-            // preamble - styles for toggle buttons. this code and the below was based off the useful info provided by user Lasse here:
-            // https://gamedev.stackexchange.com/questions/98920/how-do-i-create-a-toggle-button-in-unity-inspector
-            if (ToggleButtonStyleNormal == null)
-            {
-                ToggleButtonStyleNormal = "Button";
-                ToggleButtonStyleToggled = new GUIStyle(ToggleButtonStyleNormal);
-                ToggleButtonStyleToggled.normal.background = ToggleButtonStyleToggled.active.background;
-            }
 
             EditorGUILayout.Space();
 

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/OceanWaveSpectrum.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/OceanWaveSpectrum.cs
@@ -58,9 +58,10 @@ namespace Crest
         [Tooltip("Scales horizontal displacement"), Range(0f, 2f)]
         public float _chop = 1.6f;
 
-        public bool _showAdvancedControls = false;
 
 #if UNITY_EDITOR
+        [SerializeField] bool _showAdvancedControls = false;
+
         public enum SpectrumModel
         {
             None,

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/OceanWaveSpectrum.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/OceanWaveSpectrum.cs
@@ -397,6 +397,9 @@ namespace Crest
             var spGravScales = serializedObject.FindProperty("_gravityScales");
             UpgradeSpectrum(spGravScales, 1f);
 
+            // Disable sliders if authoring with model.
+            var canEditSpectrum = spec.Model != OceanWaveSpectrum.SpectrumModel.None;
+
             for (int i = 0; i < spPower.arraySize; i++)
             {
                 EditorGUILayout.BeginHorizontal();
@@ -411,12 +414,18 @@ namespace Crest
                 {
                     EditorGUILayout.LabelField(string.Format("{0}", smallWL), EditorStyles.boldLabel);
                     EditorGUILayout.EndHorizontal();
+                    // Disable slider if authoring with model.
+                    GUI.enabled = !canEditSpectrum;
                     EditorGUILayout.Slider(spPower_i, OceanWaveSpectrum.MIN_POWER_LOG, OceanWaveSpectrum.MAX_POWER_LOG, "    Power");
+                    GUI.enabled = true;
                 }
                 else
                 {
                     EditorGUILayout.LabelField(string.Format("{0}", smallWL), GUILayout.Width(30f));
+                    // Disable slider if authoring with model.
+                    GUI.enabled = !canEditSpectrum;
                     spPower_i.floatValue = GUILayout.HorizontalSlider(spPower_i.floatValue, OceanWaveSpectrum.MIN_POWER_LOG, OceanWaveSpectrum.MAX_POWER_LOG);
+                    GUI.enabled = true;
                     EditorGUILayout.EndHorizontal();
                     // This will create a tooltip for slider.
                     GUI.Label(GUILayoutUtility.GetLastRect(), new GUIContent("", spPower_i.floatValue.ToString()));

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/OceanWaveSpectrum.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/OceanWaveSpectrum.cs
@@ -71,7 +71,7 @@ namespace Crest
         }
 
         // We need to serialize if we want undo/redo.
-        [SerializeField] SpectrumModel _model;
+        [HideInInspector, SerializeField] SpectrumModel _model;
         internal SpectrumModel Model { get => _model; set => _model = value; }
 #endif
 

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/OceanWaveSpectrum.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/OceanWaveSpectrum.cs
@@ -410,13 +410,16 @@ namespace Crest
                 float smallWL = OceanWaveSpectrum.SmallWavelength(i);
                 var spPower_i = spPower.GetArrayElementAtIndex(i);
 
+                var isPowerDisabled = spDisabled_i.boolValue;
+                var powerValue = isPowerDisabled ? OceanWaveSpectrum.MIN_POWER_LOG : spPower_i.floatValue;
+
                 if (showAdvancedControls)
                 {
                     EditorGUILayout.LabelField(string.Format("{0}", smallWL), EditorStyles.boldLabel);
                     EditorGUILayout.EndHorizontal();
                     // Disable slider if authoring with model.
                     GUI.enabled = !canEditSpectrum && !spDisabled_i.boolValue;
-                    EditorGUILayout.Slider(spPower_i, OceanWaveSpectrum.MIN_POWER_LOG, OceanWaveSpectrum.MAX_POWER_LOG, "    Power");
+                    powerValue = EditorGUILayout.Slider("    Power", powerValue, OceanWaveSpectrum.MIN_POWER_LOG, OceanWaveSpectrum.MAX_POWER_LOG);
                     GUI.enabled = true;
                 }
                 else
@@ -424,11 +427,17 @@ namespace Crest
                     EditorGUILayout.LabelField(string.Format("{0}", smallWL), GUILayout.Width(30f));
                     // Disable slider if authoring with model.
                     GUI.enabled = !canEditSpectrum && !spDisabled_i.boolValue;
-                    spPower_i.floatValue = GUILayout.HorizontalSlider(spPower_i.floatValue, OceanWaveSpectrum.MIN_POWER_LOG, OceanWaveSpectrum.MAX_POWER_LOG);
+                    powerValue = GUILayout.HorizontalSlider(powerValue, OceanWaveSpectrum.MIN_POWER_LOG, OceanWaveSpectrum.MAX_POWER_LOG);
                     GUI.enabled = true;
                     EditorGUILayout.EndHorizontal();
                     // This will create a tooltip for slider.
-                    GUI.Label(GUILayoutUtility.GetLastRect(), new GUIContent("", spPower_i.floatValue.ToString()));
+                    GUI.Label(GUILayoutUtility.GetLastRect(), new GUIContent("", powerValue.ToString()));
+                }
+
+                // If the power is disabled, we are using the MIN_POWER_LOG value so we don't want to store it.
+                if (!isPowerDisabled)
+                {
+                    spPower_i.floatValue = powerValue;
                 }
 
                 if (showAdvancedControls)

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/OceanWaveSpectrum.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/OceanWaveSpectrum.cs
@@ -40,11 +40,11 @@ namespace Crest
         [Tooltip("Multiplier"), Range(0f, 10f), SerializeField]
         float _multiplier = 1f;
 
-        [SerializeField]
+        [HideInInspector, SerializeField]
         float[] _powerLog = new float[NUM_OCTAVES]
             { -6f, -6f, -6f, -4.0088496f, -3.4452133f, -2.6996124f, -2.615044f, -1.2080691f, -0.53905386f, 0.27448857f, 0.53627354f, 1.0282621f, 1.4403292f, -6f };
 
-        [SerializeField]
+        [HideInInspector, SerializeField]
         bool[] _powerDisabled = new bool[NUM_OCTAVES];
 
         [HideInInspector]
@@ -418,6 +418,8 @@ namespace Crest
                     EditorGUILayout.LabelField(string.Format("{0}", smallWL), GUILayout.Width(30f));
                     spPower_i.floatValue = GUILayout.HorizontalSlider(spPower_i.floatValue, OceanWaveSpectrum.MIN_POWER_LOG, OceanWaveSpectrum.MAX_POWER_LOG);
                     EditorGUILayout.EndHorizontal();
+                    // This will create a tooltip for slider.
+                    GUI.Label(GUILayoutUtility.GetLastRect(), new GUIContent("", spPower_i.floatValue.ToString()));
                 }
 
                 if (showAdvancedControls)

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/OceanWaveSpectrum.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/OceanWaveSpectrum.cs
@@ -415,7 +415,7 @@ namespace Crest
                     EditorGUILayout.LabelField(string.Format("{0}", smallWL), EditorStyles.boldLabel);
                     EditorGUILayout.EndHorizontal();
                     // Disable slider if authoring with model.
-                    GUI.enabled = !canEditSpectrum;
+                    GUI.enabled = !canEditSpectrum && !spDisabled_i.boolValue;
                     EditorGUILayout.Slider(spPower_i, OceanWaveSpectrum.MIN_POWER_LOG, OceanWaveSpectrum.MAX_POWER_LOG, "    Power");
                     GUI.enabled = true;
                 }
@@ -423,7 +423,7 @@ namespace Crest
                 {
                     EditorGUILayout.LabelField(string.Format("{0}", smallWL), GUILayout.Width(30f));
                     // Disable slider if authoring with model.
-                    GUI.enabled = !canEditSpectrum;
+                    GUI.enabled = !canEditSpectrum && !spDisabled_i.boolValue;
                     spPower_i.floatValue = GUILayout.HorizontalSlider(spPower_i.floatValue, OceanWaveSpectrum.MIN_POWER_LOG, OceanWaveSpectrum.MAX_POWER_LOG);
                     GUI.enabled = true;
                     EditorGUILayout.EndHorizontal();


### PR DESCRIPTION
Mostly to fix things mentioned in #557.

Fixes
- Fix broken button state by replacing with enum
- Fix undo/redo only working for some properties
- Fix some properties not serialising

Improvements
- Disable power sliders if power is disabled
- Show minimum power if power is disabled
- Hide power arrays (replaced with tooltip over slider to see value)
- Hide/show options based on spectrum model
- Spectrum model is now persistent

![1](https://user-images.githubusercontent.com/5249806/87369929-4162ca80-c5b4-11ea-91ab-8f3c8259fbfc.jpg)

Let me know what you think.