### PR TITLE
Update displacement correction policy for ocean inputs

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterAnimWavesInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterAnimWavesInput.cs
@@ -10,7 +10,7 @@ namespace Crest
     /// Registers a custom input to the wave shape. Attach this GameObjects that you want to render into the displacmeent textures to affect ocean shape.
     /// </summary>
     [ExecuteAlways]
-    public class RegisterAnimWavesInput : RegisterLodDataInputDisplacementCorrection<LodDataMgrAnimWaves>
+    public class RegisterAnimWavesInput : RegisterLodDataInput<LodDataMgrAnimWaves>
     {
         public override bool Enabled => true;
 
@@ -28,6 +28,10 @@ namespace Crest
         protected override Color GizmoColor => s_gizmoColor;
 
         protected override string ShaderPrefix => "Crest/Inputs/Animated Waves";
+
+        [SerializeField, Tooltip("Whether this input data should displace horizontally with waves. If false, data will not move from side to side with the waves. Adds a small performance overhead when disabled.")]
+        bool _followHorizontalMotion = true;
+        protected override bool FollowHorizontalMotion => _followHorizontalMotion;
 
         [SerializeField, Tooltip("Inform ocean how much this input will displace the ocean surface vertically. This is used to set bounding box heights for the ocean tiles.")]
         float _maxDisplacementVertical = 0f;

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
@@ -234,7 +234,7 @@ namespace Crest
     public abstract class RegisterLodDataInputDisplacementCorrection<LodDataType> : RegisterLodDataInput<LodDataType>
         where LodDataType : LodDataMgr
     {
-        [SerializeField, Tooltip("Correct for horizontal displacement so that this input does not move from side to side with the waves. Adds a small performance overhead when disabled.")]
+        [SerializeField, Tooltip("Whether this input data should displace horizontally with waves. If false, data will not move from side to side with the waves. Adds a small performance overhead when disabled.")]
         bool _followHorizontalMotion = false;
 
         protected override bool FollowHorizontalMotion => _followHorizontalMotion;


### PR DESCRIPTION
I had a nasty case where i was adding an anim waves input which had
displacements, and since the correction was on by default, there was
a feedback loop where the displacement in the input moved the input
itself around. This disables correction on anim waves inputs by default.
I looked for a fancier way to do this (rather than duping some code)
but settled on this.

Also the tooltip was wrong on the gui, fixed.