### PR TITLE
Refactor - remove dispatch logic from PropertyWrapperCompute

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Helpers/PropertyWrapper.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/PropertyWrapper.cs
@@ -75,38 +75,6 @@ namespace Crest
         public void SetVector(int param, Vector4 value) { _commandBuffer.SetComputeVectorParam(_computeShader, param, value); }
         public void SetVectorArray(int param, Vector4[] value) { _commandBuffer.SetComputeVectorArrayParam(_computeShader, param, value); }
         public void SetMatrix(int param, Matrix4x4 value) { _commandBuffer.SetComputeMatrixParam(_computeShader, param, value); }
-
-        // NOTE: these MUST match the values in OceanLODData.hlsl
-        // 64 recommended as a good common minimum: https://www.reddit.com/r/GraphicsProgramming/comments/aeyfkh/for_compute_shaders_is_there_an_ideal_numthreads/
-        public const int THREAD_GROUP_SIZE_X = 8;
-        public const int THREAD_GROUP_SIZE_Y = 8;
-        public void DispatchShader()
-        {
-            _commandBuffer.DispatchCompute(
-                _computeShader, _computeKernel,
-                OceanRenderer.Instance.LodDataResolution / THREAD_GROUP_SIZE_X,
-                OceanRenderer.Instance.LodDataResolution / THREAD_GROUP_SIZE_Y,
-                1
-            );
-
-            _commandBuffer = null;
-            _computeShader = null;
-            _computeKernel = -1;
-        }
-
-        public void DispatchShaderMultiLOD()
-        {
-            _commandBuffer.DispatchCompute(
-                _computeShader, _computeKernel,
-                OceanRenderer.Instance.LodDataResolution / THREAD_GROUP_SIZE_X,
-                OceanRenderer.Instance.LodDataResolution / THREAD_GROUP_SIZE_Y,
-                OceanRenderer.Instance.CurrentLodCount
-            );
-
-            _commandBuffer = null;
-            _computeShader = null;
-            _computeKernel = -1;
-        }
     }
 
     [System.Serializable]

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/TextureArrayHelpers.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/TextureArrayHelpers.cs
@@ -46,8 +46,8 @@ namespace Crest
             s_clearToBlackShader.SetTexture(krnl_ClearToBlack, sp_LD_TexArray_Target, dst);
             s_clearToBlackShader.Dispatch(
                 krnl_ClearToBlack,
-                OceanRenderer.Instance.LodDataResolution / PropertyWrapperCompute.THREAD_GROUP_SIZE_X,
-                OceanRenderer.Instance.LodDataResolution / PropertyWrapperCompute.THREAD_GROUP_SIZE_Y,
+                OceanRenderer.Instance.LodDataResolution / LodDataMgr.THREAD_GROUP_SIZE_X,
+                OceanRenderer.Instance.LodDataResolution / LodDataMgr.THREAD_GROUP_SIZE_Y,
                 dst.volumeDepth
             );
         }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgr.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgr.cs
@@ -20,6 +20,11 @@ namespace Crest
         // determines the size of the texture arrays in the shaders.
         public const int MAX_LOD_COUNT = 15;
 
+        // NOTE: these MUST match the values in OceanLODData.hlsl
+        // 64 recommended as a good common minimum: https://www.reddit.com/r/GraphicsProgramming/comments/aeyfkh/for_compute_shaders_is_there_an_ideal_numthreads/
+        public const int THREAD_GROUP_SIZE_X = 8;
+        public const int THREAD_GROUP_SIZE_Y = 8;
+
         protected abstract int GetParamIdSampler(bool sourceLod = false);
 
         protected abstract bool NeedToReadWriteTextureData { get; }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrAnimWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrAnimWaves.cs
@@ -379,7 +379,10 @@ namespace Crest
 
                 _combineProperties.SetInt(sp_LD_SliceIndex, lodIdx);
 
-                buf.DispatchCompute(_combineShader, selectedShaderKernel, OceanRenderer.Instance.LodDataResolution / THREAD_GROUP_SIZE_X, OceanRenderer.Instance.LodDataResolution / THREAD_GROUP_SIZE_Y, 1);
+                buf.DispatchCompute(_combineShader, selectedShaderKernel,
+                    OceanRenderer.Instance.LodDataResolution / THREAD_GROUP_SIZE_X,
+                    OceanRenderer.Instance.LodDataResolution / THREAD_GROUP_SIZE_Y,
+                    1);
             }
         }
 

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrAnimWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrAnimWaves.cs
@@ -378,7 +378,8 @@ namespace Crest
                 );
 
                 _combineProperties.SetInt(sp_LD_SliceIndex, lodIdx);
-                _combineProperties.DispatchShader();
+
+                buf.DispatchCompute(_combineShader, selectedShaderKernel, OceanRenderer.Instance.LodDataResolution / THREAD_GROUP_SIZE_X, OceanRenderer.Instance.LodDataResolution / THREAD_GROUP_SIZE_Y, 1);
             }
         }
 

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrPersistent.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrPersistent.cs
@@ -129,7 +129,10 @@ namespace Crest
                 // Bind current data
                 BindData(_renderSimProperties, null, false, ref OceanRenderer.Instance._lodTransform._renderData, false);
 
-                _renderSimProperties.DispatchShaderMultiLOD();
+                buf.DispatchCompute(_shader, krnl_ShaderSim,
+                    OceanRenderer.Instance.LodDataResolution / THREAD_GROUP_SIZE_X,
+                    OceanRenderer.Instance.LodDataResolution / THREAD_GROUP_SIZE_Y,
+                    OceanRenderer.Instance.CurrentLodCount);
 
                 for (var lodIdx = lodCount - 1; lodIdx >= 0; lodIdx--)
                 {

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Shadows/LodDataMgrShadow.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Shadows/LodDataMgrShadow.cs
@@ -235,7 +235,11 @@ namespace Crest
                 _renderProperties.SetInt(sp_LD_SliceIndex_Source, srcDataIdx);
                 BindSourceData(_renderProperties, false);
                 _renderProperties.SetTexture(sp_LD_TexArray_Target, _targets);
-                _renderProperties.DispatchShader();
+
+                BufCopyShadowMap.DispatchCompute(_updateShadowShader, krnl_UpdateShadow,
+                    OceanRenderer.Instance.LodDataResolution / THREAD_GROUP_SIZE_X,
+                    OceanRenderer.Instance.LodDataResolution / THREAD_GROUP_SIZE_Y,
+                    1);
             }
         }
 


### PR DESCRIPTION
**Status:** Ready to merge

Removes dispatch logic from PropertyWrapperCompute.

Few reasons for this:

- Brings in line with other wrappers which serve only to wrap
- The dispatch is a single line of code and can be done outside
- Resetting state after dispatch means wrapper needs to be re-initd
- Thread group size should in general vary based on shader/workload,
so should not be baked into wrapper

I bumped into these a couple of times on dev branches so thought i should
submit this pr.

Oh i also thought we should move THREAD_GROUP_SIZE_X/Y into LodDataMgr
as i guess logically it can be considered a default value for lod-data related things
(and is paired with constants in OceanLodData.hlsl..).