### PR TITLE
Add shadow input component

### DIFF
--- a/crest/Assets/Crest/Crest/Materials/OceanInputs/ShadowOverride.mat
+++ b/crest/Assets/Crest/Crest/Materials/OceanInputs/ShadowOverride.mat
@@ -1,0 +1,80 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: ShadowOverride
+  m_Shader: {fileID: 4800000, guid: 84b07febfc25f4fec8a8cbac431c7bd0, type: 3}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _Alpha: 1
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _ShadowType: 14
+    - _ShadowValue: 1
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}

--- a/crest/Assets/Crest/Crest/Materials/OceanInputs/ShadowOverride.mat.meta
+++ b/crest/Assets/Crest/Crest/Materials/OceanInputs/ShadowOverride.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6dfb3029d5c5f426f8a254f93efe9b40
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Shadows/LodDataMgrShadow.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Shadows/LodDataMgrShadow.cs
@@ -241,6 +241,13 @@ namespace Crest
                     OceanRenderer.Instance.LodDataResolution / THREAD_GROUP_SIZE_Y,
                     1);
             }
+
+            // Process registered inputs.
+            for (var lodIdx = lt.LodCount - 1; lodIdx >= 0; lodIdx--)
+            {
+                BufCopyShadowMap.SetRenderTarget(_targets, _targets.depthBuffer, 0, CubemapFace.Unknown, lodIdx);
+                SubmitDraws(lodIdx, BufCopyShadowMap);
+            }
         }
 
         void UpdateCameraMain()

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Shadows/RegisterShadowInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Shadows/RegisterShadowInput.cs
@@ -1,0 +1,25 @@
+﻿// Crest Ocean System
+
+// This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
+
+using UnityEngine;
+
+namespace Crest
+{
+    /// <summary>
+    /// Registers a custom input for shadow data. Attach this to GameObjects that you want use to override shadows.
+    /// </summary>
+    [ExecuteAlways]
+    public class RegisterShadowInput : RegisterLodDataInput<LodDataMgrShadow>
+    {
+        public override bool Enabled => true;
+
+        public override float Wavelength => 0f;
+
+        protected override Color GizmoColor => new Color(0f, 0f, 0f, 0.5f);
+
+        protected override string ShaderPrefix => "Crest/Inputs/Shadows";
+
+        protected override bool FollowHorizontalMotion => false;
+    }
+}

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Shadows/RegisterShadowInput.cs.meta
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Shadows/RegisterShadowInput.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8e9f0ea32453849028549598223a56a0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/ShadowOverride.shader
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/ShadowOverride.shader
@@ -1,0 +1,56 @@
+﻿// Crest Ocean System
+
+// This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
+
+// Renders the geometry to the shadow texture and sets shadow data to provided value.
+
+Shader "Crest/Inputs/Shadows/Override Shadows"
+{
+	Properties
+	{
+		_ShadowValue("Shadow Value", Range(0.0, 1.0)) = 1.0
+	}
+
+	SubShader
+	{
+		Tags { "Queue" = "Geometry" }
+
+		Pass
+		{
+			Blend Off
+			ZWrite Off
+			ColorMask RG
+
+			CGPROGRAM
+			#pragma vertex Vert
+			#pragma fragment Frag
+
+			#include "UnityCG.cginc"
+
+			half _ShadowValue;
+
+			struct Attributes
+			{
+				float3 positionOS : POSITION;
+			};
+
+			struct Varyings
+			{
+				float4 positionCS : SV_POSITION;
+			};
+
+			Varyings Vert(Attributes input)
+			{
+				Varyings o;
+				o.positionCS = UnityObjectToClipPos(input.positionOS);
+				return o;
+			}
+
+			half4 Frag(Varyings input) : SV_Target
+			{
+				return _ShadowValue;
+			}
+			ENDCG
+		}
+	}
+}

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/ShadowOverride.shader.meta
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/ShadowOverride.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 84b07febfc25f4fec8a8cbac431c7bd0
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Adds a shadow input component similar to other LOD data. It could be useful for those who may have edge cases with shadows. The one advantage is complete control as it bypasses jitter.

An example use case is issue #392 where a small enclosed room can appear not shadowed inside because jitter samples outside the walls. 

Fixing the problem by reducing shadow leaks probably won't work because the fixes so far use depth.