### PR TITLE
Fix dynamic waves crashing without flow or depth sims

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgr.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgr.cs
@@ -114,7 +114,7 @@ namespace Crest
         }
 
         // Avoid heap allocations instead BindData
-        private Vector4[] _BindData_paramIdPosScales = new Vector4[MAX_LOD_COUNT + 1];
+        protected Vector4[] _BindData_paramIdPosScales = new Vector4[MAX_LOD_COUNT + 1];
         // Used in child
         protected Vector4[] _BindData_paramIdOceans = new Vector4[MAX_LOD_COUNT + 1];
         protected virtual void BindData(IPropertyWrapper properties, Texture applyData, bool blendOut, ref LodTransform.RenderData[] renderData, bool sourceLod = false)

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrPersistent.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrPersistent.cs
@@ -126,6 +126,9 @@ namespace Crest
                     DataTexture
                 );
 
+                // Bind current data
+                BindData(_renderSimProperties, null, false, ref OceanRenderer.Instance._lodTransform._renderData, false);
+
                 _renderSimProperties.DispatchShaderMultiLOD();
 
                 for (var lodIdx = lodCount - 1; lodIdx >= 0; lodIdx--)


### PR DESCRIPTION
Fixes #588 

The issue was the __BindData_paramIdPosScales_ not being set as suggested by @huwb. I went with just calling _BindData_, but we could set only that property.