### PR TITLE
Explore what multiple ocean instances would mean

### DIFF
--- a/crest/Assets/Crest/Crest-Examples/BoatDev/Scripts/BoatAlignNormal.cs
+++ b/crest/Assets/Crest/Crest-Examples/BoatDev/Scripts/BoatAlignNormal.cs
@@ -66,7 +66,7 @@ public class BoatAlignNormal : FloatingObjectBase
     {
         _rb = GetComponent<Rigidbody>();
 
-        if (OceanRenderer.Instance == null)
+        if (OceanRenderer.AnyInstance == null)
         {
             enabled = false;
             return;
@@ -75,7 +75,8 @@ public class BoatAlignNormal : FloatingObjectBase
 
     void FixedUpdate()
     {
-        if (OceanRenderer.Instance == null)
+        var ocean = OceanRenderer.ClosestInstance(transform.position);
+        if (ocean == null)
         {
             return;
         }
@@ -83,7 +84,7 @@ public class BoatAlignNormal : FloatingObjectBase
         UnityEngine.Profiling.Profiler.BeginSample("BoatAlignNormal.FixedUpdate");
 
         _sampleHeightHelper.Init(transform.position, _boatWidth, true);
-        var height = OceanRenderer.Instance.SeaLevel;
+        var height = ocean.SeaLevel;
 
         _sampleHeightHelper.Sample(out Vector3 disp, out var normal, out var waterSurfaceVel);
 

--- a/crest/Assets/Crest/Crest-Examples/BoatDev/Scripts/LerpCam.cs
+++ b/crest/Assets/Crest/Crest-Examples/BoatDev/Scripts/LerpCam.cs
@@ -17,7 +17,7 @@ public class LerpCam : MonoBehaviour
 
     void Update()
     {
-        if (OceanRenderer.Instance == null)
+        if (OceanRenderer.AnyInstance == null)
         {
             return;
         }
@@ -28,7 +28,7 @@ public class LerpCam : MonoBehaviour
         var targetPos = _targetPos.position;
         targetPos.y = Mathf.Max(targetPos.y, h + _minHeightAboveWater);
 
-        transform.position = Vector3.Lerp(transform.position, targetPos, _lerpAlpha * OceanRenderer.Instance.DeltaTime * 60f);
+        transform.position = Vector3.Lerp(transform.position, targetPos, _lerpAlpha * OceanRenderer.AnyInstance.DeltaTime * 60f);
         transform.LookAt(_targetLookatPos.position + _lookatOffset * Vector3.up);
     }
 }

--- a/crest/Assets/Crest/Crest-Examples/BoatDev/Scripts/RippleGenerator.cs
+++ b/crest/Assets/Crest/Crest-Examples/BoatDev/Scripts/RippleGenerator.cs
@@ -21,7 +21,7 @@ public class RippleGenerator : MonoBehaviour
     {
         _rdwi = GetComponent<RegisterDynWavesInput>();
 
-        if (OceanRenderer.Instance == null || !OceanRenderer.Instance.CreateDynamicWaveSim || _rdwi == null)
+        if (OceanRenderer.AnyInstance == null || !OceanRenderer.AnyInstance.CreateDynamicWaveSim || _rdwi == null)
         {
             enabled = false;
             return;
@@ -33,14 +33,15 @@ public class RippleGenerator : MonoBehaviour
 
     void Update()
     {
-        if (OceanRenderer.Instance == null)
+        var ocean = OceanRenderer.AnyInstance;
+        if (ocean == null)
         {
             return;
         }
 
         if (_animate)
         {
-            float t = OceanRenderer.Instance.CurrentTime;
+            float t = OceanRenderer.AnyInstance.CurrentTime;
             if (t < _warmUp)
                 return;
             t -= _warmUp;
@@ -50,7 +51,7 @@ public class RippleGenerator : MonoBehaviour
 
         // which lod is this object in (roughly)?
         Rect thisRect = new Rect(new Vector2(transform.position.x, transform.position.z), Vector3.zero);
-        int minLod = LodDataMgrAnimWaves.SuggestDataLOD(thisRect);
+        int minLod = LodDataMgrAnimWaves.SuggestDataLOD(ocean, thisRect);
         if (minLod == -1)
         {
             // outside all lods, nothing to update!
@@ -60,7 +61,7 @@ public class RippleGenerator : MonoBehaviour
         // how many active wave sims currently apply to this object - ideally this would eliminate sims that are too
         // low res, by providing a max grid size param
         int simsPresent, simsActive;
-        LodDataMgrDynWaves.CountWaveSims(minLod, out simsPresent, out simsActive);
+        LodDataMgrDynWaves.CountWaveSims(ocean, minLod, out simsPresent, out simsActive);
         if (simsPresent == 0)
         {
             enabled = false;
@@ -68,7 +69,7 @@ public class RippleGenerator : MonoBehaviour
         }
 
         float dt;
-        OceanRenderer.Instance._lodDataDynWaves.GetSimSubstepData(OceanRenderer.Instance.DeltaTimeDynamics, out _, out dt);
+        ocean._lodDataDynWaves.GetSimSubstepData(ocean.DeltaTimeDynamics, out _, out dt);
 
         _rend.GetPropertyBlock(_mpb);
 

--- a/crest/Assets/Crest/Crest-Examples/Shared/Scripts/Collision/OceanSampleDisplacementDemo.cs
+++ b/crest/Assets/Crest/Crest-Examples/Shared/Scripts/Collision/OceanSampleDisplacementDemo.cs
@@ -25,14 +25,15 @@ public class OceanSampleDisplacementDemo : MonoBehaviour
 
     void Update()
     {
-        if (OceanRenderer.Instance == null)
+        var ocean = OceanRenderer.ClosestInstance(transform.position);
+        if (ocean == null)
         {
             return;
         }
 
         if (_trackCamera)
         {
-            var height = Mathf.Abs(Camera.main.transform.position.y - OceanRenderer.Instance.SeaLevel);
+            var height = Mathf.Abs(Camera.main.transform.position.y - ocean.SeaLevel);
             var lookAngle = Mathf.Max(Mathf.Abs(Camera.main.transform.forward.y), 0.001f);
             var offset = height / lookAngle;
             _markerPos[0] = Camera.main.transform.position + Camera.main.transform.forward * offset;
@@ -40,7 +41,7 @@ public class OceanSampleDisplacementDemo : MonoBehaviour
             _markerPos[2] = Camera.main.transform.position + Camera.main.transform.forward * offset + _samplesRadius * Vector3.forward;
         }
 
-        var collProvider = OceanRenderer.Instance.CollisionProvider;
+        var collProvider = ocean.CollisionProvider;
 
         var status = collProvider.Query(GetHashCode(), _minGridSize, _markerPos, _resultDisps, _resultNorms, _resultVels);
 
@@ -56,7 +57,7 @@ public class OceanSampleDisplacementDemo : MonoBehaviour
                 }
 
                 var query = _markerPos[i];
-                query.y = OceanRenderer.Instance.SeaLevel;
+                query.y = ocean.SeaLevel;
 
                 var disp = _resultDisps[i];
 

--- a/crest/Assets/Crest/Crest-Examples/Shared/Scripts/UnderwaterEnvironmentalLighting.cs
+++ b/crest/Assets/Crest/Crest-Examples/Shared/Scripts/UnderwaterEnvironmentalLighting.cs
@@ -29,13 +29,14 @@ namespace Crest
 
         void Start()
         {
-            if (OceanRenderer.Instance == null)
+            // todo - how to connect this to correct ocean instance?
+            if (OceanRenderer.AnyInstance == null)
             {
                 enabled = false;
                 return;
             }
 
-            _primaryLight = OceanRenderer.Instance._primaryLight;
+            _primaryLight = OceanRenderer.AnyInstance._primaryLight;
 
             // Store lighting settings
             if (_primaryLight)
@@ -47,13 +48,13 @@ namespace Crest
             _fogDensity = RenderSettings.fogDensity;
 
             // Check to make sure the property exists. We might be using a test material.
-            if (!OceanRenderer.Instance.OceanMaterial.HasProperty("_DepthFogDensity"))
+            if (!OceanRenderer.AnyInstance.OceanMaterial.HasProperty("_DepthFogDensity"))
             {
                 enabled = false;
                 return;
             }
 
-            Color density = OceanRenderer.Instance.OceanMaterial.GetColor("_DepthFogDensity");
+            Color density = OceanRenderer.AnyInstance.OceanMaterial.GetColor("_DepthFogDensity");
             _averageDensity = (density.r + density.g + density.b) / 3f;
         }
 
@@ -71,13 +72,13 @@ namespace Crest
 
         void LateUpdate()
         {
-            if (OceanRenderer.Instance == null)
+            if (OceanRenderer.AnyInstance == null)
             {
                 return;
             }
 
             float depthMultiplier = Mathf.Exp(_averageDensity *
-                Mathf.Min(OceanRenderer.Instance.ViewerHeightAboveWater * DEPTH_OUTSCATTER_CONSTANT, 0f));
+                Mathf.Min(OceanRenderer.AnyInstance.ViewerHeightAboveWater * DEPTH_OUTSCATTER_CONSTANT, 0f));
 
             // Darken environmental lighting when viewer underwater
             if (_primaryLight)

--- a/crest/Assets/Crest/Crest-Examples/Whirlpool/Scripts/Whirlpool.cs
+++ b/crest/Assets/Crest/Crest-Examples/Whirlpool/Scripts/Whirlpool.cs
@@ -37,7 +37,7 @@ namespace Crest
 
         void Start()
         {
-            if (OceanRenderer.Instance == null)
+            if (OceanRenderer.AnyInstance == null)
             {
                 enabled = false;
                 return;
@@ -79,12 +79,16 @@ namespace Crest
 
         void Update()
         {
-            if (OceanRenderer.Instance == null)
+            for (var i = 0; i < OceanRenderer.InstanceCount; i++)
             {
-                return;
-            }
+                var ocean = OceanRenderer.GetInstance(i);
+                if (ocean == null)
+                {
+                    continue;
+                }
 
-            OceanRenderer.Instance.ReportMaxDisplacementFromShape(0f, _amplitude, 0f);
+                ocean.ReportMaxDisplacementFromShape(0f, _amplitude, 0f);
+            }
 
             UpdateMaterials();
         }

--- a/crest/Assets/Crest/Crest/Scripts/BuildCommandBuffer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/BuildCommandBuffer.cs
@@ -86,10 +86,8 @@ namespace Crest
         /// <summary>
         /// Construct the command buffer and attach it to the camera so that it will be executed in the render.
         /// </summary>
-        public void BuildAndExecute()
+        public void BuildAndExecute(OceanRenderer ocean)
         {
-            if (OceanRenderer.Instance == null) return;
-
             if (_buf == null)
             {
                 _buf = new CommandBuffer();
@@ -98,7 +96,7 @@ namespace Crest
 
             _buf.Clear();
 
-            BuildLodData(OceanRenderer.Instance, _buf);
+            BuildLodData(ocean, _buf);
 
             // This will execute at the beginning of the frame before the graphics queue
             Graphics.ExecuteCommandBuffer(_buf);

--- a/crest/Assets/Crest/Crest/Scripts/Collision/QueryBase.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Collision/QueryBase.cs
@@ -28,6 +28,8 @@ namespace Crest
         const int s_maxRequests = 4;
         const int s_maxGuids = 1024;
 
+        protected OceanRenderer _ocean;
+
         protected virtual ComputeShader ShaderProcessQueries => _shaderProcessQueries;
         ComputeShader _shaderProcessQueries;
         PropertyWrapperComputeStandalone _wrapper;
@@ -215,13 +217,15 @@ namespace Crest
             InvalidDtForVelocity = 16,
         }
 
-        public QueryBase()
+        public QueryBase(OceanRenderer ocean)
         {
+            _ocean = ocean;
+
             _dataArrivedAction = new System.Action<AsyncGPUReadbackRequest>(DataArrived);
 
-            if (_maxQueryCount != OceanRenderer.Instance._lodDataAnimWaves.Settings.MaxQueryCount)
+            if (_maxQueryCount != ocean._lodDataAnimWaves.Settings.MaxQueryCount)
             {
-                _maxQueryCount = OceanRenderer.Instance._lodDataAnimWaves.Settings.MaxQueryCount;
+                _maxQueryCount = ocean._lodDataAnimWaves.Settings.MaxQueryCount;
                 _queryPosXZ_minGridSize = new Vector3[_maxQueryCount];
             }
 
@@ -307,7 +311,7 @@ namespace Crest
             // The smallest wavelengths should repeat no more than twice across the smaller spatial length. Unless we're
             // in the last LOD - then this is the best we can do.
             float minWavelength = i_minSpatialLength / 2f;
-            float minGridSize = minWavelength / OceanRenderer.Instance.MinTexelsPerWave;
+            float minGridSize = minWavelength / _ocean.MinTexelsPerWave;
 
             if (countPts + segment.x > _queryPosXZ_minGridSize.Length)
             {
@@ -392,7 +396,7 @@ namespace Crest
                 // Retrieve Result heights
                 if (heights != null)
                 {
-                    var seaLevel = OceanRenderer.Instance.SeaLevel;
+                    var seaLevel = _ocean.SeaLevel;
                     for (int i = 0; i < countPoints; i++)
                     {
                         heights[i] = seaLevel + _queryResults[i + segment.x].y;

--- a/crest/Assets/Crest/Crest/Scripts/Collision/QueryDisplacements.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Collision/QueryDisplacements.cs
@@ -17,10 +17,14 @@ namespace Crest
         protected override string QueryShaderName => "QueryDisplacements";
         protected override string QueryKernelName => "CSMain";
 
+        public QueryDisplacements(OceanRenderer ocean) : base(ocean)
+        {
+        }
+
         protected override void BindInputsAndOutputs(PropertyWrapperComputeStandalone wrapper, ComputeBuffer resultsBuffer)
         {
-            OceanRenderer.Instance._lodDataAnimWaves.BindResultData(wrapper);
-            ShaderProcessQueries.SetTexture(_kernelHandle, sp_LD_TexArray_AnimatedWaves, OceanRenderer.Instance._lodDataAnimWaves.DataTexture);
+            _ocean._lodDataAnimWaves.BindResultData(wrapper);
+            ShaderProcessQueries.SetTexture(_kernelHandle, sp_LD_TexArray_AnimatedWaves, _ocean._lodDataAnimWaves.DataTexture);
             ShaderProcessQueries.SetBuffer(_kernelHandle, sp_ResultDisplacements, resultsBuffer);
         }
 

--- a/crest/Assets/Crest/Crest/Scripts/Collision/QueryFlow.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Collision/QueryFlow.cs
@@ -17,12 +17,16 @@ namespace Crest
         protected override string QueryShaderName => "QueryFlow";
         protected override string QueryKernelName => "CSMain";
 
+        public QueryFlow(OceanRenderer ocean) : base(ocean)
+        {
+        }
+
         protected override void BindInputsAndOutputs(PropertyWrapperComputeStandalone wrapper, ComputeBuffer resultsBuffer)
         {
-            if (OceanRenderer.Instance._lodDataFlow != null)
+            if (_ocean._lodDataFlow != null)
             {
-                OceanRenderer.Instance._lodDataFlow.BindResultData(wrapper);
-                ShaderProcessQueries.SetTexture(_kernelHandle, sp_LD_TexArray_Flow, OceanRenderer.Instance._lodDataFlow.DataTexture);
+                _ocean._lodDataFlow.BindResultData(wrapper);
+                ShaderProcessQueries.SetTexture(_kernelHandle, sp_LD_TexArray_Flow, _ocean._lodDataFlow.DataTexture);
             }
             else
             {

--- a/crest/Assets/Crest/Crest/Scripts/Collision/RayTraceHelper.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Collision/RayTraceHelper.cs
@@ -12,6 +12,8 @@ namespace Crest
     /// </summary>
     public class RayTraceHelper
     {
+        OceanRenderer _ocean;
+
         Vector3[] _queryPos;
         Vector3[] _queryResult;
 
@@ -53,6 +55,8 @@ namespace Crest
         /// <param name="i_rayDirection">World space ray direction</param>
         public void Init(Vector3 i_rayOrigin, Vector3 i_rayDirection)
         {
+            _ocean = OceanRenderer.ClosestInstance(i_rayOrigin);
+
             for (int i = 0; i < _queryPos.Length; i++)
             {
                 _queryPos[i] = i_rayOrigin + i * _rayStepSize * i_rayDirection;
@@ -82,9 +86,9 @@ namespace Crest
                 return false;
             }
 
-            var status = OceanRenderer.Instance.CollisionProvider.Query(GetHashCode(), _minLength, _queryPos, _queryResult, null, null);
+            var status = _ocean.CollisionProvider.Query(GetHashCode(), _minLength, _queryPos, _queryResult, null, null);
 
-            if (!OceanRenderer.Instance.CollisionProvider.RetrieveSucceeded(status))
+            if (!_ocean.CollisionProvider.RetrieveSucceeded(status))
             {
                 _valid = false;
                 return false;
@@ -94,8 +98,8 @@ namespace Crest
             // the ray crosses the surface, the distance to the intersection is interpolated from the heights.
             for (int i = 1; i < _queryPos.Length; i++)
             {
-                var height0 = _queryResult[i - 1].y + OceanRenderer.Instance.SeaLevel - _queryPos[i - 1].y;
-                var height1 = _queryResult[i].y + OceanRenderer.Instance.SeaLevel - _queryPos[i].y;
+                var height0 = _queryResult[i - 1].y + _ocean.SeaLevel - _queryPos[i - 1].y;
+                var height1 = _queryResult[i].y + _ocean.SeaLevel - _queryPos[i].y;
 
                 if (Mathf.Sign(height0) != Mathf.Sign(height1))
                 {

--- a/crest/Assets/Crest/Crest/Scripts/Collision/SamplingHelpers.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Collision/SamplingHelpers.cs
@@ -17,6 +17,8 @@ namespace Crest
         Vector3[] _queryResultNormal = new Vector3[1];
         Vector3[] _queryResultVel = new Vector3[1];
 
+        OceanRenderer _ocean;
+
         float _minLength = 0f;
 
 #if UNITY_EDITOR
@@ -35,6 +37,7 @@ namespace Crest
         {
             _queryPos[0] = i_queryPos;
             _minLength = i_minLength;
+            _ocean = OceanRenderer.ClosestInstance(i_queryPos);
 
 #if UNITY_EDITOR
             if (!allowMultipleCallsPerFrame && _lastFrame >= OceanRenderer.FrameCount)
@@ -50,7 +53,7 @@ namespace Crest
         /// </summary>
         public bool Sample(out float o_height)
         {
-            var collProvider = OceanRenderer.Instance?.CollisionProvider;
+            var collProvider = _ocean?.CollisionProvider;
             if (collProvider == null)
             {
                 o_height = 0f;
@@ -61,18 +64,18 @@ namespace Crest
 
             if (!collProvider.RetrieveSucceeded(status))
             {
-                o_height = OceanRenderer.Instance.SeaLevel;
+                o_height = _ocean.SeaLevel;
                 return false;
             }
 
-            o_height = _queryResult[0].y + OceanRenderer.Instance.SeaLevel;
+            o_height = _queryResult[0].y + _ocean.SeaLevel;
 
             return true;
         }
 
         public bool Sample(out float o_height, out Vector3 o_normal)
         {
-            var collProvider = OceanRenderer.Instance?.CollisionProvider;
+            var collProvider = _ocean?.CollisionProvider;
             if (collProvider == null)
             {
                 o_height = 0f;
@@ -84,12 +87,12 @@ namespace Crest
 
             if (!collProvider.RetrieveSucceeded(status))
             {
-                o_height = OceanRenderer.Instance.SeaLevel;
+                o_height = _ocean.SeaLevel;
                 o_normal = Vector3.up;
                 return false;
             }
 
-            o_height = _queryResult[0].y + OceanRenderer.Instance.SeaLevel;
+            o_height = _queryResult[0].y + _ocean.SeaLevel;
             o_normal = _queryResultNormal[0];
 
             return true;
@@ -97,7 +100,7 @@ namespace Crest
 
         public bool Sample(out float o_height, out Vector3 o_normal, out Vector3 o_surfaceVel)
         {
-            var collProvider = OceanRenderer.Instance?.CollisionProvider;
+            var collProvider = _ocean?.CollisionProvider;
             if (collProvider == null)
             {
                 o_height = 0f;
@@ -110,13 +113,13 @@ namespace Crest
 
             if (!collProvider.RetrieveSucceeded(status))
             {
-                o_height = OceanRenderer.Instance.SeaLevel;
+                o_height = _ocean.SeaLevel;
                 o_normal = Vector3.up;
                 o_surfaceVel = Vector3.zero;
                 return false;
             }
 
-            o_height = _queryResult[0].y + OceanRenderer.Instance.SeaLevel;
+            o_height = _queryResult[0].y + _ocean.SeaLevel;
             o_normal = _queryResultNormal[0];
             o_surfaceVel = _queryResultVel[0];
 
@@ -125,7 +128,7 @@ namespace Crest
 
         public bool Sample(out Vector3 o_displacementToPoint, out Vector3 o_normal, out Vector3 o_surfaceVel)
         {
-            var collProvider = OceanRenderer.Instance?.CollisionProvider;
+            var collProvider = _ocean?.CollisionProvider;
             if (collProvider == null)
             {
                 o_displacementToPoint = Vector3.zero;
@@ -159,7 +162,7 @@ namespace Crest
     {
         Vector3[] _queryPos = new Vector3[1];
         Vector3[] _queryResult = new Vector3[1];
-
+        OceanRenderer _ocean;
         float _minLength = 0f;
 
         /// <summary>
@@ -172,6 +175,7 @@ namespace Crest
         {
             _queryPos[0] = i_queryPos;
             _minLength = i_minLength;
+            _ocean = OceanRenderer.ClosestInstance(i_queryPos);
         }
 
         /// <summary>
@@ -179,7 +183,7 @@ namespace Crest
         /// </summary>
         public bool Sample(out Vector2 o_flow)
         {
-            var flowProvider = OceanRenderer.Instance?.FlowProvider;
+            var flowProvider = _ocean?.FlowProvider;
             if (flowProvider == null)
             {
                 o_flow = Vector2.zero;

--- a/crest/Assets/Crest/Crest/Scripts/Collision/VisualiseCollisionArea.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Collision/VisualiseCollisionArea.cs
@@ -23,12 +23,12 @@ namespace Crest
 
         void Update()
         {
-            if (OceanRenderer.Instance == null || OceanRenderer.Instance.CollisionProvider == null)
+            if (OceanRenderer.AnyInstance == null)
             {
                 return;
             }
 
-            var collProvider = OceanRenderer.Instance.CollisionProvider;
+            var collProvider = OceanRenderer.ClosestInstance(transform.position).CollisionProvider;
 
             for (int i = 0; i < s_steps; i++)
             {

--- a/crest/Assets/Crest/Crest/Scripts/Collision/VisualiseRayTrace.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Collision/VisualiseRayTrace.cs
@@ -15,7 +15,7 @@ namespace Crest
 
         void Update()
         {
-            if (OceanRenderer.Instance == null || OceanRenderer.Instance.CollisionProvider == null)
+            if (OceanRenderer.AnyInstance == null)
             {
                 return;
             }

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/AssignLayer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/AssignLayer.cs
@@ -21,7 +21,7 @@ namespace Crest
             enabled = false;
 
 #if UNITY_EDITOR
-            if (EditorApplication.isPlaying && !Validate(OceanRenderer.Instance, ValidatedHelper.DebugLog))
+            if (EditorApplication.isPlaying && !Validate(OceanRenderer.AnyInstance, ValidatedHelper.DebugLog))
             {
                 return;
             }

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/Editor/WindowCrestWaterBody.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/Editor/WindowCrestWaterBody.cs
@@ -46,7 +46,7 @@ namespace Crest
                 return;
             }
 
-            if (OceanRenderer.Instance == null)
+            if (OceanRenderer.AnyInstance == null)
             {
                 EditorGUILayout.HelpBox(
                     "No water object in loaded scenes, so no water will appear. To add one create a new GameObject and attach a OceanRenderer component to it.",

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/FloatingOrigin.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/FloatingOrigin.cs
@@ -139,22 +139,24 @@ namespace Crest
         /// </summary>
         void MoveOriginOcean(Vector3 newOrigin)
         {
-            if (OceanRenderer.Instance)
+            for (var i = 0; i < OceanRenderer.InstanceCount; i++)
             {
-                OceanRenderer.Instance._lodTransform.SetOrigin(newOrigin);
+                var ocean = OceanRenderer.GetInstance(i);
 
-                var fos = OceanRenderer.Instance.GetComponentsInChildren<IFloatingOrigin>();
+                ocean._lodTransform.SetOrigin(newOrigin);
+
+                var fos = ocean.GetComponentsInChildren<IFloatingOrigin>();
                 foreach (var fo in fos)
                 {
                     fo.SetOrigin(newOrigin);
                 }
+            }
 
-                // Gerstner components
-                var gerstners = _overrideGerstnerList != null && _overrideGerstnerList.Length > 0 ? _overrideGerstnerList : FindObjectsOfType<ShapeGerstnerBatched>();
-                foreach (var gerstner in gerstners)
-                {
-                    gerstner.SetOrigin(newOrigin);
-                }
+            // Gerstner components
+            var gerstners = _overrideGerstnerList != null && _overrideGerstnerList.Length > 0 ? _overrideGerstnerList : FindObjectsOfType<ShapeGerstnerBatched>();
+            foreach (var gerstner in gerstners)
+            {
+                gerstner.SetOrigin(newOrigin);
             }
         }
 

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/OceanDebugGUI.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/OceanDebugGUI.cs
@@ -57,6 +57,8 @@ namespace Crest
         {
             Color bkp = GUI.color;
 
+            var ocean = OceanRenderer.InstanceCount > 0 ? OceanRenderer.GetInstance(0) : null;
+
             if (_guiVisible)
             {
                 GUI.skin.toggle.normal.textColor = Color.white;
@@ -109,17 +111,17 @@ namespace Crest
 
                 LodDataMgrShadow.s_processData = GUI.Toggle(new Rect(x, y, w, h), LodDataMgrShadow.s_processData, "Process Shadows"); y += h;
 
-                if (OceanRenderer.Instance)
+                if (ocean != null)
                 {
-                    if (OceanRenderer.Instance._lodDataDynWaves != null)
+                    if (ocean._lodDataDynWaves != null)
                     {
                         int steps; float dt;
-                        OceanRenderer.Instance._lodDataDynWaves.GetSimSubstepData(OceanRenderer.Instance.DeltaTimeDynamics, out steps, out dt);
+                        ocean._lodDataDynWaves.GetSimSubstepData(ocean.DeltaTimeDynamics, out steps, out dt);
                         GUI.Label(new Rect(x, y, w, h), string.Format("Sim steps: {0:0.00000} x {1}", dt, steps)); y += h;
                     }
 
-                    var querySystem = OceanRenderer.Instance.CollisionProvider as QueryBase;
-                    if (OceanRenderer.Instance.CollisionProvider != null && querySystem != null)
+                    var querySystem = ocean.CollisionProvider as QueryBase;
+                    if (ocean.CollisionProvider != null && querySystem != null)
                     {
                         GUI.Label(new Rect(x, y, w, h), string.Format("Query result GUIDs: {0}", querySystem.ResultGuidCount)); y += h;
                     }
@@ -127,7 +129,7 @@ namespace Crest
 #if UNITY_EDITOR
                     if (GUI.Button(new Rect(x, y, w, h), "Select Ocean Mat"))
                     {
-                        var path = UnityEditor.AssetDatabase.GetAssetPath(OceanRenderer.Instance.OceanMaterial);
+                        var path = UnityEditor.AssetDatabase.GetAssetPath(ocean.OceanMaterial);
                         var asset = UnityEditor.AssetDatabase.LoadMainAssetAtPath(path);
                         UnityEditor.Selection.activeObject = asset;
                     }
@@ -145,15 +147,15 @@ namespace Crest
             // draw source textures to screen
             if (_showOceanData)
             {
-                DrawShapeTargets();
+                DrawShapeTargets(ocean);
             }
 
             GUI.color = bkp;
         }
 
-        void DrawShapeTargets()
+        void DrawShapeTargets(OceanRenderer ocean)
         {
-            if (OceanRenderer.Instance == null) return;
+            if (ocean == null) return;
 
             // Draw bottom panel for toggles
             var bottomBar = new Rect(_guiVisible ? _leftPanelWidth : 0,
@@ -164,23 +166,23 @@ namespace Crest
 
             // Show viewer height above water in bottom panel
             bottomBar.x += 10;
-            GUI.Label(bottomBar, "Viewer Height Above Water: " + OceanRenderer.Instance.ViewerHeightAboveWater);
+            GUI.Label(bottomBar, "Viewer Height Above Water: " + ocean.ViewerHeightAboveWater);
 
             // Draw sim data
-            DrawSims();
+            DrawSims(ocean);
         }
 
-        void DrawSims()
+        void DrawSims(OceanRenderer ocean)
         {
             float column = 1f;
 
-            DrawSim<LodDataMgrAnimWaves>(OceanRenderer.Instance._lodDataAnimWaves, ref _drawAnimWaves, ref column);
-            DrawSim<LodDataMgrDynWaves>(OceanRenderer.Instance._lodDataDynWaves, ref _drawDynWaves, ref column);
-            DrawSim<LodDataMgrFoam>(OceanRenderer.Instance._lodDataFoam, ref _drawFoam, ref column);
-            DrawSim<LodDataMgrFlow>(OceanRenderer.Instance._lodDataFlow, ref _drawFlow, ref column);
-            DrawSim<LodDataMgrShadow>(OceanRenderer.Instance._lodDataShadow, ref _drawShadow, ref column);
-            DrawSim<LodDataMgrSeaFloorDepth>(OceanRenderer.Instance._lodDataSeaDepths, ref _drawSeaFloorDepth, ref column);
-            DrawSim<LodDataMgrClipSurface>(OceanRenderer.Instance._lodDataClipSurface, ref _drawClipSurface, ref column);
+            DrawSim<LodDataMgrAnimWaves>(ocean._lodDataAnimWaves, ref _drawAnimWaves, ref column);
+            DrawSim<LodDataMgrDynWaves>(ocean._lodDataDynWaves, ref _drawDynWaves, ref column);
+            DrawSim<LodDataMgrFoam>(ocean._lodDataFoam, ref _drawFoam, ref column);
+            DrawSim<LodDataMgrFlow>(ocean._lodDataFlow, ref _drawFlow, ref column);
+            DrawSim<LodDataMgrShadow>(ocean._lodDataShadow, ref _drawShadow, ref column);
+            DrawSim<LodDataMgrSeaFloorDepth>(ocean._lodDataSeaDepths, ref _drawSeaFloorDepth, ref column);
+            DrawSim<LodDataMgrClipSurface>(ocean._lodDataClipSurface, ref _drawClipSurface, ref column);
         }
 
         static void DrawSim<SimType>(LodDataMgr lodData, ref bool doDraw, ref float offset) where SimType : LodDataMgr

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/PropertyWrapper.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/PropertyWrapper.cs
@@ -80,12 +80,12 @@ namespace Crest
         // 64 recommended as a good common minimum: https://www.reddit.com/r/GraphicsProgramming/comments/aeyfkh/for_compute_shaders_is_there_an_ideal_numthreads/
         public const int THREAD_GROUP_SIZE_X = 8;
         public const int THREAD_GROUP_SIZE_Y = 8;
-        public void DispatchShader()
+        public void DispatchShader(OceanRenderer ocean)
         {
             _commandBuffer.DispatchCompute(
                 _computeShader, _computeKernel,
-                OceanRenderer.Instance.LodDataResolution / THREAD_GROUP_SIZE_X,
-                OceanRenderer.Instance.LodDataResolution / THREAD_GROUP_SIZE_Y,
+                ocean.LodDataResolution / THREAD_GROUP_SIZE_X,
+                ocean.LodDataResolution / THREAD_GROUP_SIZE_Y,
                 1
             );
 
@@ -94,13 +94,13 @@ namespace Crest
             _computeKernel = -1;
         }
 
-        public void DispatchShaderMultiLOD()
+        public void DispatchShaderMultiLOD(OceanRenderer ocean)
         {
             _commandBuffer.DispatchCompute(
                 _computeShader, _computeKernel,
-                OceanRenderer.Instance.LodDataResolution / THREAD_GROUP_SIZE_X,
-                OceanRenderer.Instance.LodDataResolution / THREAD_GROUP_SIZE_Y,
-                OceanRenderer.Instance.CurrentLodCount
+                ocean.LodDataResolution / THREAD_GROUP_SIZE_X,
+                ocean.LodDataResolution / THREAD_GROUP_SIZE_Y,
+                ocean.CurrentLodCount
             );
 
             _commandBuffer = null;

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/TextureArrayHelpers.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/TextureArrayHelpers.cs
@@ -44,10 +44,11 @@ namespace Crest
                 return;
             }
             s_clearToBlackShader.SetTexture(krnl_ClearToBlack, sp_LD_TexArray_Target, dst);
+            // todo - make lod data resolution a global setting (or pass in ocean?)
             s_clearToBlackShader.Dispatch(
                 krnl_ClearToBlack,
-                OceanRenderer.Instance.LodDataResolution / PropertyWrapperCompute.THREAD_GROUP_SIZE_X,
-                OceanRenderer.Instance.LodDataResolution / PropertyWrapperCompute.THREAD_GROUP_SIZE_Y,
+                OceanRenderer.AnyInstance.LodDataResolution / PropertyWrapperCompute.THREAD_GROUP_SIZE_X,
+                OceanRenderer.AnyInstance.LodDataResolution / PropertyWrapperCompute.THREAD_GROUP_SIZE_Y,
                 dst.volumeDepth
             );
         }

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/UnderwaterEffect.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/UnderwaterEffect.cs
@@ -44,6 +44,8 @@ namespace Crest
         PropertyWrapperMPB _mpb;
         Renderer _rend;
 
+        [SerializeField] Camera _camera;
+
         readonly int sp_HeightOffset = Shader.PropertyToID("_HeightOffset");
 
         SampleHeightHelper _sampleWaterHeight = new SampleHeightHelper();
@@ -59,12 +61,13 @@ namespace Crest
 #endif
             _rend = GetComponent<Renderer>();
 
+            _camera = transform.parent.gameObject.GetComponent<Camera>();
+
             // Render before the surface mesh
             _rend.sortingOrder = _overrideSortingOrder ? _overridenSortingOrder : -LodDataMgr.MAX_LOD_COUNT - 1;
             GetComponent<MeshFilter>().sharedMesh = Mesh2DGrid(0, 2, -0.5f, -0.5f, 1f, 1f, GEOM_HORIZ_DIVISIONS, 1);
 
-            // TODO - how to connect camera/underwater effect with ocean?
-            _ocean = OceanRenderer.AnyInstance;
+            _ocean = OceanRenderer.GetInstance(_camera);
 
 #if UNITY_EDITOR
             if (EditorApplication.isPlaying && !Validate(_ocean, ValidatedHelper.DebugLog))

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/UnderwaterEffect.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/UnderwaterEffect.cs
@@ -43,8 +43,7 @@ namespace Crest
         OceanRenderer _ocean;
         PropertyWrapperMPB _mpb;
         Renderer _rend;
-
-        [SerializeField] Camera _camera;
+        Camera _camera;
 
         readonly int sp_HeightOffset = Shader.PropertyToID("_HeightOffset");
 
@@ -61,7 +60,7 @@ namespace Crest
 #endif
             _rend = GetComponent<Renderer>();
 
-            _camera = transform.parent.gameObject.GetComponent<Camera>();
+            _camera = GetComponentInParent<Camera>();
 
             // Render before the surface mesh
             _rend.sortingOrder = _overrideSortingOrder ? _overridenSortingOrder : -LodDataMgr.MAX_LOD_COUNT - 1;

--- a/crest/Assets/Crest/Crest/Scripts/Interaction/BoatProbes.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Interaction/BoatProbes.cs
@@ -70,7 +70,7 @@ namespace Crest
             _rb = GetComponent<Rigidbody>();
             _rb.centerOfMass = _centerOfMass;
 
-            if (OceanRenderer.Instance == null)
+            if (OceanRenderer.AnyInstance == null)
             {
                 enabled = false;
                 return;
@@ -98,19 +98,20 @@ namespace Crest
             // Sum weights every frame when running in editor in case weights are edited in the inspector.
             CalcTotalWeight();
 #endif
+            var ocean = OceanRenderer.ClosestInstance(transform.position);
 
-            if (OceanRenderer.Instance == null)
+            if (ocean == null)
             {
                 return;
             }
 
-            var collProvider = OceanRenderer.Instance.CollisionProvider;
+            var collProvider = ocean.CollisionProvider;
 
             // Do queries
             UpdateWaterQueries(collProvider);
 
             var undispPos = transform.position - _queryResultDisps[_forcePoints.Length];
-            undispPos.y = OceanRenderer.Instance.SeaLevel;
+            undispPos.y = ocean.SeaLevel;
 
             var waterSurfaceVel = _queryResultVels[_forcePoints.Length];
 
@@ -121,7 +122,7 @@ namespace Crest
             }
 
             // Buoyancy
-            FixedUpdateBuoyancy();
+            FixedUpdateBuoyancy(ocean);
             FixedUpdateDrag(waterSurfaceVel);
             FixedUpdateEngine();
         }
@@ -152,13 +153,13 @@ namespace Crest
             _rb.AddTorque(rotVec * _turnPower * sideways, ForceMode.Acceleration);
         }
 
-        void FixedUpdateBuoyancy()
+        void FixedUpdateBuoyancy(OceanRenderer ocean)
         {
             var archimedesForceMagnitude = WATER_DENSITY * Mathf.Abs(Physics.gravity.y);
 
             for (int i = 0; i < _forcePoints.Length; i++)
             {
-                var waterHeight = OceanRenderer.Instance.SeaLevel + _queryResultDisps[i].y;
+                var waterHeight = ocean.SeaLevel + _queryResultDisps[i].y;
                 var heightDiff = waterHeight - _queryPoints[i].y;
                 if (heightDiff > 0)
                 {

--- a/crest/Assets/Crest/Crest/Scripts/Interaction/ObjectWaterInteractionAdaptor.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Interaction/ObjectWaterInteractionAdaptor.cs
@@ -27,18 +27,19 @@ namespace Crest
 
         private void Update()
         {
-            if (OceanRenderer.Instance == null)
+            var ocean = OceanRenderer.ClosestInstance(transform.position);
+            if (ocean == null)
             {
                 return;
             }
 
             _queryPoints[0] = transform.position;
-            var result = OceanRenderer.Instance.CollisionProvider.Query(GetHashCode(), ObjectWidth, _queryPoints, _resultDisps, null, null);
-            if (OceanRenderer.Instance.CollisionProvider.RetrieveSucceeded(result))
+            var result = ocean.CollisionProvider.Query(GetHashCode(), ObjectWidth, _queryPoints, _resultDisps, null, null);
+            if (ocean.CollisionProvider.RetrieveSucceeded(result))
             {
                 _hasWaterData = true;
 
-                _height = OceanRenderer.Instance.SeaLevel + _resultDisps[0].y;
+                _height = ocean.SeaLevel + _resultDisps[0].y;
             }
 
             if (Time.deltaTime > 0.00001f)

--- a/crest/Assets/Crest/Crest/Scripts/Interaction/SimpleFloatingObject.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Interaction/SimpleFloatingObject.cs
@@ -52,7 +52,7 @@ namespace Crest
         {
             _rb = GetComponent<Rigidbody>();
 
-            if (OceanRenderer.Instance == null)
+            if (OceanRenderer.AnyInstance == null)
             {
                 enabled = false;
                 return;
@@ -63,7 +63,8 @@ namespace Crest
         {
             UnityEngine.Profiling.Profiler.BeginSample("SimpleFloatingObject.FixedUpdate");
 
-            if (OceanRenderer.Instance == null)
+            var ocean = OceanRenderer.ClosestInstance(transform.position);
+            if (ocean == null)
             {
                 UnityEngine.Profiling.Profiler.EndSample();
                 return;
@@ -87,7 +88,7 @@ namespace Crest
 
             var velocityRelativeToWater = _rb.velocity - waterSurfaceVel;
 
-            float height = disp.y + OceanRenderer.Instance.SeaLevel;
+            float height = disp.y + ocean.SeaLevel;
 
             float bottomDepth = height - transform.position.y + _raiseObject;
 

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrClipSurface.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrClipSurface.cs
@@ -30,7 +30,7 @@ namespace Crest
             base.Start();
 
 #if UNITY_EDITOR
-            if (!OceanRenderer.Instance.OceanMaterial.IsKeywordEnabled("_CLIPSURFACE_ON"))
+            if (!_ocean.OceanMaterial.IsKeywordEnabled("_CLIPSURFACE_ON"))
             {
                 Debug.LogWarning("Clip Surface is not enabled on the current ocean material, so the surface clipping will not work. Please enable it on the material.", _ocean);
             }
@@ -48,10 +48,10 @@ namespace Crest
                 return;
             }
 
-            for (int lodIdx = OceanRenderer.Instance.CurrentLodCount - 1; lodIdx >= 0; lodIdx--)
+            for (int lodIdx = _ocean.CurrentLodCount - 1; lodIdx >= 0; lodIdx--)
             {
                 buf.SetRenderTarget(_targets, 0, CubemapFace.Unknown, lodIdx);
-                var defaultToClip = OceanRenderer.Instance._defaultClippingState == OceanRenderer.DefaultClippingState.EverythingClipped;
+                var defaultToClip = _ocean._defaultClippingState == OceanRenderer.DefaultClippingState.EverythingClipped;
                 buf.ClearRenderTarget(false, true, defaultToClip ? Color.white : Color.black);
                 buf.SetGlobalInt(sp_LD_SliceIndex, lodIdx);
                 SubmitDraws(lodIdx, buf);

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrFlow.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrFlow.cs
@@ -49,7 +49,7 @@ namespace Crest
             base.Start();
 
 #if UNITY_EDITOR
-            if (!OceanRenderer.Instance.OceanMaterial.IsKeywordEnabled("_FLOW_ON"))
+            if (!_ocean.OceanMaterial.IsKeywordEnabled("_FLOW_ON"))
             {
                 Debug.LogWarning("Flow is not enabled on the current ocean material and will not be visible.", _ocean);
             }
@@ -81,7 +81,7 @@ namespace Crest
                 return;
             }
 
-            for (int lodIdx = OceanRenderer.Instance.CurrentLodCount - 1; lodIdx >= 0; lodIdx--)
+            for (int lodIdx = _ocean.CurrentLodCount - 1; lodIdx >= 0; lodIdx--)
             {
                 buf.SetRenderTarget(_targets, 0, CubemapFace.Unknown, lodIdx);
                 buf.ClearRenderTarget(false, true, Color.black);

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrFoam.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrFoam.cs
@@ -50,8 +50,8 @@ namespace Crest
             base.Start();
 
 #if UNITY_EDITOR
-            if (OceanRenderer.Instance != null && OceanRenderer.Instance.OceanMaterial != null
-                && !OceanRenderer.Instance.OceanMaterial.IsKeywordEnabled("_FOAM_ON"))
+            if (_ocean != null && _ocean.OceanMaterial != null
+                && !_ocean.OceanMaterial.IsKeywordEnabled("_FOAM_ON"))
             {
                 Debug.LogWarning("Foam is not enabled on the current ocean material and will not be visible.", _ocean);
             }
@@ -69,12 +69,12 @@ namespace Crest
             simMaterial.SetFloat(sp_ShorelineFoamStrength, Settings._shorelineFoamStrength);
 
             // assign animated waves - to slot 1 current frame data
-            OceanRenderer.Instance._lodDataAnimWaves.BindResultData(simMaterial);
+            _ocean._lodDataAnimWaves.BindResultData(simMaterial);
 
             // assign sea floor depth - to slot 1 current frame data
-            if (OceanRenderer.Instance._lodDataSeaDepths != null)
+            if (_ocean._lodDataSeaDepths != null)
             {
-                OceanRenderer.Instance._lodDataSeaDepths.BindResultData(simMaterial);
+                _ocean._lodDataSeaDepths.BindResultData(simMaterial);
             }
             else
             {
@@ -82,9 +82,9 @@ namespace Crest
             }
 
             // assign flow - to slot 1 current frame data
-            if (OceanRenderer.Instance._lodDataFlow != null)
+            if (_ocean._lodDataFlow != null)
             {
-                OceanRenderer.Instance._lodDataFlow.BindResultData(simMaterial);
+                _ocean._lodDataFlow.BindResultData(simMaterial);
             }
             else
             {

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrPersistent.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrPersistent.cs
@@ -56,9 +56,9 @@ namespace Crest
         {
             base.InitData();
 
-            int resolution = OceanRenderer.Instance.LodDataResolution;
+            int resolution = _ocean.LodDataResolution;
             var desc = new RenderTextureDescriptor(resolution, resolution, TextureFormat, 0);
-            _sources = CreateLodDataTextures(desc, SimName + "_1", NeedToReadWriteTextureData);
+            _sources = CreateLodDataTextures(_ocean, desc, SimName + "_1", NeedToReadWriteTextureData);
 
             TextureArrayHelpers.ClearToBlack(_targets);
             TextureArrayHelpers.ClearToBlack(_sources);
@@ -67,8 +67,8 @@ namespace Crest
         public void ValidateSourceData(bool usePrevTransform)
         {
             var renderDataToValidate = usePrevTransform ?
-                OceanRenderer.Instance._lodTransform._renderDataSource
-                : OceanRenderer.Instance._lodTransform._renderData;
+                _ocean._lodTransform._renderDataSource
+                : _ocean._lodTransform._renderData;
             int validationFrame = usePrevTransform ? BuildCommandBufferBase._lastUpdateFrame - OceanRenderer.FrameCount : 0;
             foreach (var renderData in renderDataToValidate)
             {
@@ -79,8 +79,8 @@ namespace Crest
         public void BindSourceData(IPropertyWrapper properties, bool paramsOnly, bool usePrevTransform, bool sourceLod = false)
         {
             var renderData = usePrevTransform ?
-                OceanRenderer.Instance._lodTransform._renderDataSource
-                : OceanRenderer.Instance._lodTransform._renderData;
+                _ocean._lodTransform._renderDataSource
+                : _ocean._lodTransform._renderData;
 
             BindData(properties, paramsOnly ? TextureArrayHelpers.BlackTextureArray : (Texture)_sources, true, ref renderData, sourceLod);
         }
@@ -127,9 +127,9 @@ namespace Crest
                 );
 
                 // Bind current data
-                BindData(_renderSimProperties, null, false, ref OceanRenderer.Instance._lodTransform._renderData, false);
+                BindData(_renderSimProperties, null, false, ref _ocean._lodTransform._renderData, false);
 
-                _renderSimProperties.DispatchShaderMultiLOD();
+                _renderSimProperties.DispatchShaderMultiLOD(_ocean);
 
                 for (var lodIdx = lodCount - 1; lodIdx >= 0; lodIdx--)
                 {

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
@@ -40,7 +40,7 @@ namespace Crest
                 return;
             }
 
-            for (int lodIdx = OceanRenderer.Instance.CurrentLodCount - 1; lodIdx >= 0; lodIdx--)
+            for (int lodIdx = _ocean.CurrentLodCount - 1; lodIdx >= 0; lodIdx--)
             {
                 buf.SetRenderTarget(_targets, 0, CubemapFace.Unknown, lodIdx);
                 buf.ClearRenderTarget(false, true, s_nullColor);

--- a/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
@@ -88,7 +88,7 @@ namespace Crest
 #if UNITY_EDITOR
             if (EditorApplication.isPlaying && _runValidationOnStart)
             {
-                Validate(OceanRenderer.Instance, ValidatedHelper.DebugLog);
+                Validate(OceanRenderer.AnyInstance, ValidatedHelper.DebugLog);
             }
 #endif
 
@@ -217,11 +217,13 @@ namespace Crest
             if (EditorApplication.isPlaying)
 #endif
             {
+                var ocean = OceanRenderer.ClosestInstance(transform.position);
+
                 // Shader needs sea level to determine water depth
                 var centerPoint = Vector3.zero;
-                if (OceanRenderer.Instance != null)
+                if (ocean != null)
                 {
-                    centerPoint.y = OceanRenderer.Instance.Root.position.y;
+                    centerPoint.y = ocean.Root.position.y;
                 }
                 else
                 {

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterAnimWavesInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterAnimWavesInput.cs
@@ -16,13 +16,7 @@ namespace Crest
 
         [SerializeField, Tooltip("Which octave to render into, for example set this to 2 to use render into the 2m-4m octave. These refer to the same octaves as the wave spectrum editor. Set this value to 0 to render into all LODs.")]
         float _octaveWavelength = 0f;
-        public override float Wavelength
-        {
-            get
-            {
-                return _octaveWavelength;
-            }
-        }
+        public override float Wavelength(OceanRenderer ocean) => _octaveWavelength;
 
         public readonly static Color s_gizmoColor = new Color(0f, 1f, 0f, 0.5f);
         protected override Color GizmoColor => s_gizmoColor;
@@ -41,27 +35,28 @@ namespace Crest
         {
             base.Update();
 
-            if (OceanRenderer.Instance == null)
+            for (int i = 0; i < OceanRenderer.InstanceCount; i++)
             {
-                return;
-            }
+                var ocean = OceanRenderer.GetInstance(i);
+                if (ocean == null) continue;
 
-            var maxDispVert = 0f;
+                var maxDispVert = 0f;
 
-            // let ocean system know how far from the sea level this shape may displace the surface
-            if (_reportRendererBoundsToOceanSystem)
-            {
-                var minY = _renderer.bounds.min.y;
-                var maxY = _renderer.bounds.max.y;
-                var seaLevel = OceanRenderer.Instance.SeaLevel;
-                maxDispVert = Mathf.Max(Mathf.Abs(seaLevel - minY), Mathf.Abs(seaLevel - maxY));
-            }
+                // let ocean system know how far from the sea level this shape may displace the surface
+                if (_reportRendererBoundsToOceanSystem)
+                {
+                    var minY = _renderer.bounds.min.y;
+                    var maxY = _renderer.bounds.max.y;
+                    var seaLevel = ocean.SeaLevel;
+                    maxDispVert = Mathf.Max(Mathf.Abs(seaLevel - minY), Mathf.Abs(seaLevel - maxY));
+                }
 
-            maxDispVert = Mathf.Max(maxDispVert, _maxDisplacementVertical);
+                maxDispVert = Mathf.Max(maxDispVert, _maxDisplacementVertical);
 
-            if (_maxDisplacementHorizontal > 0f || _maxDisplacementVertical > 0f)
-            {
-                OceanRenderer.Instance.ReportMaxDisplacementFromShape(_maxDisplacementHorizontal, maxDispVert, 0f);
+                if (_maxDisplacementHorizontal > 0f || _maxDisplacementVertical > 0f)
+                {
+                    ocean.ReportMaxDisplacementFromShape(_maxDisplacementHorizontal, maxDispVert, 0f);
+                }
             }
         }
     }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterDynWavesInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterDynWavesInput.cs
@@ -12,7 +12,7 @@ namespace Crest
     [ExecuteAlways]
     public class RegisterDynWavesInput : RegisterLodDataInput<LodDataMgrDynWaves>
     {
-        public override float Wavelength => 0f;
+        public override float Wavelength(OceanRenderer ocean) => 0f;
 
         public override bool Enabled => true;
 

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterFlowInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterFlowInput.cs
@@ -14,7 +14,7 @@ namespace Crest
     {
         public override bool Enabled => true;
 
-        public override float Wavelength => 0f;
+        public override float Wavelength(OceanRenderer ocean) => 0f;
 
         protected override Color GizmoColor => new Color(0f, 0f, 1f, 0.5f);
 

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterFoamInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterFoamInput.cs
@@ -14,7 +14,7 @@ namespace Crest
     {
         public override bool Enabled => true;
 
-        public override float Wavelength => 0f;
+        public override float Wavelength(OceanRenderer ocean) => 0f;
 
         protected override Color GizmoColor => new Color(1f, 1f, 1f, 0.5f);
 

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
@@ -31,8 +31,8 @@ namespace Crest
 
     public interface ILodDataInput
     {
-        void Draw(CommandBuffer buf, float weight, int isTransition, int lodIdx);
-        float Wavelength { get; }
+        void Draw(OceanRenderer ocean, CommandBuffer buf, float weight, int isTransition, int lodIdx);
+        float Wavelength(OceanRenderer ocean);
         bool Enabled { get; }
     }
 
@@ -47,7 +47,7 @@ namespace Crest
         bool _checkShaderName = true;
 #endif
 
-        public abstract float Wavelength { get; }
+        public abstract float Wavelength(OceanRenderer ocean);
 
         public abstract bool Enabled { get; }
 
@@ -110,7 +110,7 @@ namespace Crest
 #endif
         }
 
-        public void Draw(CommandBuffer buf, float weight, int isTransition, int lodIdx)
+        public void Draw(OceanRenderer ocean, CommandBuffer buf, float weight, int isTransition, int lodIdx)
         {
             if (_renderer && _material && weight > 0f)
             {

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterSeaFloorDepthInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterSeaFloorDepthInput.cs
@@ -17,7 +17,7 @@ namespace Crest
 
         public bool _assignOceanDepthMaterial = true;
 
-        public override float Wavelength => 0f;
+        public override float Wavelength(OceanRenderer ocean) => 0f;
 
         protected override Color GizmoColor => new Color(1f, 0f, 0f, 0.5f);
 

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsAnimatedWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsAnimatedWaves.cs
@@ -32,7 +32,7 @@ namespace Crest
         /// <summary>
         /// Provides ocean shape to CPU.
         /// </summary>
-        public ICollProvider CreateCollisionProvider()
+        public ICollProvider CreateCollisionProvider(OceanRenderer ocean)
         {
             ICollProvider result = null;
 
@@ -45,7 +45,7 @@ namespace Crest
                     result = FindObjectOfType<ShapeGerstnerBatched>();
                     break;
                 case CollisionSources.ComputeShaderQueries:
-                    result = new QueryDisplacements();
+                    result = new QueryDisplacements(ocean);
                     break;
             }
 
@@ -66,7 +66,7 @@ namespace Crest
             // Flow is GPU only, and can only be queried using the compute path
             if (ocean._lodDataFlow != null)
             {
-                return new QueryFlow();
+                return new QueryFlow(ocean);
             }
 
             return new FlowProviderNull();

--- a/crest/Assets/Crest/Crest/Scripts/OceanBuilder.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanBuilder.cs
@@ -451,6 +451,7 @@ namespace Crest
 
                 {
                     var oceanChunkRenderer = patch.AddComponent<OceanChunkRenderer>();
+                    oceanChunkRenderer._ocean = ocean;
                     oceanChunkRenderer._boundsLocal = meshBounds[(int)patchTypes[i]];
                     patch.AddComponent<MeshFilter>().sharedMesh = meshData[(int)patchTypes[i]];
                     oceanChunkRenderer.SetInstanceData(lodIndex, lodCount, lodDataResolution, geoDownSampleFactor);

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -1099,16 +1099,6 @@ namespace Crest
                 isValid = false;
             }
 
-            // OceanRenderer
-            if (FindObjectsOfType<OceanRenderer>().Length > 1)
-            {
-                showMessage
-                (
-                    "Multiple OceanRenderer scripts detected in open scenes, this is not typical - usually only one OceanRenderer is expected to be present.",
-                    ValidatedHelper.MessageType.Warning, ocean
-                );
-            }
-
             // ShapeGerstnerBatched
             var gerstners = FindObjectsOfType<ShapeGerstnerBatched>();
             if (gerstners.Length == 0)

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -288,6 +288,21 @@ namespace Crest
             return result;
         }
 
+        public static OceanRenderer GetInstance(Camera camera)
+        {
+            if (_instances.Count == 0) return null;
+
+            for (int i = 0; i < _instances.Count; i++)
+            {
+                if (_instances[i].Viewpoint == camera.transform)
+                {
+                    return _instances[i];
+                }
+            }
+
+            return null;
+        }
+
         static List<OceanRenderer> _instances = new List<OceanRenderer>();
 
         // We are computing these values to be optimal based on the base mesh vertex density.

--- a/crest/Assets/Crest/Crest/Scripts/Reflection/OceanPlanarReflection.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Reflection/OceanPlanarReflection.cs
@@ -119,7 +119,7 @@ namespace Crest
 
         private void Start()
         {
-            if (OceanRenderer.Instance == null)
+            if (OceanRenderer.AnyInstance == null)
             {
                 enabled = false;
                 return;
@@ -139,7 +139,7 @@ namespace Crest
             CreateWaterObjects(_camViewpoint);
 
 #if UNITY_EDITOR
-            if (!OceanRenderer.Instance.OceanMaterial.IsKeywordEnabled("_PLANARREFLECTIONS_ON"))
+            if (!OceanRenderer.AnyInstance.OceanMaterial.IsKeywordEnabled("_PLANARREFLECTIONS_ON"))
             {
                 Debug.LogWarning("Planar reflections are not enabled on the current ocean material and will not be visible.", this);
             }
@@ -163,7 +163,7 @@ namespace Crest
             if (!RequestRefresh(Time.renderedFrameCount))
                 return; // Skip if not need to refresh on this frame
 
-            if (OceanRenderer.Instance == null)
+            if (OceanRenderer.AnyInstance == null)
             {
                 return;
             }
@@ -176,7 +176,7 @@ namespace Crest
             }
 
             // Find out the reflection plane: position and normal in world space
-            Vector3 planePos = OceanRenderer.Instance.Root.position;
+            Vector3 planePos = OceanRenderer.AnyInstance.Root.position;
             Vector3 planeNormal = Vector3.up;
 
             // Optionally disable pixel lights for reflection/refraction

--- a/crest/Assets/Crest/Crest/Scripts/WaterBody.cs
+++ b/crest/Assets/Crest/Crest/Scripts/WaterBody.cs
@@ -56,7 +56,7 @@ namespace Crest
         {
             if (EditorApplication.isPlaying && _runValidationOnStart)
             {
-                Validate(OceanRenderer.Instance, ValidatedHelper.DebugLog);
+                Validate(OceanRenderer.AnyInstance, ValidatedHelper.DebugLog);
             }
         }
 
@@ -68,9 +68,9 @@ namespace Crest
             var oldColor = Gizmos.color;
             Gizmos.color = new Color(1f, 1f, 1f, 0.5f);
             var center = AABB.center;
-            if (OceanRenderer.Instance != null && OceanRenderer.Instance.Root != null)
+            if (OceanRenderer.AnyInstance != null && OceanRenderer.AnyInstance.Root != null)
             {
-                center.y = OceanRenderer.Instance.Root.position.y;
+                center.y = OceanRenderer.AnyInstance.Root.position.y;
             }
             Gizmos.DrawCube(center, 2f * new Vector3(AABB.extents.x, 1f, AABB.extents.z));
             Gizmos.color = oldColor;


### PR DESCRIPTION
**Status:** Definitely not ready to merge. I'm creating this as someone enquired about it and it took me a while to find it.

Experiment with what would be required for multiple oceans: #540 

This branch should work like before in the case of a single ocean. There are a few issues before it will support multiple instances.

Questions / problems that arose:

- [ ] RegisterLodDataClipSurface - this sets per-ocean data on MPB. might be tricky to fix..
- [x] How to connect underwater effect to ocean instance?
- [ ] How to connect underwater environment lighting with ocean instance?
- [ ] OceanChunkRenderer.OnWillRenderObject - tiles will need Layer so it only goes in one camera??


Misc notes:

- [ ] Validation gets passed "AnyInstance" in a few places, is this ok?
- [ ] RenderData.Validate - uses any instance
- [ ] Debuggui always takes first instance of ocean, shall we make this selectable?
- [ ] Lod data resolution should be global setting, right now taken from one instance
