### PR TITLE
Fix underwater safety margin edge cases

### DIFF
--- a/crest/Assets/Crest/Crest-Examples/Shared/Scripts/CamController.cs
+++ b/crest/Assets/Crest/Crest-Examples/Shared/Scripts/CamController.cs
@@ -23,6 +23,9 @@ public class CamController : MonoBehaviour
     [System.Serializable]
     class DebugFields
     {
+        [Tooltip("Disables controller preventing the camera from rolling (rotating on the z axis).")]
+        public bool disableCameraRollPrevention = false;
+
         [Tooltip("Disables the XR occlusion mesh for debugging purposes. Only works with legacy XR.")]
         public bool disableOcclusionMesh = false;
 
@@ -150,6 +153,7 @@ public class CamController : MonoBehaviour
 
     void UpdateKillRoll()
     {
+        if (_debug.disableCameraRollPrevention) return;
         Vector3 ea = _targetTransform.eulerAngles;
         ea.z = 0f;
         transform.eulerAngles = ea;

--- a/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterPostProcessUtils.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterPostProcessUtils.cs
@@ -234,7 +234,13 @@ namespace Crest
             }
             else
             {
-                var inverseViewProjectionMatrix = (camera.GetStereoProjectionMatrix(Camera.StereoscopicEye.Left) * camera.worldToCameraMatrix).inverse;
+                // Store projection matrix to restore later.
+                var projectionMatrix = camera.projectionMatrix;
+
+                // We need to set the matrix ourselves. Maybe ViewportToWorldPoint has a bug.
+                camera.projectionMatrix = camera.GetStereoProjectionMatrix(Camera.StereoscopicEye.Left);
+
+                var inverseViewProjectionMatrix = (camera.GetStereoProjectionMatrix(Camera.StereoscopicEye.Left) * camera.GetStereoViewMatrix(Camera.StereoscopicEye.Left)).inverse;
                 underwaterPostProcessMaterial.SetMatrix(sp_InvViewProjection, inverseViewProjectionMatrix);
 
                 {
@@ -242,13 +248,19 @@ namespace Crest
                     underwaterPostProcessMaterial.SetVector(sp_HorizonPosNormal, new Vector4(pos.x, pos.y, normal.x, normal.y));
                 }
 
-                var inverseViewProjectionMatrixRightEye = (camera.GetStereoProjectionMatrix(Camera.StereoscopicEye.Right) * camera.worldToCameraMatrix).inverse;
+                // We need to set the matrix ourselves. Maybe ViewportToWorldPoint has a bug.
+                camera.projectionMatrix = camera.GetStereoProjectionMatrix(Camera.StereoscopicEye.Right);
+
+                var inverseViewProjectionMatrixRightEye = (camera.GetStereoProjectionMatrix(Camera.StereoscopicEye.Right) * camera.GetStereoViewMatrix(Camera.StereoscopicEye.Right)).inverse;
                 underwaterPostProcessMaterial.SetMatrix(sp_InvViewProjectionRight, inverseViewProjectionMatrixRightEye);
 
                 {
                     GetHorizonPosNormal(camera, Camera.MonoOrStereoscopicEye.Right, seaLevel, horizonSafetyMarginMultiplier, out Vector2 pos, out Vector2 normal);
                     underwaterPostProcessMaterial.SetVector(sp_HorizonPosNormalRight, new Vector4(pos.x, pos.y, normal.x, normal.y));
                 }
+
+                // Restore projection matrix.
+                camera.projectionMatrix = projectionMatrix;
             }
 
             // Not sure why we need to do this - blit should set it...?

--- a/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterPostProcessUtils.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterPostProcessUtils.cs
@@ -386,10 +386,12 @@ namespace Crest
                         var cameraToSeaLevelSign = seaLevel - camera.transform.position.y;
                         cameraToSeaLevelSign = cameraToSeaLevelSign > 0f ? 1f : cameraToSeaLevelSign < 0f ? -1f : 0f;
 
+                        // We want to invert the direction of the multiplier when underwater.
+                        horizonSafetyMarginMultiplier *= -cameraToSeaLevelSign;
                         // For compatibility so previous 0.01f property value is the same strength as before.
-                        horizonSafetyMarginMultiplier *= 0.01f * cameraToSeaLevelSign;
+                        horizonSafetyMarginMultiplier *= 0.01f;
                         // We use the normal so the multiplier is applied in the correct direction.
-                        resultPos += -resultNormal.normalized * horizonSafetyMarginMultiplier;
+                        resultPos += resultNormal.normalized * horizonSafetyMarginMultiplier;
                     }
                     else
                     {

--- a/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterPostProcessUtils.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterPostProcessUtils.cs
@@ -340,6 +340,22 @@ namespace Crest
                         {
                             resultNormal = -resultNormal;
                         }
+
+                        // The above will sometimes produce a normal that is inverted around 90° along the Z axis. Here
+                        // we are using world up to make sure that water is world down.
+                        {
+                            var cameraFacing = Vector3.Dot(camera.transform.right, Vector3.up);
+                            var normalFacing = Vector2.Dot(resultNormal, Vector2.right);
+
+                            if (cameraFacing > 0.75f && normalFacing > 0.9f)
+                            {
+                                resultNormal = -resultNormal;
+                            }
+                            else if (cameraFacing < -0.75f && normalFacing < -0.9f)
+                            {
+                                resultNormal = -resultNormal;
+                            }
+                        }
                     }
                     else
                     {


### PR DESCRIPTION
Hopefully fixes #520

Solves a handful of edge cases for the underwater horizon.

## Fixes

### Edge case where camera is +/-90° roll

The horizon normal would sometimes be inverted when camera has +/-90° roll which may have been due to precision errors. I have added a fuzzy check to catch this.

### Safety margin didn't handle camera roll

The margin was added the horizon position up. But up will be along the normal when the camera is rolled. This result in the multiplier either having no effect or the opposite effect. I just used then normal to take roll into account.

### Safety margin could be too large

The camera position to sea level was being used for the safety margin which lead to it sometimes covering a quarter of the screen. I have changed it to only use the sign so the margin's size is determined by the multiplier property. This fixed a lot of edge cases where checks to disable the margin failed.

### Fix Single Pass XR

The ocean surface on the right eye is slightly higher than the left, leaving a gap and the safety margin falling short. Looks like we had to set the projection matrix on the camera.

## Testing

I know how to reproduce on my machine. An ocean with no waves and:

```
Camera Position
X = 0
Y = -0.2
Z = 0.16

Camera Rotation
X = -4.68
Y = 0
Z = 0
```

In the game view, there is a dropdown where you can add your own screen dimension presets. Create one with a height of 684. Width doesn't appear to make a difference. Then set that preset.

I've added a debug option to disable camera kill roll.