### PR TITLE
Fix underwater effect appearing at top of screen when looking up

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterPostProcessUtils.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterPostProcessUtils.cs
@@ -294,6 +294,14 @@ namespace Crest
                     v_world[i] = camera.ViewportToWorldPoint(v_screenXY_viewZ[i], eye);
                 }
 
+                // This is a temporary fix to the horizonSafetyMarginMultiplier thinking the horizon is the top of the
+                // screen causing the underwater effect to render from the top of the screen downwards when looking up.
+                if ((v_world[0].y >= 0 && v_world[1].y >= 0 && v_world[2].y >= 0 && v_world[3].y >= 0) ||
+                    (v_world[0].y <= 0 && v_world[1].y <= 0 && v_world[2].y <= 0 && v_world[3].y <= 0))
+                {
+                    horizonSafetyMarginMultiplier = 0.0f;
+                }
+
                 NativeArray<Vector2> intersectionsScreen = new NativeArray<Vector2>(2, Allocator.Temp);
                 // This is only used to disambiguate the normal later. Could be removed if we were more careful with point order/indices below.
                 NativeArray<Vector3> intersectionsWorld = new NativeArray<Vector3>(2, Allocator.Temp);


### PR DESCRIPTION
Fixes #572

There is probably a proper way to fix this in the horizon calculation. But this seemed like the easiest way for me.

All it does is check to see if the horizon is within the far clip plane. And if it is not, set the _Horizon Safety Margin Multiplier_ to zero since this is the cause of the bar of underwater fog.

Is there a reason we are using the _camera.farClipPlane_ value rather than a hard-coded one?