### PR TITLE
Minor refactor of update shadow

### DIFF
--- a/crest/Assets/Crest/Crest/Shaders/OceanConstants.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanConstants.hlsl
@@ -19,6 +19,10 @@
 // Bias ocean floor depth so that default (0) values in texture are not interpreted as shallow and generating foam everywhere
 #define CREST_OCEAN_DEPTH_BASELINE 1000.0
 
+// Soft shadows is red, hard shadows is green.
+#define CREST_SHADOW_INDEX_SOFT 0
+#define CREST_SHADOW_INDEX_HARD 1
+
 // Background
 #define UNDERWATER_MASK_NO_MASK 1.0
 // Water rendered from above

--- a/crest/Assets/Crest/Crest/Shaders/Resources/UpdateShadow.compute
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/UpdateShadow.compute
@@ -163,8 +163,23 @@ void UpdateShadow(uint3 id : SV_DispatchThreadID)
 		half shadowFade = saturate(sphereDist * _LightShadowData.z + _LightShadowData.w);
 
 		fixed2 shadowThisFrame;
-		shadowThisFrame.x = ComputeShadow(shadowCoords, _JitterDiameters_CurrentFrameWeights.x, cascadeWeights);
-		shadowThisFrame.y = ComputeShadow(shadowCoords, _JitterDiameters_CurrentFrameWeights.y, cascadeWeights);
+
+		// Add soft shadowing data.
+		shadowThisFrame[CREST_SHADOW_INDEX_SOFT] = ComputeShadow
+		(
+			shadowCoords,
+			_JitterDiameters_CurrentFrameWeights[CREST_SHADOW_INDEX_SOFT],
+			cascadeWeights
+		);
+
+		// Add hard shadowing data.
+		shadowThisFrame[CREST_SHADOW_INDEX_HARD] = ComputeShadow
+		(
+			shadowCoords,
+			_JitterDiameters_CurrentFrameWeights[CREST_SHADOW_INDEX_HARD],
+			cascadeWeights
+		);
+
 		shadowThisFrame = (fixed2)1.0 - saturate(shadowThisFrame + shadowFade);
 
 		shadow = lerp(shadow, shadowThisFrame, _JitterDiameters_CurrentFrameWeights.zw * _SimDeltaTime * 60.0);


### PR DESCRIPTION
UpdateShadow now uses the shadow term constants from downstream. This works towards making it easier to remove the hard shadow term in HDRP.