### PR TITLE
Fix precision issues in grid

### DIFF
--- a/crest/Assets/Crest/Crest/Shaders/OceanHelpers.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanHelpers.hlsl
@@ -30,8 +30,8 @@ float ComputeLodAlpha(float3 i_worldPos, float i_meshScaleAlpha)
 
 void SnapAndTransitionVertLayout(float i_meshScaleAlpha, inout float3 io_worldPos, out float o_lodAlpha)
 {
-	// see comments above on _GeomData
-	const float GRID_SIZE_2 = 2.0*_GeomData.y, GRID_SIZE_4 = 4.0*_GeomData.y;
+	// Grid includes small "epsilon" to solve numerical issues.
+	const float GRID_SIZE_2 = 2.00000012 *  _GeomData.y, GRID_SIZE_4 = 4.0 * _GeomData.y;
 
 	// snap the verts to the grid
 	// The snap size should be twice the original size to keep the shape of the eight triangles (otherwise the edge layout changes).

--- a/crest/Assets/Crest/Crest/Shaders/OceanVertHelpers.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanVertHelpers.hlsl
@@ -33,7 +33,8 @@ float ComputeLodAlpha(float3 i_worldPos, float i_meshScaleAlpha, in const float3
 
 void SnapAndTransitionVertLayout(in const float i_meshScaleAlpha, in const float3 i_oceanPosScale0, in const float i_geometryGridSize, inout float3 io_worldPos, out float o_lodAlpha)
 {
-	const float GRID_SIZE_2 = 2.0 * i_geometryGridSize, GRID_SIZE_4 = 4.0 * i_geometryGridSize;
+	// Grid includes small "epsilon" to solve numerical issues.
+	const float GRID_SIZE_2 = 2.00000012 * i_geometryGridSize, GRID_SIZE_4 = 4.0 * i_geometryGridSize;
 
 	// snap the verts to the grid
 	// The snap size should be twice the original size to keep the shape of the eight triangles (otherwise the edge layout changes).


### PR DESCRIPTION
I have been seeing gaps in the ocean tiles at particular coordinates. It appears to be a precision issue in the grid. This is not screen resolution dependent so you should be able to reproduce with provided example scene.

![1_Broke](https://user-images.githubusercontent.com/5249806/88022655-46022280-cb62-11ea-8175-1c7126b2a7f7.jpg)
Without fix

![1_Fixed](https://user-images.githubusercontent.com/5249806/88022673-4c909a00-cb62-11ea-904a-200e3a511e54.jpg)
With fix

I am not sure if this is just my machine or not. I would think I would have noticed this when developing the black point fade fix which was developed on different machines. I had a look at the LOD fade and it didn't have any affect on this issue.

It appears when either the X or Z coordinates is nearly divisible by 8 (so 7.999997 or 15.999997). The gaps will appear in different locations depending how large the whole number is.

_Geometry Down Sample Factor_ has an affect but only a value of 8 clears it without the fix.

Increasing _2.0_ by _0.000001_ is the smallest number that fixes the issue. Going larger will start to spread the grid apart.

I will fix up the commit if this is indeed an issue on other machines. I experienced the issue on MacOS and Windows (both on MacBook Pro), but only tested the fix on MacOS. I looked back and this issue occurs for me back in commits from 2019. So I am a bit suspicious of my computer. Occurs on HDRP too. I haven't tested URP but I guess it would be there too.

### Testing

Open up the _PrecisionIssuesExample_ scene. Enter play mode and the gaps should be there. Enable the fix on the ocean material to have it fixed.



