### PR TITLE
Fix underwater normals not flipped with flow

### DIFF
--- a/crest/Assets/Crest/Crest/Shaders/Ocean.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Ocean.shader
@@ -520,16 +520,17 @@ Shader "Crest/Ocean"
 				}
 				n_geom = normalize(n_geom);
 
-				if (underwater) n_geom = -n_geom;
 				half3 n_pixel = n_geom;
 				#if _APPLYNORMALMAPPING_ON
 				#if _FLOW_ON
 				ApplyNormalMapsWithFlow(input.lodAlpha_worldXZUndisplaced_oceanDepth.yz, input.flow_shadow.xy, lodAlpha, cascadeData0, instanceData, n_pixel);
 				#else
-				n_pixel.xz += (underwater ? -1. : 1.) * SampleNormalMaps(input.lodAlpha_worldXZUndisplaced_oceanDepth.yz, lodAlpha, cascadeData0, instanceData);
+				n_pixel.xz += SampleNormalMaps(input.lodAlpha_worldXZUndisplaced_oceanDepth.yz, lodAlpha, cascadeData0, instanceData);
 				n_pixel = normalize(n_pixel);
 				#endif
 				#endif
+				// We do not flip n_geom because we do not use it.
+				if (underwater) n_pixel = -n_pixel;
 
 				// Foam - underwater bubbles and whitefoam
 				half3 bubbleCol = (half3)0.;


### PR DESCRIPTION
When rendering underwater, the ocean surface normals were not being flipped if flow was enabled.

This PR solves it by flipping normals only once after they have been computed. _n_geom_ is not flipped because we don't use it since it becomes _n_pixel_. Easier to just flip them once at the end. Happy to change it so that _n_geom_ is flipped.