### PR TITLE
Example height component using UnityEvents

### DIFF
--- a/USERGUIDE.md
+++ b/USERGUIDE.md
@@ -446,6 +446,9 @@ When rendering the ocean, the various LOD data are sample for each vert and the 
 **Can I sample the water height at a position from C#?**
 Yes, see *SampleHeightHelper*. *OceanRenderer* uses this helper to get the height of the viewer above the water, and makes this viewer height available via the *ViewerHeightAboveWater* property.
 
+**Can I trigger something when an object is above or under the ocean surface without any scripting knowledge?**
+The *OceanSampleHeightEvents* can be used for this purpose. It will invoke a *UnityEvent* when the attached game object is above or below the ocean surface once per state change.
+
 **Is Crest well suited for medium-to-low powered mobile devices?**
 Crest is built to be performant by design and has numerous quality/performance levers.
 However it is also built to be very flexible and powerful and as such can not compete with a minimal, mobile-centric ocean renderer such as the one in the *BoatAttack* project.

--- a/crest/Assets/Crest/Crest-Examples/Shared/Scripts/Collision/OceanSampleHeightEvents.cs
+++ b/crest/Assets/Crest/Crest-Examples/Shared/Scripts/Collision/OceanSampleHeightEvents.cs
@@ -15,8 +15,10 @@ using UnityEditor;
 /// </summary>
 public class OceanSampleHeightEvents : MonoBehaviour
 {
-    [Tooltip("The higher the value, the more smaller waves will be ignored.")]
-    [SerializeField] float _samplingLengthScale = 1f;
+    [Header("Settings For All Events")]
+
+    [Tooltip("The higher the value, the more smaller waves will be ignored when sampling the ocean surface.")]
+    [SerializeField] float _minimumWaveLength = 1f;
 
 
     [Header("Distance From Ocean Surface")]
@@ -50,7 +52,7 @@ public class OceanSampleHeightEvents : MonoBehaviour
 
     void Update()
     {
-        _sampleHeightHelper.Init(transform.position, 2f * _samplingLengthScale);
+        _sampleHeightHelper.Init(transform.position, 2f * _minimumWaveLength);
 
         if (_sampleHeightHelper.Sample(out var height))
         {

--- a/crest/Assets/Crest/Crest-Examples/Shared/Scripts/Collision/OceanSampleHeightEvents.cs
+++ b/crest/Assets/Crest/Crest-Examples/Shared/Scripts/Collision/OceanSampleHeightEvents.cs
@@ -1,0 +1,75 @@
+﻿// Crest Ocean System
+
+// This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
+
+using Crest;
+using UnityEngine;
+using UnityEngine.Events;
+
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
+
+/// <summary>
+/// Emits an event on state change for when either above or below the ocean surface.
+/// </summary>
+public class OceanSampleHeightEvents : MonoBehaviour
+{
+    [Tooltip("The higher the value, the more smaller waves will be ignored.")]
+    [SerializeField] float _samplingLengthScale = 1f;
+    [SerializeField] UnityEvent _onBelowOceanSurface = new UnityEvent();
+    public UnityEvent OnBelowOceanSurface => _onBelowOceanSurface;
+    [SerializeField] UnityEvent _onAboveOceanSurface = new UnityEvent();
+    public UnityEvent OnAboveOceanSurface => _onAboveOceanSurface;
+
+    // Store state
+    bool _isAboveSurface = false;
+    bool _isFirstUpdate = true;
+    readonly SampleHeightHelper _sampleHeightHelper = new SampleHeightHelper();
+
+    void Update()
+    {
+        _sampleHeightHelper.Init(transform.position, 2f * _samplingLengthScale);
+
+        if (_sampleHeightHelper.Sample(out var height))
+        {
+            var isAboveSurface = (transform.position.y - height) > 0;
+
+            // Has the below/above ocean surface state changed?
+            if (_isAboveSurface != isAboveSurface || _isFirstUpdate)
+            {
+                _isAboveSurface = isAboveSurface;
+                _isFirstUpdate = false;
+
+                if (_isAboveSurface)
+                {
+                    _onAboveOceanSurface.Invoke();
+                }
+                else
+                {
+                    _onBelowOceanSurface.Invoke();
+                }
+            }
+        }
+    }
+
+#if UNITY_EDITOR
+    [CustomEditor(typeof(OceanSampleHeightEvents))]
+    public class OceanSampleHeightEventsEditor : Editor
+    {
+        public override void OnInspectorGUI()
+        {
+            EditorGUILayout.Space();
+            EditorGUILayout.HelpBox
+            (
+                "Whenever this game object goes below or above the ocean surface, the appropriate event is fired " +
+                "once per state change. It can be used to trigger audio to play underwater and much more.",
+                MessageType.Info
+            );
+            EditorGUILayout.Space();
+
+            base.OnInspectorGUI();
+        }
+    }
+#endif
+}

--- a/crest/Assets/Crest/Crest-Examples/Shared/Scripts/Collision/OceanSampleHeightEvents.cs
+++ b/crest/Assets/Crest/Crest-Examples/Shared/Scripts/Collision/OceanSampleHeightEvents.cs
@@ -11,7 +11,7 @@ using UnityEditor;
 #endif
 
 /// <summary>
-/// Emits an event on state change for when either above or below the ocean surface.
+/// Emits useful events (UnityEvents) based on the sampled height of the ocean surface.
 /// </summary>
 public class OceanSampleHeightEvents : MonoBehaviour
 {

--- a/crest/Assets/Crest/Crest-Examples/Shared/Scripts/Collision/OceanSampleHeightEvents.cs
+++ b/crest/Assets/Crest/Crest-Examples/Shared/Scripts/Collision/OceanSampleHeightEvents.cs
@@ -23,7 +23,7 @@ public class OceanSampleHeightEvents : MonoBehaviour
 
     [Header("Distance From Ocean Surface")]
 
-    [Tooltip("Distance from ocean surface will be between zero and one.")]
+    [Tooltip("A normalised distance from ocean surface will be between zero and one.")]
     [SerializeField] bool _normaliseDistance = true;
 
     [Tooltip("The maximum distance passed to function. Always use a real distance value (not a normalised one).")]

--- a/crest/Assets/Crest/Crest-Examples/Shared/Scripts/Collision/OceanSampleHeightEvents.cs
+++ b/crest/Assets/Crest/Crest-Examples/Shared/Scripts/Collision/OceanSampleHeightEvents.cs
@@ -17,15 +17,36 @@ public class OceanSampleHeightEvents : MonoBehaviour
 {
     [Tooltip("The higher the value, the more smaller waves will be ignored.")]
     [SerializeField] float _samplingLengthScale = 1f;
+
+
+    [Header("Distance From Ocean Surface")]
+
+    [Tooltip("Distance from ocean surface will be between zero and one.")]
+    [SerializeField] bool _normaliseDistance = true;
+
+    [Tooltip("The maximum distance passed to function. Always use a real distance value (not a normalised one).")]
+    [SerializeField] float _maximumDistance = 100f;
+
+    [Tooltip("Apply a curve to the distance passed to the function.")]
+    [SerializeField] AnimationCurve _distanceCurve = AnimationCurve.Linear(0f, 0f, 1f, 1f);
+
+
+    [Header("Events")]
+
     [SerializeField] UnityEvent _onBelowOceanSurface = new UnityEvent();
     public UnityEvent OnBelowOceanSurface => _onBelowOceanSurface;
     [SerializeField] UnityEvent _onAboveOceanSurface = new UnityEvent();
     public UnityEvent OnAboveOceanSurface => _onAboveOceanSurface;
+    [SerializeField] FloatEvent _distanceFromOceanSurface = new FloatEvent();
+    public FloatEvent DistanceFromOceanSurface => _distanceFromOceanSurface;
 
     // Store state
     bool _isAboveSurface = false;
     bool _isFirstUpdate = true;
     readonly SampleHeightHelper _sampleHeightHelper = new SampleHeightHelper();
+
+    // Dynamic UnityEvent definitions.
+    [System.Serializable] public class FloatEvent : UnityEvent<float> { }
 
     void Update()
     {
@@ -33,7 +54,8 @@ public class OceanSampleHeightEvents : MonoBehaviour
 
         if (_sampleHeightHelper.Sample(out var height))
         {
-            var isAboveSurface = (transform.position.y - height) > 0;
+            var distance = transform.position.y - height;
+            var isAboveSurface = distance > 0;
 
             // Has the below/above ocean surface state changed?
             if (_isAboveSurface != isAboveSurface || _isFirstUpdate)
@@ -50,6 +72,21 @@ public class OceanSampleHeightEvents : MonoBehaviour
                     _onBelowOceanSurface.Invoke();
                 }
             }
+
+            // Save some processing when not being used.
+            if (_distanceFromOceanSurface.GetPersistentEventCount() > 0)
+            {
+                // Normalise distance so we can use the curve.
+                var distanceFromOceanSurface = _distanceCurve.Evaluate(1f - Mathf.Abs(distance) / _maximumDistance);
+
+                // Restore raw distance if desired.
+                if (!_normaliseDistance)
+                {
+                    distanceFromOceanSurface = _maximumDistance - distanceFromOceanSurface * _maximumDistance;
+                }
+
+                _distanceFromOceanSurface.Invoke(distanceFromOceanSurface);
+            }
         }
     }
 
@@ -62,8 +99,10 @@ public class OceanSampleHeightEvents : MonoBehaviour
             EditorGUILayout.Space();
             EditorGUILayout.HelpBox
             (
-                "Whenever this game object goes below or above the ocean surface, the appropriate event is fired " +
-                "once per state change. It can be used to trigger audio to play underwater and much more.",
+                "For the Above/Below Ocean Surface Events, whenever this game object goes below or above the ocean " + 
+                "surface, the appropriate event is fired once per state change. It can be used to trigger audio to " +
+                "play underwater and much more. For the Distance From Ocean Surface event, it will pass the " +
+                "distance every frame (passing normalised distance to audio volume as an example).",
                 MessageType.Info
             );
             EditorGUILayout.Space();

--- a/crest/Assets/Crest/Crest-Examples/Shared/Scripts/Collision/OceanSampleHeightEvents.cs.meta
+++ b/crest/Assets/Crest/Crest-Examples/Shared/Scripts/Collision/OceanSampleHeightEvents.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0ff8316675e444bc893ea5ecbbf3ba26
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Adds a component that will invoke an event for when the game object changes state from above to below the ocean surface and vice versa.

It can be used to trigger audio and many other things. Pretty versatile and powerful for those who don't know scripting.