### PR TITLE
Option to accelerate some boat types 'downhill'

### DIFF
--- a/crest/Assets/Crest/Crest-Examples/BoatDev/Scripts/BoatAlignNormal.cs
+++ b/crest/Assets/Crest/Crest-Examples/BoatDev/Scripts/BoatAlignNormal.cs
@@ -125,7 +125,7 @@ public class BoatAlignNormal : FloatingObjectBase
         // Approximate hydrodynamics of sliding along water
         if (_accelerateDownhill > 0f)
         {
-            _rb.AddForce(new Vector3(normal.x, 0f, normal.z) * -Physics.gravity.y, ForceMode.Acceleration);
+            _rb.AddForce(new Vector3(normal.x, 0f, normal.z) * -Physics.gravity.y * _accelerateDownhill, ForceMode.Acceleration);
         }
 
         // apply drag relative to water

--- a/crest/Assets/Crest/Crest-Examples/BoatDev/Scripts/BoatAlignNormal.cs
+++ b/crest/Assets/Crest/Crest-Examples/BoatDev/Scripts/BoatAlignNormal.cs
@@ -17,6 +17,8 @@ public class BoatAlignNormal : FloatingObjectBase
     float _buoyancyCoeff = 1.5f;
     [Tooltip("Strength of torque applied to match boat orientation to water normal."), SerializeField]
     float _boyancyTorque = 8f;
+    [Tooltip("Approximate hydrodynamics of 'surfing' down waves."), SerializeField, Range(0, 1)]
+    float _accelerateDownhill = 0f;
 
     [Header("Engine Power")]
     [Tooltip("Vertical offset for where engine force should be applied."), SerializeField]
@@ -120,6 +122,11 @@ public class BoatAlignNormal : FloatingObjectBase
         var buoyancy = -Physics.gravity.normalized * _buoyancyCoeff * bottomDepth * bottomDepth * bottomDepth;
         _rb.AddForce(buoyancy, ForceMode.Acceleration);
 
+        // Approximate hydrodynamics of sliding along water
+        if (_accelerateDownhill > 0f)
+        {
+            _rb.AddForce(new Vector3(normal.x, 0f, normal.z) * -Physics.gravity.y, ForceMode.Acceleration);
+        }
 
         // apply drag relative to water
         var forcePosition = _rb.position + _forceHeightOffset * Vector3.up;

--- a/crest/Assets/Crest/Crest-Examples/Whirlpool/Scenes/Internal/WhirlpoolSceneCore.prefab
+++ b/crest/Assets/Crest/Crest-Examples/Whirlpool/Scenes/Internal/WhirlpoolSceneCore.prefab
@@ -446,6 +446,11 @@ PrefabInstance:
       propertyPath: _debugValidateCollision
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 114101010989703450, guid: 71ede3c2ab0b7cb43b7dad6ae3b6190b,
+        type: 3}
+      propertyPath: _accelerateDownhill
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 114123981558006810, guid: 71ede3c2ab0b7cb43b7dad6ae3b6190b,
         type: 3}
       propertyPath: _weight

--- a/crest/Assets/Crest/Crest/Scripts/Interaction/SimpleFloatingObject.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Interaction/SimpleFloatingObject.cs
@@ -106,7 +106,7 @@ namespace Crest
             // Approximate hydrodynamics of sliding along water
             if (_accelerateDownhill > 0f)
             {
-                _rb.AddForce(new Vector3(normal.x, 0f, normal.z) * -Physics.gravity.y, ForceMode.Acceleration);
+                _rb.AddForce(new Vector3(normal.x, 0f, normal.z) * -Physics.gravity.y * _accelerateDownhill, ForceMode.Acceleration);
             }
 
             // Apply drag relative to water

--- a/crest/Assets/Crest/Crest/Scripts/Interaction/SimpleFloatingObject.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Interaction/SimpleFloatingObject.cs
@@ -21,6 +21,8 @@ namespace Crest
         float _buoyancyCoeff = 3f;
         [Tooltip("Strength of torque applied to match boat orientation to water normal."), SerializeField]
         float _boyancyTorque = 8f;
+        [Tooltip("Approximate hydrodynamics of 'surfing' down waves."), SerializeField, Range(0, 1)]
+        float _accelerateDownhill = 0f;
 
         [Header("Wave Response")]
         [Tooltip("Diameter of object, for physics purposes. The larger this value, the more filtered/smooth the wave response will be."), SerializeField]
@@ -101,8 +103,13 @@ namespace Crest
             var buoyancy = -Physics.gravity.normalized * _buoyancyCoeff * bottomDepth * bottomDepth * bottomDepth;
             _rb.AddForce(buoyancy, ForceMode.Acceleration);
 
+            // Approximate hydrodynamics of sliding along water
+            if (_accelerateDownhill > 0f)
+            {
+                _rb.AddForce(new Vector3(normal.x, 0f, normal.z) * -Physics.gravity.y, ForceMode.Acceleration);
+            }
 
-            // apply drag relative to water
+            // Apply drag relative to water
             var forcePosition = _rb.position + _forceHeightOffset * Vector3.up;
             _rb.AddForceAtPosition(Vector3.up * Vector3.Dot(Vector3.up, -velocityRelativeToWater) * _dragInWaterUp, forcePosition, ForceMode.Acceleration);
             _rb.AddForceAtPosition(transform.right * Vector3.Dot(transform.right, -velocityRelativeToWater) * _dragInWaterRight, forcePosition, ForceMode.Acceleration);


### PR DESCRIPTION
Approximates hydro dynamics of surfing down a wave. Not physical but helps to compensate for surface motion/flow being unphysical, like in whirlpool scene.

BoatProbes does not have an all-up water normal currently and i didnt end up adding something for it.

I turned this on for the whirlpool scene.