### PR TITLE
Fix ocean tiles frustum culling

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/OceanChunkRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanChunkRenderer.cs
@@ -5,6 +5,10 @@
 using UnityEngine;
 using UnityEngine.Rendering;
 
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
+
 namespace Crest
 {
     /// <summary>
@@ -256,4 +260,27 @@ namespace Crest
             Gizmos.DrawLine(new Vector3(xmin, ymax, zmax), new Vector3(xmin, ymin, zmax));
         }
     }
+
+#if UNITY_EDITOR
+    [CustomEditor(typeof(OceanChunkRenderer))]
+    public class OceanChunkRendererEditor : Editor
+    {
+        Renderer renderer;
+        public override void OnInspectorGUI()
+        {
+            base.OnInspectorGUI();
+
+            var oceanChunkRenderer = target as OceanChunkRenderer;
+
+            if (renderer == null)
+            {
+                renderer = oceanChunkRenderer.GetComponent<Renderer>();
+            }
+
+            GUI.enabled = false;
+            EditorGUILayout.BoundsField("Expanded Bounds", renderer.bounds);
+            GUI.enabled = true;
+        }
+    }
+#endif
 }

--- a/crest/Assets/Crest/Crest/Scripts/OceanChunkRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanChunkRenderer.cs
@@ -35,7 +35,17 @@ namespace Crest
         void Start()
         {
             Rend = GetComponent<Renderer>();
-            _mesh = GetComponent<MeshFilter>().sharedMesh;
+#if UNITY_EDITOR
+            if (!Application.isPlaying)
+            {
+                _mesh = GetComponent<MeshFilter>().sharedMesh;
+            }
+            else
+#endif
+            {
+                // An unshared mesh will break instancing, but a shared mesh will break culling due to shared bounds.
+                _mesh = GetComponent<MeshFilter>().mesh;
+            }
 
             UpdateMeshBounds();
         }

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -632,6 +632,8 @@ namespace Crest
                 }
             }
 
+            LateUpdateResetMaxDisplacementFromShape();
+
             if (_followViewpoint && Viewpoint != null)
             {
                 LateUpdatePosition();
@@ -772,6 +774,22 @@ namespace Crest
             _canSkipCulling = WaterBody.WaterBodies.Count == 0;
         }
 
+        void LateUpdateResetMaxDisplacementFromShape()
+        {
+            // If time stops, then reporting will become inconsistent.
+            if (Time.timeScale == 0)
+            {
+                return;
+            }
+
+            if (FrameCount != _maxDisplacementCachedTime)
+            {
+                _maxHorizDispFromShape = _maxVertDispFromShape = _maxVertDispFromWaves = 0f;
+            }
+
+            _maxDisplacementCachedTime = FrameCount;
+        }
+
         /// <summary>
         /// Could the ocean horizontal scale increase (for e.g. if the viewpoint gains altitude). Will be false if ocean already at maximum scale.
         /// </summary>
@@ -787,16 +805,15 @@ namespace Crest
         /// </summary>
         public void ReportMaxDisplacementFromShape(float maxHorizDisp, float maxVertDisp, float maxVertDispFromWaves)
         {
-            if (FrameCount != _maxDisplacementCachedTime)
+            // If time stops, then reporting will become inconsistent.
+            if (Time.timeScale == 0)
             {
-                _maxHorizDispFromShape = _maxVertDispFromShape = _maxVertDispFromWaves = 0f;
+                return;
             }
 
             _maxHorizDispFromShape += maxHorizDisp;
             _maxVertDispFromShape += maxVertDisp;
             _maxVertDispFromWaves += maxVertDispFromWaves;
-
-            _maxDisplacementCachedTime = FrameCount;
         }
         float _maxHorizDispFromShape = 0f;
         float _maxVertDispFromShape = 0f;


### PR DESCRIPTION
Fixes #585 by fixing both the displacement reporting and reverting shared mesh usage.

Displacement reporting had shared state that was being overwritten which is now fixed. There are still some very minor issues with displacement reporting. I have to freeze time to get correct culling when using the frame debugger. It works fine otherwise. I think using delegates and making Crest more event oriented should help with this further.

And lastly there is moving away from shared meshes. We will lose instancing as a result, but culling is more important. Using sharedMesh in the editor is still correct from testing. The mesh bounds gizmos don't expand in edit mode, but using a mesh instance didn't appear to fix it.

I've also added a custom inspector to show the renderer bounds in the inspector.


