### PR TITLE
Use ViewCamera in underwater post-processing

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterPostProcess.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterPostProcess.cs
@@ -41,7 +41,6 @@ namespace Crest
         private RenderTexture _depthBuffer;
         private CommandBuffer _maskCommandBuffer;
         private CommandBuffer _postProcessCommandBuffer;
-        private readonly SampleHeightHelper _sampleHeightHelper = new SampleHeightHelper();
 
         private Plane[] _cameraFrustumPlanes;
 
@@ -223,7 +222,6 @@ namespace Crest
                 _mainCamera,
                 _underwaterPostProcessMaterialWrapper,
                 _sphericalHarmonicsData,
-                _sampleHeightHelper,
                 _firstRender || _copyOceanMaterialParamsEachFrame,
                 _viewPostProcessMask,
                 _horizonSafetyMarginMultiplier,

--- a/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterPostProcessUtils.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterPostProcessUtils.cs
@@ -121,7 +121,6 @@ namespace Crest
             Camera camera,
             PropertyWrapperMaterial underwaterPostProcessMaterialWrapper,
             UnderwaterSphericalHarmonicsData sphericalHarmonicsData,
-            SampleHeightHelper sampleHeightHelper,
             bool copyParamsFromOceanMaterial,
             bool debugViewPostProcessMask,
             float horizonSafetyMarginMultiplier,
@@ -159,17 +158,7 @@ namespace Crest
                 // relative to the sea-level are the same. This ensures that in incredibly turbulent
                 // water - if in doubt - use the neutral horizon.
                 float seaLevelHeightDifference = camera.transform.position.y - seaLevel;
-                float waterHeightLevelDifference = seaLevelHeightDifference;
-                {
-                    // Viewpoint and camera transform could be different so we will sample again instead of using
-                    // ViewerHeightAboveWater. Allow multiple samples per frame for multi-pass XR.
-                    sampleHeightHelper.Init(camera.transform.position, 0f, allowMultipleCallsPerFrame: true);
-                    if (sampleHeightHelper.Sample(out var waterHeight))
-                    {
-                        waterHeightLevelDifference = camera.transform.position.y - waterHeight;
-                    }
-                }
-                if (seaLevelHeightDifference >= 0.0f ^ waterHeightLevelDifference >= 0.0f)
+                if (seaLevelHeightDifference >= 0.0f ^ OceanRenderer.Instance.ViewerHeightAboveWater >= 0.0f)
                 {
                     horizonSafetyMarginMultiplier = 0.0f;
                 }
@@ -270,7 +259,7 @@ namespace Crest
 
                 UnityEngine.Profiling.Profiler.BeginSample("Underwater sample spherical harmonics");
 
-                LightProbes.GetInterpolatedProbe(OceanRenderer.Instance.Viewpoint.position, null, out SphericalHarmonicsL2 sphericalHarmonicsL2);
+                LightProbes.GetInterpolatedProbe(OceanRenderer.Instance.ViewCamera.transform.position, null, out SphericalHarmonicsL2 sphericalHarmonicsL2);
                 sphericalHarmonicsL2.Evaluate(sphericalHarmonicsData._shDirections, sphericalHarmonicsData._ambientLighting);
                 underwaterPostProcessMaterial.SetVector(sp_AmbientLighting, sphericalHarmonicsData._ambientLighting[0]);
 


### PR DESCRIPTION
Use the _ViewCamera_ and _ViewerHeightAboveWater_ properties on the _OceanRenderer_ for underwater effects instead of using the post-processing camera. _ViewCamera_ and the post-processing camera will be the same. Reduces code complexity and saves a height query. This will be merged into HDRP if okay to merge here.