### PR TITLE
OceanLODData.hlsl removed

### DIFF
--- a/crest/Assets/Crest/Crest/Shaders/Ocean.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Ocean.shader
@@ -317,7 +317,7 @@ Shader "Crest/Ocean"
 				// Data that needs to be sampled at the undisplaced position
 				if (wt_smallerLod > 0.001)
 				{
-					const float3 uv_slice_smallerLod = WorldToUV(positionWS_XZ_before);
+					const float3 uv_slice_smallerLod = WorldToUV(positionWS_XZ_before, _LD_Pos_Scale[_LD_SliceIndex], _LD_Params[_LD_SliceIndex], _LD_SliceIndex);
 
 					#if !_DEBUGDISABLESHAPETEXTURES_ON
 					half sss = 0.;
@@ -354,7 +354,7 @@ Shader "Crest/Ocean"
 				// Data that needs to be sampled at the displaced position
 				if (wt_smallerLod > 0.0001)
 				{
-					const float3 uv_slice_smallerLodDisp = WorldToUV(o.worldPos.xz);
+					const float3 uv_slice_smallerLodDisp = WorldToUV(o.worldPos.xz, _LD_Pos_Scale[_LD_SliceIndex], _LD_Params[_LD_SliceIndex], _LD_SliceIndex);
 
 					#if _SUBSURFACESHALLOWCOLOUR_ON
 					// The minimum sampling weight is lower (0.0001) than others to fix shallow water colour popping.
@@ -458,7 +458,8 @@ Shader "Crest/Ocean"
 				half clipVal = 0.0;
 				if (wt_smallerLod > 0.001)
 				{
-					SampleClip(_LD_TexArray_ClipSurface, WorldToUV(input.worldPos.xz), wt_smallerLod, clipVal);
+					const float3 uv_slice_smallerLod = WorldToUV(input.worldPos.xz, _LD_Pos_Scale[_LD_SliceIndex], _LD_Params[_LD_SliceIndex], _LD_SliceIndex);
+					SampleClip(_LD_TexArray_ClipSurface, uv_slice_smallerLod, wt_smallerLod, clipVal);
 				}
 				if (wt_biggerLod > 0.001)
 				{
@@ -493,11 +494,14 @@ Shader "Crest/Ocean"
 					;
 
 				// Normal - geom + normal mapping. Subsurface scattering.
-				const float3 uv_slice_smallerLod = WorldToUV(input.lodAlpha_worldXZUndisplaced_oceanDepth.yz);
 				float3 dummy = 0.;
 				half3 n_geom = half3(0.0, 1.0, 0.0);
 				half sss = 0.;
-				if (wt_smallerLod > 0.001) SampleDisplacementsNormals(_LD_TexArray_AnimatedWaves, uv_slice_smallerLod, wt_smallerLod, _LD_Params[_LD_SliceIndex].w, _LD_Params[_LD_SliceIndex].x, dummy, n_geom.xz, sss);
+				if (wt_smallerLod > 0.001)
+				{
+					const float3 uv_slice_smallerLod = WorldToUV(input.lodAlpha_worldXZUndisplaced_oceanDepth.yz, _LD_Pos_Scale[_LD_SliceIndex], _LD_Params[_LD_SliceIndex], _LD_SliceIndex);
+					SampleDisplacementsNormals(_LD_TexArray_AnimatedWaves, uv_slice_smallerLod, wt_smallerLod, _LD_Params[_LD_SliceIndex].w, _LD_Params[_LD_SliceIndex].x, dummy, n_geom.xz, sss);
+				}
 				if (wt_biggerLod > 0.001)
 				{
 					const uint si = _LD_SliceIndex + 1;

--- a/crest/Assets/Crest/Crest/Shaders/Ocean.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Ocean.shader
@@ -279,7 +279,6 @@ Shader "Crest/Ocean"
 			#include "OceanConstants.hlsl"
 			#include "OceanGlobals.hlsl"
 			#include "OceanInputsDriven.hlsl"
-			#include "OceanLODData.hlsl"
 			#include "OceanHelpersNew.hlsl"
 			#include "OceanHelpers.hlsl"
 

--- a/crest/Assets/Crest/Crest/Shaders/Ocean.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Ocean.shader
@@ -334,7 +334,8 @@ Shader "Crest/Ocean"
 				}
 				if (wt_biggerLod > 0.001)
 				{
-					const float3 uv_slice_biggerLod = WorldToUV_BiggerLod(positionWS_XZ_before);
+					const uint si = _LD_SliceIndex + 1;
+					const float3 uv_slice_biggerLod = WorldToUV(positionWS_XZ_before, _LD_Pos_Scale[si], _LD_Params[si], si);
 
 					#if !_DEBUGDISABLESHAPETEXTURES_ON
 					half sss = 0.;
@@ -369,7 +370,8 @@ Shader "Crest/Ocean"
 				}
 				if (wt_biggerLod > 0.0001)
 				{
-					const float3 uv_slice_biggerLodDisp = WorldToUV_BiggerLod(o.worldPos.xz);
+					const uint si = _LD_SliceIndex + 1;
+					const float3 uv_slice_biggerLodDisp = WorldToUV(o.worldPos.xz, _LD_Pos_Scale[si], _LD_Params[si], si);
 
 					#if _SUBSURFACESHALLOWCOLOUR_ON
 					// The minimum sampling weight is lower (0.0001) than others to fix shallow water colour popping.
@@ -460,7 +462,9 @@ Shader "Crest/Ocean"
 				}
 				if (wt_biggerLod > 0.001)
 				{
-					SampleClip(_LD_TexArray_ClipSurface, WorldToUV_BiggerLod(input.worldPos.xz), wt_biggerLod, clipVal);
+					const uint si = _LD_SliceIndex + 1;
+					const float3 uv_slice_biggerLod = WorldToUV(input.worldPos.xz, _LD_Pos_Scale[si], _LD_Params[si], si);
+					SampleClip(_LD_TexArray_ClipSurface, uv_slice_biggerLod, wt_biggerLod, clipVal);
 				}
 				clipVal = lerp(_CrestClipByDefault, clipVal, wt_smallerLod + wt_biggerLod);
 				// Add 0.5 bias for LOD blending and texel resolution correction. This will help to tighten and smooth clipped edges
@@ -490,12 +494,16 @@ Shader "Crest/Ocean"
 
 				// Normal - geom + normal mapping. Subsurface scattering.
 				const float3 uv_slice_smallerLod = WorldToUV(input.lodAlpha_worldXZUndisplaced_oceanDepth.yz);
-				const float3 uv_slice_biggerLod = WorldToUV_BiggerLod(input.lodAlpha_worldXZUndisplaced_oceanDepth.yz);
 				float3 dummy = 0.;
 				half3 n_geom = half3(0.0, 1.0, 0.0);
 				half sss = 0.;
 				if (wt_smallerLod > 0.001) SampleDisplacementsNormals(_LD_TexArray_AnimatedWaves, uv_slice_smallerLod, wt_smallerLod, _LD_Params[_LD_SliceIndex].w, _LD_Params[_LD_SliceIndex].x, dummy, n_geom.xz, sss);
-				if (wt_biggerLod > 0.001) SampleDisplacementsNormals(_LD_TexArray_AnimatedWaves, uv_slice_biggerLod, wt_biggerLod, _LD_Params[_LD_SliceIndex + 1].w, _LD_Params[_LD_SliceIndex + 1].x, dummy, n_geom.xz, sss);
+				if (wt_biggerLod > 0.001)
+				{
+					const uint si = _LD_SliceIndex + 1;
+					const float3 uv_slice_biggerLod = WorldToUV(input.lodAlpha_worldXZUndisplaced_oceanDepth.yz, _LD_Pos_Scale[si], _LD_Params[si], si);
+					SampleDisplacementsNormals(_LD_TexArray_AnimatedWaves, uv_slice_biggerLod, wt_biggerLod, _LD_Params[_LD_SliceIndex + 1].w, _LD_Params[_LD_SliceIndex + 1].x, dummy, n_geom.xz, sss);
+				}
 				n_geom = normalize(n_geom);
 
 				if (underwater) n_geom = -n_geom;

--- a/crest/Assets/Crest/Crest/Shaders/OceanEmission.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanEmission.hlsl
@@ -132,7 +132,10 @@ void ApplyCaustics(in const half3 i_view, in const half3 i_lightDir, in const fl
 	// underwater caustics - dedicated to P
 	float3 camForward = mul((float3x3)unity_CameraToWorld, float3(0., 0., 1.));
 	float3 scenePos = _WorldSpaceCameraPos - i_view * i_sceneZ / dot(camForward, -i_view);
-	const float3 scenePosUV = WorldToUV_BiggerLod(scenePos.xz);
+
+	const uint si = _LD_SliceIndex + 1;
+	const float3 scenePosUV = WorldToUV(scenePos.xz, _LD_Pos_Scale[si], _LD_Params[si], si);
+
 	half3 disp = 0.;
 	half sss = 0.;
 	// this gives height at displaced position, not exactly at query position.. but it helps. i cant pass this from vert shader
@@ -171,7 +174,8 @@ void ApplyCaustics(in const half3 i_view, in const half3 i_lightDir, in const fl
 		else
 		{
 			// only sample the bigger lod. if pops are noticeable this could lerp the 2 lods smoothly, but i didnt notice issues.
-			float3 uv_biggerLod = WorldToUV_BiggerLod(shadowSurfacePosXZ);
+			const uint si = _LD_SliceIndex + 1;
+			const float3 uv_biggerLod = WorldToUV(shadowSurfacePosXZ, _LD_Pos_Scale[si], _LD_Params[si], si);
 			SampleShadow(_LD_TexArray_Shadow, uv_biggerLod, 1.0, causticShadow);
 		}
 		causticsStrength *= 1.0 - causticShadow.y;

--- a/crest/Assets/Crest/Crest/Shaders/OceanEmission.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanEmission.hlsl
@@ -62,7 +62,7 @@ half3 ScatterColour(
 		// 2. for the underwater skirt geometry, we don't have the lod data sampled from the verts with lod transitions etc,
 		//    so just approximate by sampling at the camera position.
 		// this used to sample LOD1 but that doesnt work in last LOD, the data will be missing.
-		const float3 uv_smallerLod = WorldToUV(i_cameraPos.xz);
+		const float3 uv_smallerLod = WorldToUV(i_cameraPos.xz, _LD_Pos_Scale[_LD_SliceIndex], _LD_Params[_LD_SliceIndex], _LD_SliceIndex);
 		depth = CREST_OCEAN_DEPTH_BASELINE;
 		SampleSeaDepth(_LD_TexArray_SeaFloorDepth, uv_smallerLod, 1.0, depth);
 
@@ -75,9 +75,14 @@ half3 ScatterColour(
 		PosToSliceIndices(samplePoint, minSliceIndex, _InstanceData.x, _LD_Pos_Scale[0].z, slice0, slice1, lodAlpha);
 
 		half2 shadowSoftHard = 0.0;
-		// TODO - fix data type of slice index in WorldToUV - #343
-		SampleShadow(_LD_TexArray_Shadow, WorldToUV(samplePoint, slice0), 1.0 - lodAlpha, shadowSoftHard);
-		SampleShadow(_LD_TexArray_Shadow, WorldToUV(samplePoint, slice1), lodAlpha, shadowSoftHard);
+		{
+			const float3 uv = WorldToUV(samplePoint, _LD_Pos_Scale[slice0], _LD_Params[slice0], slice0);
+			SampleShadow(_LD_TexArray_Shadow, uv, 1.0 - lodAlpha, shadowSoftHard);
+		}
+		{
+			const float3 uv = WorldToUV(samplePoint, _LD_Pos_Scale[slice1], _LD_Params[slice1], slice1);
+			SampleShadow(_LD_TexArray_Shadow, uv, lodAlpha, shadowSoftHard);
+		}
 
 		shadow = saturate(1.0 - shadowSoftHard.x);
 #endif
@@ -168,7 +173,7 @@ void ApplyCaustics(in const half3 i_view, in const half3 i_lightDir, in const fl
 		// LOD_1 data can be missing when underwater
 		if (i_underwater)
 		{
-			const float3 uv_smallerLod = WorldToUV(shadowSurfacePosXZ);
+			const float3 uv_smallerLod = WorldToUV(shadowSurfacePosXZ, _LD_Pos_Scale[_LD_SliceIndex], _LD_Params[_LD_SliceIndex], _LD_SliceIndex);
 			SampleShadow(_LD_TexArray_Shadow, uv_smallerLod, 1.0, causticShadow);
 		}
 		else

--- a/crest/Assets/Crest/Crest/Shaders/OceanHelpers.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanHelpers.hlsl
@@ -66,7 +66,9 @@ void ApplyOceanClipSurface(in const float3 io_positionWS, in const float i_lodAl
 	}
 	if (wt_biggerLod > 0.001)
 	{
-		SampleClip(_LD_TexArray_ClipSurface, WorldToUV_BiggerLod(worldXZ), wt_biggerLod, clipValue);
+		const uint si = _LD_SliceIndex + 1;
+		float3 uv = WorldToUV(worldXZ, _LD_Pos_Scale[si], _LD_Params[si], si);
+		SampleClip(_LD_TexArray_ClipSurface, uv, wt_biggerLod, clipValue);
 	}
 
 	// Add 0.5 bias for LOD blending and texel resolution correction. This will help to tighten and smooth clipped edges

--- a/crest/Assets/Crest/Crest/Shaders/OceanHelpers.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanHelpers.hlsl
@@ -62,12 +62,13 @@ void ApplyOceanClipSurface(in const float3 io_positionWS, in const float i_lodAl
 	half clipValue = 0.0;
 	if (wt_smallerLod > 0.001)
 	{
-		SampleClip(_LD_TexArray_ClipSurface, WorldToUV(worldXZ), wt_smallerLod, clipValue);
+		const float3 uv = WorldToUV(worldXZ, _LD_Pos_Scale[_LD_SliceIndex], _LD_Params[_LD_SliceIndex], _LD_SliceIndex);
+		SampleClip(_LD_TexArray_ClipSurface, uv, wt_smallerLod, clipValue);
 	}
 	if (wt_biggerLod > 0.001)
 	{
 		const uint si = _LD_SliceIndex + 1;
-		float3 uv = WorldToUV(worldXZ, _LD_Pos_Scale[si], _LD_Params[si], si);
+		const float3 uv = WorldToUV(worldXZ, _LD_Pos_Scale[si], _LD_Params[si], si);
 		SampleClip(_LD_TexArray_ClipSurface, uv, wt_biggerLod, clipValue);
 	}
 

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/AnimWavesGerstnerBatchGeometry.shader
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/AnimWavesGerstnerBatchGeometry.shader
@@ -33,7 +33,7 @@ Shader "Crest/Inputs/Animated Waves/Gerstner Batch Geometry"
 
 			#include "../OceanGlobals.hlsl"
 			#include "../OceanInputsDriven.hlsl"
-			#include "../OceanLODData.hlsl"
+			#include "../OceanHelpersNew.hlsl"
 
 			#include "GerstnerShared.hlsl"
 
@@ -75,7 +75,7 @@ Shader "Crest/Inputs/Animated Waves/Gerstner Batch Geometry"
 				o.worldPosXZ_uv.xy = worldPos.xz;
 				o.worldPosXZ_uv.zw = input.uv;
 
-				o.uv_slice_wt.xyz = WorldToUV(o.worldPosXZ_uv.xy, _LD_SliceIndex);
+				o.uv_slice_wt.xyz = WorldToUV(o.worldPosXZ_uv.xy, _LD_Pos_Scale[_LD_SliceIndex], _LD_Params[_LD_SliceIndex], _LD_SliceIndex);
 				o.uv_slice_wt.w = 1.0;
 
 #if _WEIGHTFROMVERTEXCOLOURRED_ON

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/AnimWavesGerstnerBatch.shader
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/AnimWavesGerstnerBatch.shader
@@ -23,7 +23,7 @@ Shader "Hidden/Crest/Inputs/Animated Waves/Gerstner Batch Global"
 
 			#include "../../OceanGlobals.hlsl"
 			#include "../../OceanInputsDriven.hlsl"
-			#include "../../OceanLODData.hlsl"
+			#include "../../OceanHelpersNew.hlsl"
 
 			#include "../GerstnerShared.hlsl"
 
@@ -50,7 +50,7 @@ Shader "Hidden/Crest/Inputs/Animated Waves/Gerstner Batch Global"
 				o.positionCS.y = -o.positionCS.y;
 #endif
 
-				float2 worldXZ = UVToWorld(input.uv);
+				const float2 worldXZ = UVToWorld(input.uv, _LD_SliceIndex, _LD_Pos_Scale[_LD_SliceIndex], _LD_Params[_LD_SliceIndex]);
 				o.worldPosXZ = worldXZ;
 				o.uv_slice = float3(input.uv, _LD_SliceIndex);
 

--- a/crest/Assets/Crest/Crest/Shaders/OceanLODData.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanLODData.hlsl
@@ -20,15 +20,6 @@ float3 WorldToUV(in float2 i_samplePos, in uint i_sliceIndex) {
 	return float3(result, i_sliceIndex);
 }
 
-float3 WorldToUV_BiggerLod(in float2 i_samplePos, in uint i_sliceIndex_BiggerLod) {
-	const float2 result = LD_WorldToUV(
-		i_samplePos, _LD_Pos_Scale[i_sliceIndex_BiggerLod].xy,
-		_LD_Params[i_sliceIndex_BiggerLod].y,
-		_LD_Params[i_sliceIndex_BiggerLod].x
-	);
-	return float3(result, i_sliceIndex_BiggerLod);
-}
-
 float3 WorldToUV_Source(in float2 i_samplePos, in uint i_sliceIndex_Source) {
 	const float2 result = LD_WorldToUV(
 		i_samplePos,
@@ -49,5 +40,4 @@ float2 UVToWorld(in float2 i_uv, in float i_sliceIndex) { return LD_UVToWorld(i_
 
 // Shortcuts if _LD_SliceIndex is set
 float3 WorldToUV(in float2 i_samplePos) { return WorldToUV(i_samplePos, _LD_SliceIndex); }
-float3 WorldToUV_BiggerLod(in float2 i_samplePos) { return WorldToUV_BiggerLod(i_samplePos, _LD_SliceIndex + 1); }
 float2 UVToWorld(in float2 i_uv) { return UVToWorld(i_uv, _LD_SliceIndex); }

--- a/crest/Assets/Crest/Crest/Shaders/OceanLODData.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanLODData.hlsl
@@ -5,21 +5,6 @@
 // Ocean LOD data - data, samplers and functions associated with LODs
 
 // Conversions for world space from/to UV space. All these should *not* be clamped otherwise they'll break fullscreen triangles.
-float2 LD_WorldToUV(in float2 i_samplePos, in float2 i_centerPos, in float i_res, in float i_texelSize)
-{
-	return (i_samplePos - i_centerPos) / (i_texelSize * i_res) + 0.5;
-}
-
-float3 WorldToUV_Source(in float2 i_samplePos, in uint i_sliceIndex_Source) {
-	const float2 result = LD_WorldToUV(
-		i_samplePos,
-		_LD_Pos_Scale_Source[i_sliceIndex_Source].xy,
-		_LD_Params_Source[i_sliceIndex_Source].y,
-		_LD_Params_Source[i_sliceIndex_Source].x
-	);
-	return float3(result, i_sliceIndex_Source);
-}
-
 
 float2 LD_UVToWorld(in float2 i_uv, in float2 i_centerPos, in float i_res, in float i_texelSize)
 {

--- a/crest/Assets/Crest/Crest/Shaders/OceanLODData.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanLODData.hlsl
@@ -6,12 +6,3 @@
 
 // Conversions for world space from/to UV space. All these should *not* be clamped otherwise they'll break fullscreen triangles.
 
-float2 LD_UVToWorld(in float2 i_uv, in float2 i_centerPos, in float i_res, in float i_texelSize)
-{
-	return i_texelSize * i_res * (i_uv - 0.5) + i_centerPos;
-}
-
-float2 UVToWorld(in float2 i_uv, in float i_sliceIndex) { return LD_UVToWorld(i_uv, _LD_Pos_Scale[i_sliceIndex].xy, _LD_Params[i_sliceIndex].y, _LD_Params[i_sliceIndex].x); }
-
-// Shortcuts if _LD_SliceIndex is set
-float2 UVToWorld(in float2 i_uv) { return UVToWorld(i_uv, _LD_SliceIndex); }

--- a/crest/Assets/Crest/Crest/Shaders/OceanLODData.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanLODData.hlsl
@@ -1,8 +1,0 @@
-// Crest Ocean System
-
-// This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
-
-// Ocean LOD data - data, samplers and functions associated with LODs
-
-// Conversions for world space from/to UV space. All these should *not* be clamped otherwise they'll break fullscreen triangles.
-

--- a/crest/Assets/Crest/Crest/Shaders/OceanLODData.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanLODData.hlsl
@@ -10,16 +10,6 @@ float2 LD_WorldToUV(in float2 i_samplePos, in float2 i_centerPos, in float i_res
 	return (i_samplePos - i_centerPos) / (i_texelSize * i_res) + 0.5;
 }
 
-float3 WorldToUV(in float2 i_samplePos, in uint i_sliceIndex) {
-	const float2 result = LD_WorldToUV(
-		i_samplePos,
-		_LD_Pos_Scale[i_sliceIndex].xy,
-		_LD_Params[i_sliceIndex].y,
-		_LD_Params[i_sliceIndex].x
-	);
-	return float3(result, i_sliceIndex);
-}
-
 float3 WorldToUV_Source(in float2 i_samplePos, in uint i_sliceIndex_Source) {
 	const float2 result = LD_WorldToUV(
 		i_samplePos,
@@ -39,5 +29,4 @@ float2 LD_UVToWorld(in float2 i_uv, in float2 i_centerPos, in float i_res, in fl
 float2 UVToWorld(in float2 i_uv, in float i_sliceIndex) { return LD_UVToWorld(i_uv, _LD_Pos_Scale[i_sliceIndex].xy, _LD_Params[i_sliceIndex].y, _LD_Params[i_sliceIndex].x); }
 
 // Shortcuts if _LD_SliceIndex is set
-float3 WorldToUV(in float2 i_samplePos) { return WorldToUV(i_samplePos, _LD_SliceIndex); }
 float2 UVToWorld(in float2 i_uv) { return UVToWorld(i_uv, _LD_SliceIndex); }

--- a/crest/Assets/Crest/Crest/Shaders/OceanLODData.hlsl.meta
+++ b/crest/Assets/Crest/Crest/Shaders/OceanLODData.hlsl.meta
@@ -1,9 +1,0 @@
-fileFormatVersion: 2
-guid: ea5fd95ff2a4fe446be5c6909535a979
-ShaderImporter:
-  externalObjects: {}
-  defaultTextures: []
-  nonModifiableTextures: []
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/crest/Assets/Crest/Crest/Shaders/OceanSurfaceAlpha.shader
+++ b/crest/Assets/Crest/Crest/Shaders/OceanSurfaceAlpha.shader
@@ -83,14 +83,15 @@ Shader "Crest/Ocean Surface Alpha"
 
 				// sample shape textures - always lerp between 2 scales, so sample two textures
 
-				// sample weights. params.z allows shape to be faded out (used on last lod to support pop-less scale transitions)
-				float wt_smallerLod = (1.0 - lodAlpha) * _LD_Params[_LD_SliceIndex].z;
 				// sample displacement textures, add results to current world pos / normal / foam
-				const float2 wxz = worldPos.xz;
 				half foam = 0.0;
 				half sss = 0.;
-				SampleDisplacements(_LD_TexArray_AnimatedWaves, WorldToUV(wxz), wt_smallerLod, worldPos, sss);
-
+				// sample weight. params.z allows shape to be faded out (used on last lod to support pop-less scale transitions)
+				float wt_smallerLod = (1.0 - lodAlpha) * _LD_Params[_LD_SliceIndex].z;
+				{
+					const float3 uv_slice = WorldToUV(worldPos.xz, _LD_Pos_Scale[_LD_SliceIndex], _LD_Params[_LD_SliceIndex], _LD_SliceIndex);
+					SampleDisplacements(_LD_TexArray_AnimatedWaves, uv_slice, wt_smallerLod, worldPos, sss);
+				}
 				{
 					// sample weight. params.z allows shape to be faded out (used on last lod to support pop-less scale transitions)
 					const float wt_biggerLod = (1.0 - wt_smallerLod) * _LD_Params[_LD_SliceIndex + 1].z;

--- a/crest/Assets/Crest/Crest/Shaders/OceanSurfaceAlpha.shader
+++ b/crest/Assets/Crest/Crest/Shaders/OceanSurfaceAlpha.shader
@@ -38,7 +38,6 @@ Shader "Crest/Ocean Surface Alpha"
 
 			#include "OceanGlobals.hlsl"
 			#include "OceanInputsDriven.hlsl"
-			#include "OceanLODData.hlsl"
 			#include "OceanHelpersNew.hlsl"
 			#include "OceanHelpers.hlsl"
 

--- a/crest/Assets/Crest/Crest/Shaders/OceanSurfaceAlpha.shader
+++ b/crest/Assets/Crest/Crest/Shaders/OceanSurfaceAlpha.shader
@@ -85,13 +85,19 @@ Shader "Crest/Ocean Surface Alpha"
 
 				// sample weights. params.z allows shape to be faded out (used on last lod to support pop-less scale transitions)
 				float wt_smallerLod = (1.0 - lodAlpha) * _LD_Params[_LD_SliceIndex].z;
-				float wt_biggerLod = (1.0 - wt_smallerLod) * _LD_Params[_LD_SliceIndex + 1].z;
 				// sample displacement textures, add results to current world pos / normal / foam
 				const float2 wxz = worldPos.xz;
 				half foam = 0.0;
 				half sss = 0.;
 				SampleDisplacements(_LD_TexArray_AnimatedWaves, WorldToUV(wxz), wt_smallerLod, worldPos, sss);
-				SampleDisplacements(_LD_TexArray_AnimatedWaves, WorldToUV_BiggerLod(wxz), wt_biggerLod, worldPos, sss);
+
+				{
+					// sample weight. params.z allows shape to be faded out (used on last lod to support pop-less scale transitions)
+					const float wt_biggerLod = (1.0 - wt_smallerLod) * _LD_Params[_LD_SliceIndex + 1].z;
+					const uint si = _LD_SliceIndex + 1;
+					const float3 uv_slice = WorldToUV(worldPos.xz, _LD_Pos_Scale[si], _LD_Params[si], si);
+					SampleDisplacements(_LD_TexArray_AnimatedWaves, uv_slice, wt_biggerLod, worldPos, sss);
+				}
 
 				// move to sea level
 				worldPos.y += _OceanCenterPosWorld.y;

--- a/crest/Assets/Crest/Crest/Shaders/Resources/QueryDisplacements.compute
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/QueryDisplacements.compute
@@ -22,8 +22,8 @@ float3 ComputeDisplacement(float2 undispPos, float minSlice)
 	float lodAlpha;
 	PosToSliceIndices(undispPos, minSlice, _MeshScaleLerp, _LD_Pos_Scale[0].z, slice0, slice1, lodAlpha);
 
-	float3 uv0 = WorldToUV(undispPos, slice0);
-	float3 uv1 = WorldToUV(undispPos, slice1);
+	const float3 uv0 = WorldToUV(undispPos, _LD_Pos_Scale[slice0], _LD_Params[slice0], slice0);
+	const float3 uv1 = WorldToUV(undispPos, _LD_Pos_Scale[slice1], _LD_Params[slice1], slice1);
 
 	const float wt_0 = (1. - lodAlpha) * _LD_Params[slice0].z;
 	const float wt_1 = (1. - wt_0) * _LD_Params[slice1].z;

--- a/crest/Assets/Crest/Crest/Shaders/Resources/QueryFlow.compute
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/QueryFlow.compute
@@ -22,8 +22,8 @@ float3 ComputeFlow(float2 undispPos, float minSlice)
 	float lodAlpha;
 	PosToSliceIndices(undispPos, minSlice, _MeshScaleLerp, _LD_Pos_Scale[0].z, slice0, slice1, lodAlpha);
 
-	float3 uv0 = WorldToUV(undispPos, slice0);
-	float3 uv1 = WorldToUV(undispPos, slice1);
+	const float3 uv0 = WorldToUV(undispPos, _LD_Pos_Scale[slice0], _LD_Params[slice0], slice0);
+	const float3 uv1 = WorldToUV(undispPos, _LD_Pos_Scale[slice1], _LD_Params[slice1], slice1);
 
 	const float wt_0 = (1. - lodAlpha) * _LD_Params[slice0].z;
 	const float wt_1 = (1. - wt_0) * _LD_Params[slice1].z;

--- a/crest/Assets/Crest/Crest/Shaders/Resources/ShapeCombine.compute
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/ShapeCombine.compute
@@ -83,7 +83,7 @@ void ShapeCombineBase(uint3 id)
 	}
 	const float2 input_uv = IDtoUV(id.xy, width, height);
 
-	const float2 worldPosXZ = UVToWorld(input_uv);
+	const float2 worldPosXZ = UVToWorld(input_uv, _LD_SliceIndex, _LD_Pos_Scale[_LD_SliceIndex], _LD_Params[_LD_SliceIndex]);
 
 	// sample the shape 1 texture at this world pos
 	const uint si = _LD_SliceIndex + 1;

--- a/crest/Assets/Crest/Crest/Shaders/Resources/ShapeCombine.compute
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/ShapeCombine.compute
@@ -101,8 +101,8 @@ void ShapeCombineBase(uint3 id)
 	float2 offsets, weights;
 	Flow(offsets, weights);
 
-	float3 uv_thisLod_flow_0 = WorldToUV(worldPosXZ - offsets[0] * flow);
-	float3 uv_thisLod_flow_1 = WorldToUV(worldPosXZ - offsets[1] * flow);
+	const float3 uv_thisLod_flow_0 = WorldToUV(worldPosXZ - offsets[0] * flow, _LD_Pos_Scale[_LD_SliceIndex], _LD_Params[_LD_SliceIndex], _LD_SliceIndex);
+	const float3 uv_thisLod_flow_1 = WorldToUV(worldPosXZ - offsets[1] * flow, _LD_Pos_Scale[_LD_SliceIndex], _LD_Params[_LD_SliceIndex], _LD_SliceIndex);
 	SampleDisplacements(_LD_TexArray_WaveBuffer, uv_thisLod_flow_0, weights[0], result, sss);
 	SampleDisplacements(_LD_TexArray_WaveBuffer, uv_thisLod_flow_1, weights[1], result, sss);
 #else

--- a/crest/Assets/Crest/Crest/Shaders/Resources/ShapeCombine.compute
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/ShapeCombine.compute
@@ -86,7 +86,8 @@ void ShapeCombineBase(uint3 id)
 	const float2 worldPosXZ = UVToWorld(input_uv);
 
 	// sample the shape 1 texture at this world pos
-	const float3 uv_nextLod = WorldToUV_BiggerLod(worldPosXZ);
+	const uint si = _LD_SliceIndex + 1;
+	const float3 uv_nextLod = WorldToUV(worldPosXZ, _LD_Pos_Scale[si], _LD_Params[si], si);
 
 	float3 uv_thisLod = float3(input_uv, _LD_SliceIndex);
 

--- a/crest/Assets/Crest/Crest/Shaders/Resources/ShapeCombine.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/ShapeCombine.shader
@@ -69,7 +69,7 @@ Shader "Hidden/Crest/Simulation/Combine Animated Wave LODs"
 				float3 uv_thisLod = float3(input.uv, _LD_SliceIndex);
 
 				// go from uv out to world for the current shape texture
-				const float2 worldPosXZ = UVToWorld(input.uv);
+				const float2 worldPosXZ = UVToWorld(input.uv, _LD_SliceIndex, _LD_Pos_Scale[_LD_SliceIndex], _LD_Params[_LD_SliceIndex]);
 
 				// sample the shape 1 texture at this world pos
 				const uint si = _LD_SliceIndex + 1;

--- a/crest/Assets/Crest/Crest/Shaders/Resources/ShapeCombine.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/ShapeCombine.shader
@@ -28,7 +28,6 @@ Shader "Hidden/Crest/Simulation/Combine Animated Wave LODs"
 
 			#include "../OceanGlobals.hlsl"
 			#include "../OceanInputsDriven.hlsl"
-			#include "../OceanLODData.hlsl"
 			#include "../OceanHelpersNew.hlsl"
 			#include "../FullScreenTriangle.hlsl"
 

--- a/crest/Assets/Crest/Crest/Shaders/Resources/ShapeCombine.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/ShapeCombine.shader
@@ -85,8 +85,8 @@ Shader "Hidden/Crest/Simulation/Combine Animated Wave LODs"
 				float2 offsets, weights;
 				Flow(offsets, weights);
 
-				float3 uv_thisLod_flow_0 = WorldToUV(worldPosXZ - offsets[0] * flow);
-				float3 uv_thisLod_flow_1 = WorldToUV(worldPosXZ - offsets[1] * flow);
+				const float3 uv_thisLod_flow_0 = WorldToUV(worldPosXZ - offsets[0] * flow, _LD_Pos_Scale[_LD_SliceIndex], _LD_Params[_LD_SliceIndex], _LD_SliceIndex);
+				const float3 uv_thisLod_flow_1 = WorldToUV(worldPosXZ - offsets[1] * flow, _LD_Pos_Scale[_LD_SliceIndex], _LD_Params[_LD_SliceIndex], _LD_SliceIndex);
 				SampleDisplacements(_LD_TexArray_WaveBuffer, uv_thisLod_flow_0, weights[0], result, sss);
 				SampleDisplacements(_LD_TexArray_WaveBuffer, uv_thisLod_flow_1, weights[1], result, sss);
 #else

--- a/crest/Assets/Crest/Crest/Shaders/Resources/ShapeCombine.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/ShapeCombine.shader
@@ -72,7 +72,8 @@ Shader "Hidden/Crest/Simulation/Combine Animated Wave LODs"
 				const float2 worldPosXZ = UVToWorld(input.uv);
 
 				// sample the shape 1 texture at this world pos
-				const float3 uv_nextLod = WorldToUV_BiggerLod(worldPosXZ);
+				const uint si = _LD_SliceIndex + 1;
+				const float3 uv_nextLod = WorldToUV(worldPosXZ, _LD_Pos_Scale[si], _LD_Params[si], si);
 
 				float3 result = 0.0;
 				half sss = 0.0;

--- a/crest/Assets/Crest/Crest/Shaders/Resources/UpdateDynWaves.compute
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/UpdateDynWaves.compute
@@ -57,7 +57,7 @@ void UpdateDynWaves(uint3 id : SV_DispatchThreadID)
 	const float3 uv_slice = float3(input_uv, sliceIndex);
 
 	const half2 velocity = SampleLod(_LD_TexArray_Flow, uv_slice).xy;
-	const float3 uv_source = WorldToUV_Source(worldPosXZ - (dt * velocity), sliceIndexSource);
+	const float3 uv_source = WorldToUV(worldPosXZ - (dt * velocity), _LD_Pos_Scale_Source[sliceIndexSource], _LD_Params_Source[sliceIndexSource], sliceIndexSource);
 
 	// weighting for source position - weight 0 for off texture accesses to stop streaky artifacts
 	float2 distToEdge = min(uv_source.xy, 1.0 - uv_source.xy);

--- a/crest/Assets/Crest/Crest/Shaders/Resources/UpdateDynWaves.compute
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/UpdateDynWaves.compute
@@ -43,7 +43,7 @@ void UpdateDynWaves(uint3 id : SV_DispatchThreadID)
 		_LD_TexArray_DynamicWaves_Source.GetDimensions(width, height, depth);
 	}
 	const float2 input_uv = IDtoUV(id.xy, width, height);
-	const float2 worldPosXZ = UVToWorld(input_uv, sliceIndex);
+	const float2 worldPosXZ = UVToWorld(input_uv, sliceIndex, _LD_Pos_Scale[sliceIndex], _LD_Params[sliceIndex]);
 	const float gridSize = _LD_Params[sliceIndex].x;
 
 	// average wavelength for this scale

--- a/crest/Assets/Crest/Crest/Shaders/Resources/UpdateFoam.compute
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/UpdateFoam.compute
@@ -84,7 +84,7 @@ void UpdateFoam(uint3 id : SV_DispatchThreadID)
 	foam += 5.0 * _SimDeltaTime * _WaveFoamStrength * saturate(_WaveFoamCoverage - det);
 
 	// add foam in shallow water. use the displaced position to ensure we add foam where world objects are.
-	float3 uv_slice_displaced = WorldToUV(worldPosXZ + disp.xz, sliceIndex);
+	const float3 uv_slice_displaced = WorldToUV(worldPosXZ + disp.xz, _LD_Pos_Scale[sliceIndex], _LD_Params[sliceIndex], sliceIndex);
 	float signedOceanDepth = SampleLodLevel(_LD_TexArray_SeaFloorDepth, uv_slice_displaced, 0.0).x + disp.y;
 	foam += _ShorelineFoamStrength * _SimDeltaTime * saturate(1.0 - signedOceanDepth / _ShorelineFoamMaxDepth);
 

--- a/crest/Assets/Crest/Crest/Shaders/Resources/UpdateFoam.compute
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/UpdateFoam.compute
@@ -46,8 +46,8 @@ void UpdateFoam(uint3 id : SV_DispatchThreadID)
 	const half r_max = 0.5 - _LD_Params_Source[sliceIndexSource].w;
 
 	// Try to sample the source slice, if it the sample position lies within its footprint
-	const float3 uv_slice_source = WorldToUV_Source(worldPosXZ_flowed, sliceIndexSource);
-	half2 r = abs(uv_slice_source.xy - 0.5);
+	const float3 uv_slice_source = WorldToUV(worldPosXZ_flowed, _LD_Pos_Scale_Source[sliceIndexSource], _LD_Params_Source[sliceIndexSource], sliceIndexSource);
+	const half2 r = abs(uv_slice_source.xy - 0.5);
 	if (max(r.x, r.y) <= r_max)
 	{
 		foam = _LD_TexArray_Foam_Source.SampleLevel(LODData_linear_clamp_sampler, uv_slice_source, 0.0).x;
@@ -56,8 +56,8 @@ void UpdateFoam(uint3 id : SV_DispatchThreadID)
 	{
 		// Sample lies outside this cascade. Try to use the next cascade in the chain - better to get something rather lower res
 		// than nothing.
-		float3 uv_slice_source_nextlod = WorldToUV_Source(worldPosXZ_flowed, sliceIndexSource + 1.0);
-		half2 r2 = abs(uv_slice_source_nextlod.xy - 0.5);
+		const float3 uv_slice_source_nextlod = WorldToUV(worldPosXZ_flowed, _LD_Pos_Scale_Source[sliceIndexSource + 1], _LD_Params_Source[sliceIndexSource + 1], sliceIndexSource + 1);
+		const half2 r2 = abs(uv_slice_source_nextlod.xy - 0.5);
 		if (max(r2.x, r2.y) <= r_max)
 		{
 			foam = _LD_TexArray_Foam_Source.SampleLevel(LODData_linear_clamp_sampler, uv_slice_source_nextlod, 0.0).x;

--- a/crest/Assets/Crest/Crest/Shaders/Resources/UpdateFoam.compute
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/UpdateFoam.compute
@@ -36,7 +36,7 @@ void UpdateFoam(uint3 id : SV_DispatchThreadID)
 	const float sliceIndexSource = clamp(id.z + _LODChange, 0.0, depth - 1.0);
 
 	const float2 input_uv = IDtoUV(id.xy, width, height);
-	const float2 worldPosXZ = UVToWorld(input_uv, sliceIndex);
+	const float2 worldPosXZ = UVToWorld(input_uv, sliceIndex, _LD_Pos_Scale[sliceIndex], _LD_Params[sliceIndex]);
 	const float3 uv_slice = float3(input_uv, id.z);
 
 	half2 velocity = _LD_TexArray_Flow.SampleLevel(LODData_linear_clamp_sampler, uv_slice, 0).xy;

--- a/crest/Assets/Crest/Crest/Shaders/Resources/UpdateShadow.compute
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/UpdateShadow.compute
@@ -132,16 +132,16 @@ void UpdateShadow(uint3 id : SV_DispatchThreadID)
 	const half r_max = 0.5 - _LD_Params_Source[_LD_SliceIndex_Source].w;
 
 	// Shadow from last frame - manually implement black border
-	float3 uv_source = WorldToUV_Source(shadowCoords._WorldPosViewZ.xz, _LD_SliceIndex_Source);
-	half2 r = abs(uv_source.xy - 0.5);
+	const float3 uv_source = WorldToUV(shadowCoords._WorldPosViewZ.xz, _LD_Pos_Scale_Source[_LD_SliceIndex_Source], _LD_Params_Source[_LD_SliceIndex_Source], _LD_SliceIndex_Source);
+	const half2 r = abs(uv_source.xy - 0.5);
 	if (max(r.x, r.y) <= r_max)
 	{
 		SampleShadow(_LD_TexArray_Shadow_Source, uv_source, 1.0, shadow);
 	}
 	else if (_LD_SliceIndex_Source + 1.0 < depth)
 	{
-		float3 uv_source_nextlod = WorldToUV_Source(shadowCoords._WorldPosViewZ.xz, _LD_SliceIndex_Source + 1);
-		half2 r2 = abs(uv_source_nextlod.xy - 0.5);
+		const float3 uv_source_nextlod = WorldToUV(shadowCoords._WorldPosViewZ.xz, _LD_Pos_Scale_Source[_LD_SliceIndex_Source + 1], _LD_Params_Source[_LD_SliceIndex_Source + 1], _LD_SliceIndex_Source + 1);
+		const half2 r2 = abs(uv_source_nextlod.xy - 0.5);
 		if (max(r2.x, r2.y) < r_max)
 		{
 			SampleShadow(_LD_TexArray_Shadow_Source, uv_source_nextlod, 1.0, shadow);

--- a/crest/Assets/Crest/Crest/Shaders/Underwater/UnderwaterCurtain.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Underwater/UnderwaterCurtain.shader
@@ -55,7 +55,6 @@ Shader "Crest/Underwater Curtain"
 
 			#include "../OceanGlobals.hlsl"
 			#include "../OceanInputsDriven.hlsl"
-			#include "../OceanLODData.hlsl"
 			#include "../OceanHelpersNew.hlsl"
 			#include "UnderwaterShared.hlsl"
 

--- a/crest/Assets/Crest/Crest/Shaders/Underwater/UnderwaterCurtain.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Underwater/UnderwaterCurtain.shader
@@ -197,7 +197,7 @@ Shader "Crest/Underwater Curtain"
 
 				float3 dummy = 0.0;
 				half sss = 0.;
-				const float3 uv_slice = WorldToUV(_WorldSpaceCameraPos.xz);
+				const float3 uv_slice = WorldToUV(_WorldSpaceCameraPos.xz, _LD_Pos_Scale[_LD_SliceIndex], _LD_Params[_LD_SliceIndex], _LD_SliceIndex);
 				SampleDisplacements(_LD_TexArray_AnimatedWaves, uv_slice, 1.0, dummy, sss);
 
 				// depth and shadow are computed in ScatterColour when underwater==true, using the LOD1 texture.

--- a/crest/Assets/Crest/Crest/Shaders/Underwater/UnderwaterMeniscus.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Underwater/UnderwaterMeniscus.shader
@@ -31,7 +31,6 @@ Shader "Crest/Underwater Meniscus"
 
 			#include "../OceanGlobals.hlsl"
 			#include "../OceanInputsDriven.hlsl"
-			#include "../OceanLODData.hlsl"
 			#include "../OceanHelpersNew.hlsl"
 			#include "UnderwaterShared.hlsl"
 

--- a/crest/Assets/Crest/Crest/Shaders/Underwater/UnderwaterShared.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/Underwater/UnderwaterShared.hlsl
@@ -20,7 +20,8 @@ float IntersectRayWithWaterSurface(const float3 pos, const float3 dir)
 		// Sample displacement textures, add results to current world pos / normal / foam
 		disp = float3(sampleXZ.x, _OceanCenterPosWorld.y, sampleXZ.y);
 		half sss = 0.;
-		SampleDisplacements(_LD_TexArray_AnimatedWaves, WorldToUV(sampleXZ), 1.0, disp, sss);
+		const float3 uv = WorldToUV(sampleXZ, _LD_Pos_Scale[_LD_SliceIndex], _LD_Params[_LD_SliceIndex], _LD_SliceIndex);
+		SampleDisplacements(_LD_TexArray_AnimatedWaves, uv, 1.0, disp, sss);
 		float3 nearestPointOnRay = pos + dir * dot(disp - pos, dir);
 		const float2 error = disp.xz - nearestPointOnRay.xz;
 		sampleXZ -= error;
@@ -29,7 +30,8 @@ float IntersectRayWithWaterSurface(const float3 pos, const float3 dir)
 		// Sample displacement textures, add results to current world pos / normal / foam
 		disp = float3(sampleXZ.x, _OceanCenterPosWorld.y, sampleXZ.y);
 		half sss = 0.;
-		SampleDisplacements(_LD_TexArray_AnimatedWaves, WorldToUV(sampleXZ), 1.0, disp, sss);
+		const float3 uv = WorldToUV(sampleXZ, _LD_Pos_Scale[_LD_SliceIndex], _LD_Params[_LD_SliceIndex], _LD_SliceIndex);
+		SampleDisplacements(_LD_TexArray_AnimatedWaves, uv, 1.0, disp, sss);
 		float3 nearestPointOnRay = pos + dir * dot(disp - pos, dir);
 		const float2 error = disp.xz - nearestPointOnRay.xz;
 		sampleXZ -= error;
@@ -38,7 +40,8 @@ float IntersectRayWithWaterSurface(const float3 pos, const float3 dir)
 		// Sample displacement textures, add results to current world pos / normal / foam
 		disp = float3(sampleXZ.x, _OceanCenterPosWorld.y, sampleXZ.y);
 		half sss = 0.;
-		SampleDisplacements(_LD_TexArray_AnimatedWaves, WorldToUV(sampleXZ), 1.0, disp, sss);
+		const float3 uv = WorldToUV(sampleXZ, _LD_Pos_Scale[_LD_SliceIndex], _LD_Params[_LD_SliceIndex], _LD_SliceIndex);
+		SampleDisplacements(_LD_TexArray_AnimatedWaves, uv, 1.0, disp, sss);
 		float3 nearestPointOnRay = pos + dir * dot(disp - pos, dir);
 		const float2 error = disp.xz - nearestPointOnRay.xz;
 		sampleXZ -= error;
@@ -47,7 +50,8 @@ float IntersectRayWithWaterSurface(const float3 pos, const float3 dir)
 		// Sample displacement textures, add results to current world pos / normal / foam
 		disp = float3(sampleXZ.x, _OceanCenterPosWorld.y, sampleXZ.y);
 		half sss = 0.;
-		SampleDisplacements(_LD_TexArray_AnimatedWaves, WorldToUV(sampleXZ), 1.0, disp, sss);
+		const float3 uv = WorldToUV(sampleXZ, _LD_Pos_Scale[_LD_SliceIndex], _LD_Params[_LD_SliceIndex], _LD_SliceIndex);
+		SampleDisplacements(_LD_TexArray_AnimatedWaves, uv, 1.0, disp, sss);
 		float3 nearestPointOnRay = pos + dir * dot(disp - pos, dir);
 		const float2 error = disp.xz - nearestPointOnRay.xz;
 		sampleXZ -= error;
@@ -56,7 +60,8 @@ float IntersectRayWithWaterSurface(const float3 pos, const float3 dir)
 		// Sample displacement textures, add results to current world pos / normal / foam
 		disp = float3(sampleXZ.x, _OceanCenterPosWorld.y, sampleXZ.y);
 		half sss = 0.;
-		SampleDisplacements(_LD_TexArray_AnimatedWaves, WorldToUV(sampleXZ), 1.0, disp, sss);
+		const float3 uv = WorldToUV(sampleXZ, _LD_Pos_Scale[_LD_SliceIndex], _LD_Params[_LD_SliceIndex], _LD_SliceIndex);
+		SampleDisplacements(_LD_TexArray_AnimatedWaves, uv, 1.0, disp, sss);
 		float3 nearestPointOnRay = pos + dir * dot(disp - pos, dir);
 		const float2 error = disp.xz - nearestPointOnRay.xz;
 		sampleXZ -= error;
@@ -65,7 +70,8 @@ float IntersectRayWithWaterSurface(const float3 pos, const float3 dir)
 		// Sample displacement textures, add results to current world pos / normal / foam
 		disp = float3(sampleXZ.x, _OceanCenterPosWorld.y, sampleXZ.y);
 		half sss = 0.;
-		SampleDisplacements(_LD_TexArray_AnimatedWaves, WorldToUV(sampleXZ), 1.0, disp, sss);
+		const float3 uv = WorldToUV(sampleXZ, _LD_Pos_Scale[_LD_SliceIndex], _LD_Params[_LD_SliceIndex], _LD_SliceIndex);
+		SampleDisplacements(_LD_TexArray_AnimatedWaves, uv, 1.0, disp, sss);
 		float3 nearestPointOnRay = pos + dir * dot(disp - pos, dir);
 		const float2 error = disp.xz - nearestPointOnRay.xz;
 		sampleXZ -= error;


### PR DESCRIPTION
Goodbye OceanLODData.hlsl. You won't be missed!

Removes helper functions which relied implicitly on hidden state, and added unnecessary concepts such as the 'bigger'/'smaller' naming. A downside of this is some fairly verbose calling code. A potential fix for this is grouping args in structs.

I think there is more cleanup to follow (OceanHelpersNew -> OceanHelpers?), but thought i'd stop at this point as thats more than enough change for one PR..