### PR TITLE
Add foam override to remove foam

### DIFF
--- a/USERGUIDE.md
+++ b/USERGUIDE.md
@@ -150,6 +150,8 @@ To turn on this feature, enable the *Create Foam Sim* option on the *OceanRender
 
 Crest supports inputing any foam into the system. To add some shape, add some geometry into the world which when rendered from a top down perspective will generate the desired foam values. Then assign the *RegisterFoamInput* script which will tag it for rendering into the shape, and apply a material with a shader of type *Crest/Inputs/Foam/...*. The process for adding inputs is demonstrated in this tutorial video: https://www.youtube.com/watch?v=sQIakAjSq4Y.
 
+Foam can be masked by using the *FoamOverride* material.
+
 The foam sim can be configured by assigning a Foam Sim Settings asset to the OceanRenderer script in your scene (*Create/Crest/Foam Sim Settings*). There are also parameters on the material which control the appearance of the foam.
 
 ## Sea Floor Depth

--- a/crest/Assets/Crest/Crest/Materials/OceanInputs/FoamOverride.mat
+++ b/crest/Assets/Crest/Crest/Materials/OceanInputs/FoamOverride.mat
@@ -1,0 +1,78 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: FoamOverride
+  m_Shader: {fileID: 4800000, guid: b6a746f025d0b4281a602898f9333230, type: 3}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _FoamValue: 1
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}

--- a/crest/Assets/Crest/Crest/Materials/OceanInputs/FoamOverride.mat.meta
+++ b/crest/Assets/Crest/Crest/Materials/OceanInputs/FoamOverride.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 68d36d57521f647dfbf893bb13362da3
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/FoamOverride.shader
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/FoamOverride.shader
@@ -1,0 +1,57 @@
+﻿// Crest Ocean System
+
+// This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
+
+// Renders the geometry to the foam texture and sets foam data to provided value.
+
+Shader "Crest/Inputs/Foam/Override Foam"
+{
+	Properties
+	{
+		_FoamValue("Foam Value", Range(0.0, 1.0)) = 1.0
+	}
+
+	SubShader
+	{
+		// Base simulation runs on the Geometry queue, before this shader.
+		Tags { "Queue" = "Transparent" }
+
+		Pass
+		{
+			Blend Off
+			ZWrite Off
+			ColorMask R
+
+			CGPROGRAM
+			#pragma vertex Vert
+			#pragma fragment Frag
+
+			#include "UnityCG.cginc"
+
+			half _FoamValue;
+
+			struct Attributes
+			{
+				float3 positionOS : POSITION;
+			};
+
+			struct Varyings
+			{
+				float4 positionCS : SV_POSITION;
+			};
+
+			Varyings Vert(Attributes input)
+			{
+				Varyings o;
+				o.positionCS = UnityObjectToClipPos(input.positionOS);
+				return o;
+			}
+
+			half4 Frag(Varyings input) : SV_Target
+			{
+				return _FoamValue;
+			}
+			ENDCG
+		}
+	}
+}

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/FoamOverride.shader.meta
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/FoamOverride.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: b6a746f025d0b4281a602898f9333230
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Solves #670 

The same shader as the shadow override but for foam. When used, the input _sets_ the value of the foam data. Can be used to add or remove foam.