### PR TITLE
Fix memory leak

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -622,9 +622,16 @@ namespace Crest
 
         void RunUpdate()
         {
-            // Do this *before* changing the ocean position, as it needs the current LOD positions to associate with the current queries
-            CollisionProvider.UpdateQueries();
-            FlowProvider.UpdateQueries();
+            // Run queries *before* changing the ocean position, as it needs the current LOD positions to associate with the current queries
+#if UNITY_EDITOR
+            // Issue #630 - seems to be a terrible memory leak coming from creating async gpu readbacks. We don't rely on queries in edit mode AFAIK
+            // so knock this out.
+            if (EditorApplication.isPlaying)
+#endif
+            {
+                CollisionProvider.UpdateQueries();
+                FlowProvider.UpdateQueries();
+            }
 
             // set global shader params
             Shader.SetGlobalFloat(sp_texelsPerWave, MinTexelsPerWave);


### PR DESCRIPTION
Don't run queries when in edit mode to stop leaking memory from within the code that creates async gpu readback requests.

Fixes #630 