### PR TITLE
Add underwater sun occlusion

### DIFF
--- a/crest/Assets/Crest/Crest/Shaders/Ocean.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Ocean.shader
@@ -163,6 +163,14 @@ Shader "Crest/Ocean"
 		// underwater effect is being used.
 		[Enum(CullMode)] _CullMode("Cull Mode", Int) = 2
 
+		[Header(Underwater Sun Occlusion)]
+		// Whether to occlude light scattering for the volume.
+		[Toggle] _UnderwaterSunOcclusion("Enable", Float) = 1
+		// Strength of the occlusion through the underwater fog.
+		_UnderwaterSunOcclusionDistance("Sun Occlusion Distance Strength", Range(0.0, 1000.0)) = 100.0
+		// Fall-off to affect directionality.
+		_UnderwaterSunOcclusionFallOff("Sun Occlusion Fall-Off", Range(0, 1.0)) = 0.5
+
 		[Header(Flow)]
 		// Flow is horizontal motion in water as demonstrated in the 'whirlpool' example scene. 'Create Flow Sim' must be
 		// enabled on the OceanRenderer to generate flow data.
@@ -231,6 +239,7 @@ Shader "Crest/Ocean"
 
 			#pragma shader_feature_local _PROCEDURALSKY_ON
 			#pragma shader_feature_local _UNDERWATER_ON
+			#pragma shader_feature_local _UNDERWATERSUNOCCLUSION_ON
 			#pragma shader_feature_local _FLOW_ON
 			#pragma shader_feature_local _SHADOWS_ON
 			#pragma shader_feature_local _CLIPSURFACE_ON
@@ -545,7 +554,7 @@ Shader "Crest/Ocean"
 				// Compute color of ocean - in-scattered light + refracted scene
 				const float baseCascadeScale = _CrestCascadeData[0]._scale;
 				const float meshScaleLerp = instanceData._meshScaleLerp;
-				half3 scatterCol = ScatterColour(input.lodAlpha_worldXZUndisplaced_oceanDepth.w, _WorldSpaceCameraPos, lightDir, view, shadow.x, underwater, true, sss, meshScaleLerp, baseCascadeScale, cascadeData0);
+				half3 scatterCol = ScatterColour(input.lodAlpha_worldXZUndisplaced_oceanDepth.w, _WorldSpaceCameraPos, lightDir, view, sceneZ, shadow.x, underwater, true, sss, meshScaleLerp, baseCascadeScale, cascadeData0);
 				half3 col = OceanEmission(view, n_pixel, lightDir, input.grabPos, pixelZ, uvDepth, sceneZ, sceneZ01, bubbleCol, _Normals, underwater, scatterCol, cascadeData0, cascadeData1);
 
 				// Light that reflects off water surface

--- a/crest/Assets/Crest/Crest/Shaders/Underwater/UnderwaterCurtain.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Underwater/UnderwaterCurtain.shader
@@ -46,6 +46,7 @@ Shader "Crest/Underwater Curtain"
 			#pragma multi_compile_local __ _TRANSPARENCY_ON
 			#pragma multi_compile_local __ _CAUSTICS_ON
 			#pragma multi_compile_local __ _SHADOWS_ON
+			#pragma multi_compile_local __ _UNDERWATERSUNOCCLUSION_ON
 			#pragma multi_compile_local __ _COMPILESHADERWITHDEBUGINFO_ON
 
 			#if _COMPILESHADERWITHDEBUGINFO_ON
@@ -210,7 +211,7 @@ Shader "Crest/Underwater Curtain"
 
 				const float meshScaleLerp = _CrestPerCascadeInstanceData[_LD_SliceIndex]._meshScaleLerp;
 				const float baseCascadeScale = _CrestCascadeData[0]._scale;
-				const half3 scatterCol = ScatterColour(depth, _WorldSpaceCameraPos, lightDir, view, shadow, true, true, sss, meshScaleLerp, baseCascadeScale, cascadeData0);
+				const half3 scatterCol = ScatterColour(depth, _WorldSpaceCameraPos, lightDir, view, sceneZ, shadow, true, true, sss, meshScaleLerp, baseCascadeScale, cascadeData0);
 
 				half3 sceneColour = UNITY_SAMPLE_SCREENSPACE_TEXTURE(_BackgroundTexture, input.grabPos.xy / input.grabPos.w).rgb;
 


### PR DESCRIPTION
Occludes the subsurface scattering. Someone asked about this on Discord. I did it a little while ago so I thought I would put it here rather than let it sit.

![Screenshot (2)](https://user-images.githubusercontent.com/5249806/100490022-f9f55a80-30cc-11eb-97ed-2aaabad5113d.png)
Before

![Screenshot (1)](https://user-images.githubusercontent.com/5249806/100490024-fbbf1e00-30cc-11eb-9b1b-2929e3c0a67b.png)
After

I don't think it looks correct for objects above water. Not sure whether to exclude them or if refraction needs to be applied.

It uses the depth buffer. The other option could be using the Unity shadow map to occlude. But I think that will be more work across pipelines.

Happy to hear your thoughts.

### Testing

Other than the keyword, it has two properties:

#### Sun Occlusion Distance Strength
Applied to the linear depth to make it more usable.

#### Sun Occlusion Fall-Off
The same as the SSS fall-off but for occlusion.
