### PR TITLE
Use 'out' which allows some reduction around the sample helpers

### DIFF
--- a/crest/Assets/Crest/Crest-Examples/BoatDev/Scripts/BoatAlignNormal.cs
+++ b/crest/Assets/Crest/Crest-Examples/BoatDev/Scripts/BoatAlignNormal.cs
@@ -85,7 +85,7 @@ public class BoatAlignNormal : FloatingObjectBase
         _sampleHeightHelper.Init(transform.position, _boatWidth, true);
         var height = OceanRenderer.Instance.SeaLevel;
 
-        _sampleHeightHelper.Sample(out Vector3 disp, out Vector3 normal, out Vector3 waterSurfaceVel);
+        _sampleHeightHelper.Sample(out Vector3 disp, out var normal, out var waterSurfaceVel);
 
         // height = base sea level + surface displacement y
         height += disp.y;

--- a/crest/Assets/Crest/Crest-Examples/BoatDev/Scripts/BoatAlignNormal.cs
+++ b/crest/Assets/Crest/Crest-Examples/BoatDev/Scripts/BoatAlignNormal.cs
@@ -87,11 +87,8 @@ public class BoatAlignNormal : FloatingObjectBase
 
         _sampleHeightHelper.Init(transform.position, _boatWidth, true);
         var height = OceanRenderer.Instance.SeaLevel;
-        var disp = Vector3.zero;
-        var normal = Vector3.up;
-        var waterSurfaceVel = Vector3.zero;
 
-        _sampleHeightHelper.Sample(ref disp, ref normal, ref waterSurfaceVel);
+        _sampleHeightHelper.Sample(out Vector3 disp, out Vector3 normal, out Vector3 waterSurfaceVel);
 
         // height = base sea level + surface displacement y
         height += disp.y;
@@ -99,8 +96,7 @@ public class BoatAlignNormal : FloatingObjectBase
         {
             _sampleFlowHelper.Init(transform.position, _boatWidth);
 
-            Vector2 surfaceFlow = Vector2.zero;
-            _sampleFlowHelper.Sample(ref surfaceFlow);
+            _sampleFlowHelper.Sample(out var surfaceFlow);
             waterSurfaceVel += new Vector3(surfaceFlow.x, 0, surfaceFlow.y);
         }
 
@@ -162,8 +158,7 @@ public class BoatAlignNormal : FloatingObjectBase
         if (_useBoatLength)
         {
             _sampleHeightHelperLengthwise.Init(transform.position, _boatLength, true);
-            var dummy = 0f;
-            if (_sampleHeightHelperLengthwise.Sample(ref dummy, ref normalLongitudinal))
+            if (_sampleHeightHelperLengthwise.Sample(out _, out normalLongitudinal))
             {
                 var F = transform.forward;
                 F.y = 0f;

--- a/crest/Assets/Crest/Crest-Examples/BoatDev/Scripts/LerpCam.cs
+++ b/crest/Assets/Crest/Crest-Examples/BoatDev/Scripts/LerpCam.cs
@@ -23,8 +23,7 @@ public class LerpCam : MonoBehaviour
         }
 
         _sampleHeightHelper.Init(transform.position, 0f);
-        float h = 0f;
-        _sampleHeightHelper.Sample(ref h);
+        _sampleHeightHelper.Sample(out var h);
 
         var targetPos = _targetPos.position;
         targetPos.y = Mathf.Max(targetPos.y, h + _minHeightAboveWater);

--- a/crest/Assets/Crest/Crest-Examples/Shared/Scripts/Collision/OceanSampleHeightDemo.cs
+++ b/crest/Assets/Crest/Crest-Examples/Shared/Scripts/Collision/OceanSampleHeightDemo.cs
@@ -18,8 +18,7 @@ public class OceanSampleHeightDemo : MonoBehaviour
         var r = transform.lossyScale.magnitude;
         _sampleHeightHelper.Init(transform.position, 2f * r);
 
-        float height = 0f;
-        if (_sampleHeightHelper.Sample(ref height))
+        if (_sampleHeightHelper.Sample(out var height))
         {
             var pos = transform.position;
             pos.y = height;

--- a/crest/Assets/Crest/Crest/Scripts/Collision/SamplingHelpers.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Collision/SamplingHelpers.cs
@@ -48,15 +48,20 @@ namespace Crest
         /// <summary>
         /// Call this to do the query. Can be called only once after Init().
         /// </summary>
-        public bool Sample(ref float o_height)
+        public bool Sample(out float o_height)
         {
             var collProvider = OceanRenderer.Instance?.CollisionProvider;
-            if (collProvider == null) return false;
+            if (collProvider == null)
+            {
+                o_height = 0f;
+                return false;
+            }
 
             var status = collProvider.Query(GetHashCode(), _minLength, _queryPos, _queryResult, null, null);
 
             if (!collProvider.RetrieveSucceeded(status))
             {
+                o_height = OceanRenderer.Instance.SeaLevel;
                 return false;
             }
 
@@ -65,15 +70,22 @@ namespace Crest
             return true;
         }
 
-        public bool Sample(ref float o_height, ref Vector3 o_normal)
+        public bool Sample(out float o_height, out Vector3 o_normal)
         {
             var collProvider = OceanRenderer.Instance?.CollisionProvider;
-            if (collProvider == null) return false;
+            if (collProvider == null)
+            {
+                o_height = 0f;
+                o_normal = Vector3.up;
+                return false;
+            }
 
             var status = collProvider.Query(GetHashCode(), _minLength, _queryPos, _queryResult, _queryResultNormal, null);
 
             if (!collProvider.RetrieveSucceeded(status))
             {
+                o_height = OceanRenderer.Instance.SeaLevel;
+                o_normal = Vector3.up;
                 return false;
             }
 
@@ -83,15 +95,24 @@ namespace Crest
             return true;
         }
 
-        public bool Sample(ref float o_height, ref Vector3 o_normal, ref Vector3 o_surfaceVel)
+        public bool Sample(out float o_height, out Vector3 o_normal, out Vector3 o_surfaceVel)
         {
             var collProvider = OceanRenderer.Instance?.CollisionProvider;
-            if (collProvider == null) return false;
+            if (collProvider == null)
+            {
+                o_height = 0f;
+                o_normal = Vector3.up;
+                o_surfaceVel = Vector3.zero;
+                return false;
+            }
 
             var status = collProvider.Query(GetHashCode(), _minLength, _queryPos, _queryResult, _queryResultNormal, _queryResultVel);
 
             if (!collProvider.RetrieveSucceeded(status))
             {
+                o_height = OceanRenderer.Instance.SeaLevel;
+                o_normal = Vector3.up;
+                o_surfaceVel = Vector3.zero;
                 return false;
             }
 
@@ -102,14 +123,23 @@ namespace Crest
             return true;
         }
 
-        public bool Sample(ref Vector3 o_displacementToPoint, ref Vector3 o_normal, ref Vector3 o_surfaceVel)
+        public bool Sample(out Vector3 o_displacementToPoint, out Vector3 o_normal, out Vector3 o_surfaceVel)
         {
             var collProvider = OceanRenderer.Instance?.CollisionProvider;
-            if (collProvider == null) return false;
+            if (collProvider == null)
+            {
+                o_displacementToPoint = Vector3.zero;
+                o_normal = Vector3.up;
+                o_surfaceVel = Vector3.zero;
+                return false;
+            }
             var status = collProvider.Query(GetHashCode(), _minLength, _queryPos, _queryResult, _queryResultNormal, _queryResultVel);
 
             if (!collProvider.RetrieveSucceeded(status))
             {
+                o_displacementToPoint = Vector3.zero;
+                o_normal = Vector3.up;
+                o_surfaceVel = Vector3.zero;
                 return false;
             }
 
@@ -147,14 +177,19 @@ namespace Crest
         /// <summary>
         /// Call this to do the query. Can be called only once after Init().
         /// </summary>
-        public bool Sample(ref Vector2 o_flow)
+        public bool Sample(out Vector2 o_flow)
         {
             var flowProvider = OceanRenderer.Instance?.FlowProvider;
-            if (flowProvider == null) return false;
+            if (flowProvider == null)
+            {
+                o_flow = Vector2.zero;
+                return false;
+            }
             var status = flowProvider.Query(GetHashCode(), _minLength, _queryPos, _queryResult);
 
             if (!flowProvider.RetrieveSucceeded(status))
             {
+                o_flow = Vector2.zero;
                 return false;
             }
 

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/UnderwaterEffect.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/UnderwaterEffect.cs
@@ -108,11 +108,10 @@ namespace Crest
                 return;
             }
 
-            float waterHeight = OceanRenderer.Instance.SeaLevel;
             // Pass true in last arg for a crap reason - in edit mode LateUpdate can be called very frequently, and the height sampler mistakenly thinks
             // this is erroneous and complains.
             _sampleWaterHeight.Init(transform.position, 0f, true);
-            _sampleWaterHeight.Sample(ref waterHeight);
+            _sampleWaterHeight.Sample(out var waterHeight);
 
             float heightOffset = transform.position.y - waterHeight;
 

--- a/crest/Assets/Crest/Crest/Scripts/Interaction/BoatProbes.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Interaction/BoatProbes.cs
@@ -116,8 +116,7 @@ namespace Crest
 
             {
                 _sampleFlowHelper.Init(transform.position, _minSpatialLength);
-                Vector2 surfaceFlow = Vector2.zero;
-                _sampleFlowHelper.Sample(ref surfaceFlow);
+                _sampleFlowHelper.Sample(out var surfaceFlow);
                 waterSurfaceVel += new Vector3(surfaceFlow.x, 0, surfaceFlow.y);
             }
 

--- a/crest/Assets/Crest/Crest/Scripts/Interaction/ObjectWaterInteraction.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Interaction/ObjectWaterInteraction.cs
@@ -120,8 +120,7 @@ namespace Crest
 
             {
                 _sampleFlowHelper.Init(transform.position, _boat.ObjectWidth);
-                Vector2 surfaceFlow = Vector2.zero;
-                _sampleFlowHelper.Sample(ref surfaceFlow);
+                _sampleFlowHelper.Sample(out var surfaceFlow);
                 vel -= new Vector3(surfaceFlow.x, 0, surfaceFlow.y);
             }
             vel.y *= _weightUpDownMul;

--- a/crest/Assets/Crest/Crest/Scripts/Interaction/SimpleFloatingObject.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Interaction/SimpleFloatingObject.cs
@@ -72,15 +72,14 @@ namespace Crest
             var collProvider = OceanRenderer.Instance.CollisionProvider;
             var position = transform.position;
 
-            var normal = Vector3.up; var waterSurfaceVel = Vector3.zero; var disp = Vector3.zero;
+            Vector3 normal, waterSurfaceVel, disp;
             _sampleHeightHelper.Init(transform.position, _objectWidth, true);
-            _sampleHeightHelper.Sample(ref disp, ref normal, ref waterSurfaceVel);
+            _sampleHeightHelper.Sample(out disp, out normal, out waterSurfaceVel);
 
             {
                 _sampleFlowHelper.Init(transform.position, ObjectWidth);
 
-                Vector2 surfaceFlow = Vector2.zero;
-                _sampleFlowHelper.Sample(ref surfaceFlow);
+                _sampleFlowHelper.Sample(out var surfaceFlow);
                 waterSurfaceVel += new Vector3(surfaceFlow.x, 0, surfaceFlow.y);
             }
 

--- a/crest/Assets/Crest/Crest/Scripts/Interaction/SphereWaterInteraction.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Interaction/SphereWaterInteraction.cs
@@ -98,9 +98,8 @@ namespace Crest
                 return;
             }
 
-            var disp = Vector3.zero; var dummy = Vector3.zero;
             _sampleHeightHelper.Init(transform.position, 2f * Radius);
-            _sampleHeightHelper.Sample(ref disp, ref dummy, ref dummy);
+            _sampleHeightHelper.Sample(out Vector3 disp, out _, out _);
 
             // Enforce upwards
             transform.rotation = Quaternion.Euler(90f, 0f, 0f);
@@ -171,8 +170,7 @@ namespace Crest
 
             {
                 _sampleFlowHelper.Init(transform.position, _object.ObjectWidth);
-                Vector2 surfaceFlow = Vector2.zero;
-                _sampleFlowHelper.Sample(ref surfaceFlow);
+                _sampleFlowHelper.Sample(out var surfaceFlow);
                 vel -= new Vector3(surfaceFlow.x, 0, surfaceFlow.y);
             }
             vel.y *= _weightUpDownMul;

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrDynWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrDynWaves.cs
@@ -122,7 +122,6 @@ namespace Crest
             {
                 LodDataMgrFlow.BindNull(simMaterial);
             }
-
         }
 
         public static void CountWaveSims(int countFrom, out int o_present, out int o_active)

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterClipSurfaceInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterClipSurfaceInput.cs
@@ -49,9 +49,8 @@ namespace Crest
             {
                 var position = transform.position;
                 _sampleHeightHelper.Init(position, 0f);
-                float waterHeight = 0f;
 
-                if (_sampleHeightHelper.Sample(ref waterHeight))
+                if (_sampleHeightHelper.Sample(out float waterHeight))
                 {
                     position.y = waterHeight;
                     _enabled = Mathf.Abs(_renderer.bounds.ClosestPoint(position).y - waterHeight) < 1;

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
@@ -121,8 +121,7 @@ namespace Crest
                 {
                     // This can be called multiple times per frame - one for each LOD potentially
                     _sampleHelper.Init(transform.position, 0f, true, this);
-                    Vector3 displacement = Vector3.zero, dummy = Vector3.zero;
-                    _sampleHelper.Sample(ref displacement, ref dummy, ref dummy);
+                    _sampleHelper.Sample(out Vector3 displacement, out _, out _);
                     _material.SetVector(sp_DisplacementAtInputPosition, displacement);
                 }
                 else

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -712,8 +712,7 @@ namespace Crest
         {
             _sampleHeightHelper.Init(Viewpoint.position, 0f, true);
 
-            float waterHeight = 0f;
-            _sampleHeightHelper.Sample(ref waterHeight);
+            _sampleHeightHelper.Sample(out var waterHeight);
 
             ViewerHeightAboveWater = Viewpoint.position.y - waterHeight;
         }


### PR DESCRIPTION
My 'out game' has not been on point in the past, some annoying cruft can be removed by moving the sampling helpers to use out params.

Let me know what you think