### PR TITLE
Add new Gerstner system

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -673,6 +673,7 @@ namespace Crest
             sp_ForceUnderwater = Shader.PropertyToID("_ForceUnderwater");
             sp_perCascadeInstanceData = Shader.PropertyToID("_CrestPerCascadeInstanceData");
             sp_cascadeData = Shader.PropertyToID("_CrestCascadeData");
+            sp_crestTime = Shader.PropertyToID("_CrestTime");
         }
 
         void LateUpdate()

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -290,7 +290,7 @@ namespace Crest
 
         bool _canSkipCulling = false;
 
-        readonly int sp_crestTime = Shader.PropertyToID("_CrestTime");
+        public static int sp_crestTime = Shader.PropertyToID("_CrestTime");
         readonly int sp_texelsPerWave = Shader.PropertyToID("_TexelsPerWave");
         readonly int sp_oceanCenterPosWorld = Shader.PropertyToID("_OceanCenterPosWorld");
         readonly int sp_meshScaleLerp = Shader.PropertyToID("_MeshScaleLerp");
@@ -1147,8 +1147,9 @@ namespace Crest
             }
 
             // ShapeGerstnerBatched
-            var gerstners = FindObjectsOfType<ShapeGerstnerBatched>();
-            if (gerstners.Length == 0)
+            var gerstnerBatchs = FindObjectsOfType<ShapeGerstnerBatched>();
+            var gerstners = FindObjectsOfType<ShapeGerstner>();
+            if (gerstnerBatchs.Length == 0 && gerstners.Length == 0)
             {
                 showMessage
                 (

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstner.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstner.cs
@@ -301,7 +301,7 @@ namespace Crest
                     int vi = outputIdx / 4;
                     int ei = outputIdx - vi * 4;
 
-                    _waveData[vi]._twoPiOverWavelength[ei] = 2f * Mathf.PI / _wavelengths[componentIdx];
+                    _waveData[vi]._twoPiOverWavelength[ei] = _twoPi / _wavelengths[componentIdx];
                     _waveData[vi]._amp[ei] = _amplitudes[componentIdx];
 
                     float chopScale = _spectrum._chopScales[componentIdx / _componentsPerOctave];
@@ -311,8 +311,6 @@ namespace Crest
                     float dx = Mathf.Cos(angle);
                     float dz = Mathf.Sin(angle);
 
-                    // It used to be this, but I'm pushing all the stuff that doesn't depend on position into the phase.
-                    //half4 angle = k * (C * _CrestTime + x) + _Phases[vi];
                     float gravityScale = _spectrum._gravityScales[(componentIdx) / _componentsPerOctave];
                     float gravity = OceanRenderer.Instance.Gravity * _spectrum._gravityScale;
                     float C = Mathf.Sqrt(_wavelengths[componentIdx] * gravity * gravityScale * _recipTwoPi);
@@ -323,16 +321,21 @@ namespace Crest
                         float kx = k * dx;
                         float kz = k * dz;
                         var diameter = 0.5f * (1 << cascadeIdx);
-                        float n = kx / (2f * Mathf.PI / diameter);
-                        float m = kz / (2f * Mathf.PI / diameter);
-                        kx = 2f * Mathf.PI * Mathf.Round(n) / diameter;
-                        kz = 2f * Mathf.PI * Mathf.Round(m) / diameter;
 
+                        // Number of times wave repeats across domain in x and z
+                        float n = kx / (_twoPi / diameter);
+                        float m = kz / (_twoPi / diameter);
+                        // Ensure the wave repeats an integral number of times across domain
+                        kx = _twoPi * Mathf.Round(n) / diameter;
+                        kz = _twoPi * Mathf.Round(m) / diameter;
+
+                        // Compute new wave vector and direction
                         k = Mathf.Sqrt(kx * kx + kz * kz);
                         dx = kx / k;
                         dz = kz / k;
                     }
 
+                    _waveData[vi]._twoPiOverWavelength[ei] = k;
                     _waveData[vi]._waveDirX[ei] = dx;
                     _waveData[vi]._waveDirZ[ei] = dz;
 

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstner.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstner.cs
@@ -482,8 +482,6 @@ namespace Crest
         {
             var registered = RegisterLodDataInputBase.GetRegistrar(typeof(LodDataMgrAnimWaves));
 
-            //#if UNITY_EDITOR
-            // Unregister after switching modes in the editor.
             if (_batches != null)
             {
                 foreach (var batch in _batches)
@@ -491,7 +489,6 @@ namespace Crest
                     registered.Remove(batch);
                 }
             }
-            //#endif
 
             if (_meshForDrawingWaves == null)
             {

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstner.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstner.cs
@@ -301,7 +301,6 @@ namespace Crest
                     int vi = outputIdx / 4;
                     int ei = outputIdx - vi * 4;
 
-                    _waveData[vi]._twoPiOverWavelength[ei] = _twoPi / _wavelengths[componentIdx];
                     _waveData[vi]._amp[ei] = _amplitudes[componentIdx];
 
                     float chopScale = _spectrum._chopScales[componentIdx / _componentsPerOctave];

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstner.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstner.cs
@@ -19,6 +19,7 @@ namespace Crest
     [ExecuteAlways]
     public partial class ShapeGerstner : MonoBehaviour, IFloatingOrigin
     {
+        [Header("Wave Settings")]
         [Tooltip("The spectrum that defines the ocean surface shape. Assign asset of type Crest/Ocean Waves Spectrum.")]
         public OceanWaveSpectrum _spectrum;
 
@@ -29,21 +30,23 @@ namespace Crest
         public float _windDirectionAngle = 0f;
         public Vector2 WindDir => new Vector2(Mathf.Cos(Mathf.PI * _windDirectionAngle / 180f), Mathf.Sin(Mathf.PI * _windDirectionAngle / 180f));
 
+        [Tooltip("Multiplier for these waves to scale up/down."), Range(0f, 1f)]
+        public float _weight = 1f;
+
+        [Tooltip("How much these waves respect the shallow water attenuation setting in the Animated Waves Settings. Set to 0 to ignore shallow water."), SerializeField, Range(0f, 1f)]
+        float _respectShallowWaterAttenuation = 1f;
+
+        [Header("Generation Settings")]
         [Delayed, Tooltip("How many wave components to generate in each octave.")]
         public int _componentsPerOctave = 8;
 
-        [Range(0f, 1f)]
-        public float _weight = 1f;
-
-        [SerializeField, Range(0f, 1f)]
-        float _respectShallowWaterAttenuation = 1f;
-
+        [Tooltip("Change to get a different set of waves.")]
         public int _randomSeed = 0;
 
-        [Delayed]
+        [Tooltip("Resolution to use for wave generation buffers. Low resolutions are more efficient but can result in noticeable patterns in the shape."), Delayed]
         public int _resolution = 32;
 
-        [SerializeField]
+        [Tooltip("In Editor, shows the wave generation buffers on screen."), SerializeField]
         bool _debugDrawSlicesInEditor = false;
 
         Mesh _meshForDrawingWaves;

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstner.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstner.cs
@@ -1,0 +1,604 @@
+﻿// Crest Ocean System
+
+// This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
+
+using UnityEngine;
+using UnityEngine.Experimental.Rendering;
+using UnityEngine.Rendering;
+using Unity.Collections.LowLevel.Unsafe;
+
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
+
+namespace Crest
+{
+    /// <summary>
+    /// Gerstner ocean waves.
+    /// </summary>
+    [ExecuteAlways]
+    public partial class ShapeGerstner : MonoBehaviour, IFloatingOrigin
+    {
+        [Tooltip("The spectrum that defines the ocean surface shape. Assign asset of type Crest/Ocean Waves Spectrum.")]
+        public OceanWaveSpectrum _spectrum;
+
+        [Tooltip("If a spectrum will not change at runtime, set this true to calculate the wave data once on first update rather than each frame."), SerializeField]
+        bool _spectrumIsStatic = true;
+
+        [Tooltip("Wind direction (angle from x axis in degrees)"), Range(-180, 180)]
+        public float _windDirectionAngle = 0f;
+        public Vector2 WindDir => new Vector2(Mathf.Cos(Mathf.PI * _windDirectionAngle / 180f), Mathf.Sin(Mathf.PI * _windDirectionAngle / 180f));
+
+        [Delayed, Tooltip("How many wave components to generate in each octave.")]
+        public int _componentsPerOctave = 8;
+
+        [Range(0f, 1f)]
+        public float _weight = 1f;
+
+        public int _randomSeed = 0;
+
+        [Delayed]
+        public int _resolution = 32;
+
+        [SerializeField]
+        Renderer _meshForDrawingWaves;
+
+        [SerializeField]
+        bool _debugDrawSlicesInEditor = false;
+
+        public class GerstnerBatch : ILodDataInput
+        {
+            Material _material;
+            Renderer _rend;
+
+            RenderTexture _waveBuffer;
+            int _waveBufferSliceIndex;
+
+            public GerstnerBatch(float wavelength, RenderTexture waveBuffer, int waveBufferSliceIndex, Shader shaderGerstnerGlobal, Renderer renderer)
+            {
+                Wavelength = wavelength;
+                _waveBuffer = waveBuffer;
+                _waveBufferSliceIndex = waveBufferSliceIndex;
+                _rend = renderer;
+
+                if (_rend == null)
+                {
+                    _material = new Material(shaderGerstnerGlobal);
+                }
+                else
+                {
+                    _material = _rend.sharedMaterial;
+                }
+            }
+
+            // The ocean input system uses this to decide which lod this batch belongs in
+            public float Wavelength { get; private set; }
+
+            public bool Enabled { get => true; set { } }
+
+            public float Weight { get; set; }
+
+            public void Draw(CommandBuffer buf, float weight, int isTransition, int lodIdx)
+            {
+                if (weight > 0f)
+                {
+                    buf.SetGlobalInt(LodDataMgr.sp_LD_SliceIndex, lodIdx);
+                    buf.SetGlobalFloat(RegisterLodDataInputBase.sp_Weight, Weight * weight);
+                    buf.SetGlobalTexture(sp_WaveBuffer, _waveBuffer);
+                    buf.SetGlobalInt(sp_WaveBufferSliceIndex, _waveBufferSliceIndex);
+                    buf.SetGlobalFloat(sp_AverageWavelength, Wavelength * 1.5f);
+
+                    // Either use a full screen quad, or a provided mesh renderer to draw the waves
+                    if (_rend == null)
+                    {
+                        buf.DrawProcedural(Matrix4x4.identity, _material, 0, MeshTopology.Triangles, 3);
+                    }
+                    else
+                    {
+                        buf.DrawRenderer(_rend, _material);
+                    }
+                }
+            }
+        }
+
+        const int CASCADE_COUNT = 16;
+        const int MAX_WAVE_COMPONENTS = 1024;
+
+        GerstnerBatch[] _batches = null;
+
+        // Data for all components
+        float[] _wavelengths;
+        float[] _amplitudes;
+        float[] _angleDegs;
+        float[] _phases;
+
+        [HideInInspector]
+        public RenderTexture _waveBuffers;
+
+        struct GerstnerCascadeParams
+        {
+            public int _startIndex;
+        }
+        ComputeBuffer _bufCascadeParams;
+        GerstnerCascadeParams[] _cascadeParams = new GerstnerCascadeParams[CASCADE_COUNT + 1];
+
+        // First cascade of wave buffer that has waves and will be rendered
+        int _firstCascade = -1;
+        // Last cascade of wave buffer that has waves and will be rendered
+        int _lastCascade = -1;
+
+        // Used to populate data on first frame
+        bool _firstUpdate = true;
+
+        struct GerstnerWaveComponent4
+        {
+            public Vector4 _twoPiOverWavelength;
+            public Vector4 _amp;
+            public Vector4 _waveDirX;
+            public Vector4 _waveDirZ;
+            public Vector4 _omega;
+            public Vector4 _phase;
+            public Vector4 _chopAmp;
+        }
+        ComputeBuffer _bufWaveData;
+        GerstnerWaveComponent4[] _waveData = new GerstnerWaveComponent4[MAX_WAVE_COMPONENTS / 4];
+
+        ComputeShader _shaderGerstner;
+        int _krnlGerstner = -1;
+
+        readonly int sp_FirstCascadeIndex = Shader.PropertyToID("_FirstCascadeIndex");
+        readonly int sp_TextureRes = Shader.PropertyToID("_TextureRes");
+        readonly int sp_CascadeParams = Shader.PropertyToID("_GerstnerCascadeParams");
+        readonly int sp_GerstnerWaveData = Shader.PropertyToID("_GerstnerWaveData");
+        static readonly int sp_WaveBuffer = Shader.PropertyToID("_WaveBuffer");
+        static readonly int sp_WaveBufferSliceIndex = Shader.PropertyToID("_WaveBufferSliceIndex");
+        static readonly int sp_AverageWavelength = Shader.PropertyToID("_AverageWavelength");
+        readonly int sp_AxisX = Shader.PropertyToID("_AxisX");
+
+        readonly float _twoPi = 2f * Mathf.PI;
+        readonly float _recipTwoPi = 1f / (2f * Mathf.PI);
+
+        void InitData()
+        {
+            {
+                _waveBuffers = new RenderTexture(_resolution, _resolution, 0, GraphicsFormat.R16G16B16A16_SFloat);
+                _waveBuffers.wrapMode = TextureWrapMode.Clamp;
+                _waveBuffers.antiAliasing = 1;
+                _waveBuffers.filterMode = FilterMode.Bilinear;
+                _waveBuffers.anisoLevel = 0;
+                _waveBuffers.useMipMap = false;
+                _waveBuffers.name = "GerstnerCascades";
+                _waveBuffers.dimension = TextureDimension.Tex2DArray;
+                _waveBuffers.volumeDepth = CASCADE_COUNT;
+                _waveBuffers.enableRandomWrite = true;
+                _waveBuffers.Create();
+            }
+
+            _bufCascadeParams = new ComputeBuffer(CASCADE_COUNT + 1, UnsafeUtility.SizeOf<GerstnerCascadeParams>());
+            _bufWaveData = new ComputeBuffer(MAX_WAVE_COMPONENTS / 4, UnsafeUtility.SizeOf<GerstnerWaveComponent4>());
+
+            _shaderGerstner = ComputeShaderHelpers.LoadShader("Gerstner");
+            _krnlGerstner = _shaderGerstner.FindKernel("Gerstner");
+        }
+
+        /// <summary>
+        /// Min wavelength for a cascade in the wave buffer. Does not depend on viewpoint.
+        /// </summary>
+        public float MinWavelength(int cascadeIdx)
+        {
+            var diameter = 0.5f * (1 << cascadeIdx);
+            var texelSize = diameter / _resolution;
+            return texelSize * OceanRenderer.Instance.MinTexelsPerWave;
+        }
+
+        public void CrestUpdate(CommandBuffer buf)
+        {
+            if (_waveBuffers == null || _resolution != _waveBuffers.width || _bufCascadeParams == null || _bufWaveData == null)
+            {
+                InitData();
+            }
+
+            var updateDataEachFrame = !_spectrumIsStatic;
+#if UNITY_EDITOR
+            if (!EditorApplication.isPlaying) updateDataEachFrame = true;
+#endif
+            if (_firstUpdate || updateDataEachFrame)
+            {
+                UpdateWaveData();
+
+                InitBatches();
+
+                _firstUpdate = false;
+            }
+
+            // Set weights - this should always happen
+            foreach (var batch in _batches)
+            {
+                if (batch != null)
+                {
+                    batch.Weight = _weight;
+                }
+            }
+
+            ReportMaxDisplacement();
+
+            // If some cascades have waves in them, generate
+            if (_firstCascade != -1 && _lastCascade != -1)
+            {
+                UpdateGenerateWaves(buf);
+            }
+
+            buf.SetGlobalVector(sp_AxisX, WindDir);
+        }
+
+        void SliceUpWaves()
+        {
+            _firstCascade = _lastCascade = -1;
+
+            var cascadeIdx = 0;
+            var componentIdx = 0;
+            var outputIdx = 0;
+            _cascadeParams[0]._startIndex = 0;
+
+            // Seek forward to first wavelength that is big enough to render into current cascades
+            var minWl = MinWavelength(cascadeIdx);
+            while (componentIdx < _wavelengths.Length && _wavelengths[componentIdx] < minWl)
+            {
+                componentIdx++;
+            }
+            //Debug.Log($"{cascadeIdx}: start {_cascadeParams[cascadeIdx]._startIndex} minWL {minWl}");
+
+            for (; componentIdx < _wavelengths.Length; componentIdx++)
+            {
+                // Skip small amplitude waves
+                while (componentIdx < _wavelengths.Length && _amplitudes[componentIdx] < 0.001f)
+                {
+                    componentIdx++;
+                }
+                if (componentIdx >= _wavelengths.Length) break;
+
+                // Check if we need to move to the next cascade
+                while (cascadeIdx < CASCADE_COUNT && _wavelengths[componentIdx] >= 2f * minWl)
+                {
+                    // Wrap up this cascade and begin next
+
+                    // Fill remaining elements of current vector4 with 0s
+                    int vi = outputIdx / 4;
+                    int ei = outputIdx - vi * 4;
+
+                    while (ei != 0)
+                    {
+                        _waveData[vi]._twoPiOverWavelength[ei] = 1f;
+                        _waveData[vi]._amp[ei] = 0f;
+                        _waveData[vi]._waveDirX[ei] = 0f;
+                        _waveData[vi]._waveDirZ[ei] = 0f;
+                        _waveData[vi]._omega[ei] = 0f;
+                        _waveData[vi]._phase[ei] = 0f;
+                        _waveData[vi]._chopAmp[ei] = 0f;
+                        ei = (ei + 1) % 4;
+                        outputIdx++;
+                    }
+
+                    if (outputIdx > 0 && _firstCascade == -1) _firstCascade = cascadeIdx;
+
+                    cascadeIdx++;
+                    _cascadeParams[cascadeIdx]._startIndex = outputIdx / 4;
+                    minWl *= 2f;
+
+                    //Debug.Log($"{cascadeIdx}: start {_cascadeParams[cascadeIdx]._startIndex} minWL {minWl}");
+                }
+                if (cascadeIdx == CASCADE_COUNT) break;
+
+                {
+                    // Pack into vector elements
+                    int vi = outputIdx / 4;
+                    int ei = outputIdx - vi * 4;
+
+                    _waveData[vi]._twoPiOverWavelength[ei] = 2f * Mathf.PI / _wavelengths[componentIdx];
+                    _waveData[vi]._amp[ei] = _amplitudes[componentIdx];
+
+                    float chopScale = _spectrum._chopScales[componentIdx / _componentsPerOctave];
+                    _waveData[vi]._chopAmp[ei] = -chopScale * _spectrum._chop * _amplitudes[componentIdx];
+
+                    float angle = Mathf.Deg2Rad * _angleDegs[componentIdx];
+                    float dx = Mathf.Cos(angle);
+                    float dz = Mathf.Sin(angle);
+
+                    // It used to be this, but I'm pushing all the stuff that doesn't depend on position into the phase.
+                    //half4 angle = k * (C * _CrestTime + x) + _Phases[vi];
+                    float gravityScale = _spectrum._gravityScales[(componentIdx) / _componentsPerOctave];
+                    float gravity = OceanRenderer.Instance.Gravity * _spectrum._gravityScale;
+                    float C = Mathf.Sqrt(_wavelengths[componentIdx] * gravity * gravityScale * _recipTwoPi);
+                    float k = _twoPi / _wavelengths[componentIdx];
+
+                    // Constrain wave vector (wavelength and wave direction) to ensure wave tiles across domain
+                    {
+                        float kx = k * dx;
+                        float kz = k * dz;
+                        var diameter = 0.5f * (1 << cascadeIdx);
+                        float n = kx / (2f * Mathf.PI / diameter);
+                        float m = kz / (2f * Mathf.PI / diameter);
+                        kx = 2f * Mathf.PI * Mathf.Round(n) / diameter;
+                        kz = 2f * Mathf.PI * Mathf.Round(m) / diameter;
+
+                        k = Mathf.Sqrt(kx * kx + kz * kz);
+                        dx = kx / k;
+                        dz = kz / k;
+                    }
+
+                    _waveData[vi]._waveDirX[ei] = dx;
+                    _waveData[vi]._waveDirZ[ei] = dz;
+
+                    // Repeat every 2pi to keep angle bounded - helps precision on 16bit platforms
+                    _waveData[vi]._omega[ei] = k * C;
+                    _waveData[vi]._phase[ei] = Mathf.Repeat(_phases[componentIdx], Mathf.PI * 2f);
+
+                    outputIdx++;
+                }
+            }
+
+            _lastCascade = cascadeIdx;
+
+            {
+                // Fill remaining elements of current vector4 with 0s
+                int vi = outputIdx / 4;
+                int ei = outputIdx - vi * 4;
+
+                while (ei != 0)
+                {
+                    _waveData[vi]._twoPiOverWavelength[ei] = 1f;
+                    _waveData[vi]._amp[ei] = 0f;
+                    _waveData[vi]._waveDirX[ei] = 0f;
+                    _waveData[vi]._waveDirZ[ei] = 0f;
+                    _waveData[vi]._omega[ei] = 0f;
+                    _waveData[vi]._phase[ei] = 0f;
+                    _waveData[vi]._chopAmp[ei] = 0f;
+                    ei = (ei + 1) % 4;
+                    outputIdx++;
+                }
+            }
+
+            while (cascadeIdx < CASCADE_COUNT)
+            {
+                cascadeIdx++;
+                minWl *= 2f;
+                _cascadeParams[cascadeIdx]._startIndex = outputIdx / 4;
+                //Debug.Log($"{cascadeIdx}: start {_cascadeParams[cascadeIdx]._startIndex} minWL {minWl}");
+            }
+
+            _bufCascadeParams.SetData(_cascadeParams);
+            _bufWaveData.SetData(_waveData);
+        }
+
+        void UpdateGenerateWaves(CommandBuffer buf)
+        {
+            buf.SetComputeFloatParam(_shaderGerstner, sp_TextureRes, _waveBuffers.width);
+            buf.SetComputeFloatParam(_shaderGerstner, OceanRenderer.sp_crestTime, OceanRenderer.Instance.CurrentTime);
+            buf.SetComputeIntParam(_shaderGerstner, sp_FirstCascadeIndex, _firstCascade);
+            buf.SetComputeBufferParam(_shaderGerstner, _krnlGerstner, sp_CascadeParams, _bufCascadeParams);
+            buf.SetComputeBufferParam(_shaderGerstner, _krnlGerstner, sp_GerstnerWaveData, _bufWaveData);
+            buf.SetComputeTextureParam(_shaderGerstner, _krnlGerstner, sp_WaveBuffer, _waveBuffers);
+
+            buf.DispatchCompute(_shaderGerstner, _krnlGerstner, _waveBuffers.width / LodDataMgr.THREAD_GROUP_SIZE_X, _waveBuffers.height / LodDataMgr.THREAD_GROUP_SIZE_Y, _lastCascade - _firstCascade + 1);
+        }
+
+        public void SetOrigin(Vector3 newOrigin)
+        {
+            if (_phases == null) return;
+
+            var windAngle = _windDirectionAngle;
+            for (int i = 0; i < _phases.Length; i++)
+            {
+                var direction = new Vector3(Mathf.Cos((windAngle + _angleDegs[i]) * Mathf.Deg2Rad), 0f, Mathf.Sin((windAngle + _angleDegs[i]) * Mathf.Deg2Rad));
+                var phaseOffsetMeters = Vector3.Dot(newOrigin, direction);
+
+                // wave number
+                var k = 2f * Mathf.PI / _wavelengths[i];
+
+                _phases[i] = Mathf.Repeat(_phases[i] + phaseOffsetMeters * k, Mathf.PI * 2f);
+            }
+        }
+
+        public void UpdateWaveData()
+        {
+            // Set random seed to get repeatable results
+            Random.State randomStateBkp = Random.state;
+            Random.InitState(_randomSeed);
+
+            _spectrum.GenerateWaveData(_componentsPerOctave, ref _wavelengths, ref _angleDegs);
+
+            UpdateAmplitudes();
+
+            // Won't run every time so put last in the random sequence
+            if (_phases == null || _phases.Length != _wavelengths.Length)
+            {
+                InitPhases();
+            }
+
+            Random.state = randomStateBkp;
+
+            SliceUpWaves();
+        }
+
+        void UpdateAmplitudes()
+        {
+            if (_amplitudes == null || _amplitudes.Length != _wavelengths.Length)
+            {
+                _amplitudes = new float[_wavelengths.Length];
+            }
+
+            for (int i = 0; i < _wavelengths.Length; i++)
+            {
+                _amplitudes[i] = _weight * _spectrum.GetAmplitude(_wavelengths[i], _componentsPerOctave);
+            }
+        }
+
+        void InitPhases()
+        {
+            // Set random seed to get repeatable results
+            Random.State randomStateBkp = Random.state;
+            Random.InitState(_randomSeed);
+
+            var totalComps = _componentsPerOctave * OceanWaveSpectrum.NUM_OCTAVES;
+            _phases = new float[totalComps];
+            for (var octave = 0; octave < OceanWaveSpectrum.NUM_OCTAVES; octave++)
+            {
+                for (var i = 0; i < _componentsPerOctave; i++)
+                {
+                    var index = octave * _componentsPerOctave + i;
+                    var rnd = (i + Random.value) / _componentsPerOctave;
+                    _phases[index] = 2f * Mathf.PI * rnd;
+                }
+            }
+
+            Random.state = randomStateBkp;
+        }
+
+        private void ReportMaxDisplacement()
+        {
+            if (_spectrum._chopScales.Length != OceanWaveSpectrum.NUM_OCTAVES)
+            {
+                Debug.LogError($"OceanWaveSpectrum {_spectrum.name} is out of date, please open this asset and resave in editor.", _spectrum);
+            }
+
+            float ampSum = 0f;
+            for (int i = 0; i < _wavelengths.Length; i++)
+            {
+                ampSum += _amplitudes[i] * _spectrum._chopScales[i / _componentsPerOctave];
+            }
+            OceanRenderer.Instance.ReportMaxDisplacementFromShape(ampSum * _spectrum._chop, ampSum, ampSum);
+        }
+
+        void InitBatches()
+        {
+            var registered = RegisterLodDataInputBase.GetRegistrar(typeof(LodDataMgrAnimWaves));
+
+            //#if UNITY_EDITOR
+            // Unregister after switching modes in the editor.
+            if (_batches != null)
+            {
+                foreach (var batch in _batches)
+                {
+                    registered.Remove(batch);
+                }
+            }
+            //#endif
+
+            var shaderGerstnerGlobal = Shader.Find("Hidden/Crest/Inputs/Animated Waves/Gerstner Global");
+
+            // Submit draws to create the Gerstner waves
+            _batches = new GerstnerBatch[CASCADE_COUNT];
+            for (int i = _firstCascade; i <= _lastCascade; i++)
+            {
+                if (i == -1) break;
+                _batches[i] = new GerstnerBatch(MinWavelength(i), _waveBuffers, i, shaderGerstnerGlobal, _meshForDrawingWaves);
+                registered.Add(0, _batches[i]);
+            }
+        }
+
+        private void OnEnable()
+        {
+            _firstUpdate = true;
+
+#if UNITY_EDITOR
+            // Initialise with spectrum
+            if (_spectrum == null)
+            {
+                _spectrum = ScriptableObject.CreateInstance<OceanWaveSpectrum>();
+                _spectrum.name = "Default Waves (auto)";
+            }
+
+            if (EditorApplication.isPlaying && !Validate(OceanRenderer.Instance, ValidatedHelper.DebugLog))
+            {
+                enabled = false;
+                return;
+            }
+
+            _spectrum.Upgrade();
+#endif
+
+            LodDataMgrAnimWaves.RegisterUpdatable(this);
+        }
+
+        void OnDisable()
+        {
+            LodDataMgrAnimWaves.DeregisterUpdatable(this);
+
+            if (_batches != null)
+            {
+                var registered = RegisterLodDataInputBase.GetRegistrar(typeof(LodDataMgrAnimWaves));
+                foreach (var batch in _batches)
+                {
+                    registered.Remove(batch);
+                }
+
+                _batches = null;
+            }
+
+            if (_bufCascadeParams != null && _bufCascadeParams.IsValid())
+            {
+                _bufCascadeParams.Dispose();
+                _bufCascadeParams = null;
+            }
+            if (_bufWaveData != null && _bufWaveData.IsValid())
+            {
+                _bufWaveData.Dispose();
+                _bufWaveData = null;
+            }
+        }
+
+#if UNITY_EDITOR
+        private void OnDrawGizmosSelected()
+        {
+            var mf = GetComponent<MeshFilter>();
+            if (mf)
+            {
+                Gizmos.color = RegisterAnimWavesInput.s_gizmoColor;
+                Gizmos.DrawWireMesh(mf.sharedMesh, transform.position, transform.rotation, transform.lossyScale);
+            }
+        }
+
+        void OnGUI()
+        {
+            if (_debugDrawSlicesInEditor)
+            {
+                OceanDebugGUI.DrawTextureArray(_waveBuffers, 8);
+            }
+        }
+#endif
+    }
+
+#if UNITY_EDITOR
+    public partial class ShapeGerstner : IValidated
+    {
+        public bool Validate(OceanRenderer ocean, ValidatedHelper.ShowMessage showMessage)
+        {
+            var isValid = true;
+
+            if (_spectrum == null)
+            {
+                showMessage
+                (
+                    "There is no spectrum assigned meaning this Gerstner component won't generate any waves.",
+                    ValidatedHelper.MessageType.Warning, this
+                );
+
+                isValid = false;
+            }
+
+            if (_componentsPerOctave == 0)
+            {
+                showMessage
+                (
+                    "Components Per Octave set to 0 meaning this Gerstner component won't generate any waves.",
+                    ValidatedHelper.MessageType.Warning, this
+                );
+
+                isValid = false;
+            }
+
+            return isValid;
+        }
+    }
+#endif
+}

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstner.cs.meta
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstner.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 83cb23af551c5cd4b81f094099c1c6fd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences:
+  - _rasterMesh: {instanceID: 0}
+  - _spectrum: {instanceID: 0}
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
@@ -130,7 +130,6 @@ namespace Crest
         readonly int sp_Phases = Shader.PropertyToID("_Phases");
         readonly int sp_ChopAmps = Shader.PropertyToID("_ChopAmps");
         readonly int sp_NumInBatch = Shader.PropertyToID("_NumInBatch");
-        readonly int sp_AttenuationInShallows = Shader.PropertyToID("_AttenuationInShallows");
         readonly int sp_NumWaveVecs = Shader.PropertyToID("_NumWaveVecs");
         readonly int sp_TargetPointData = Shader.PropertyToID("_TargetPointData");
 
@@ -465,7 +464,7 @@ namespace Crest
                 mat.SetVectorArray(sp_Phases, UpdateBatchScratchData._phasesBatch);
                 mat.SetVectorArray(sp_ChopAmps, UpdateBatchScratchData._chopAmpsBatch);
                 mat.SetFloat(sp_NumInBatch, numInBatch);
-                mat.SetFloat(sp_AttenuationInShallows, OceanRenderer.Instance._lodDataAnimWaves.Settings.AttenuationInShallows);
+                mat.SetFloat(LodDataMgrAnimWaves.sp_AttenuationInShallows, OceanRenderer.Instance._lodDataAnimWaves.Settings.AttenuationInShallows);
 
                 int numVecs = (numInBatch + 3) / 4;
                 mat.SetInt(sp_NumWaveVecs, numVecs);

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/AnimWavesGerstnerBatchGeometry.shader
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/AnimWavesGerstnerBatchGeometry.shader
@@ -64,7 +64,6 @@ Shader "Crest/Inputs/Animated Waves/Gerstner Batch Geometry"
 			Varyings Vert(Attributes input)
 			{
 				Varyings o;
-				
 
 				float3 worldPos = mul(unity_ObjectToWorld, float4(input.positionOS, 1.0)).xyz;
 				// Correct for displacement

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/AnimWavesGerstner.shader
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/AnimWavesGerstner.shader
@@ -1,0 +1,86 @@
+﻿// Crest Ocean System
+
+// This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
+
+// Adds Gestner waves to world
+
+Shader "Hidden/Crest/Inputs/Animated Waves/Gerstner Global"
+{
+	SubShader
+	{
+		// Additive blend everywhere
+		Blend One One
+		ZWrite Off
+		ZTest Always
+		Cull Off
+
+		Pass
+		{
+			CGPROGRAM
+			#pragma vertex Vert
+			#pragma fragment Frag
+			//#pragma enable_d3d11_debug_symbols
+
+			#include "UnityCG.cginc"
+
+			#include "../../OceanGlobals.hlsl"
+			#include "../../OceanInputsDriven.hlsl"
+			#include "../../OceanHelpersNew.hlsl"
+			#include "../../FullScreenTriangle.hlsl"
+
+			Texture2DArray _WaveBuffer;
+
+			CBUFFER_START(CrestPerOceanInput)
+			int _WaveBufferSliceIndex;
+			float _Weight;
+			float _AverageWavelength;
+			float _AttenuationInShallows;
+			float2 _AxisX;
+			CBUFFER_END
+
+			struct Attributes
+			{
+				uint VertexID : SV_VertexID;
+			};
+
+			struct Varyings
+			{
+				float4 positionCS : SV_POSITION;
+				float4 uv_uvWaves : TEXCOORD0;
+			};
+
+			Varyings Vert(Attributes input)
+			{
+				Varyings o;
+				o.positionCS = GetFullScreenTriangleVertexPosition(input.VertexID);
+
+				o.uv_uvWaves.xy = GetFullScreenTriangleTexCoord(input.VertexID);
+
+				float2 worldPosXZ = UVToWorld( o.uv_uvWaves.xy, _LD_SliceIndex, _CrestCascadeData[_LD_SliceIndex] );
+
+				// UV coordinate into wave buffer
+				float2 wavePos = float2( dot(worldPosXZ, _AxisX), dot(worldPosXZ, float2(-_AxisX.y, _AxisX.x)) );
+				float scale = 0.5f * (1 << _WaveBufferSliceIndex);
+				o.uv_uvWaves.zw = wavePos / scale;
+
+				return o;
+			}
+			
+			half4 Frag( Varyings input ) : SV_Target
+			{
+				float wt = _Weight;
+
+				// Attenuate if depth is less than half of the average wavelength
+				const half depth = _LD_TexArray_SeaFloorDepth.SampleLevel(LODData_linear_clamp_sampler, float3(input.uv_uvWaves.xy, _LD_SliceIndex), 0.0).x;
+				half depth_wt = saturate(2.0 * depth / _AverageWavelength);
+				wt *= _AttenuationInShallows * depth_wt + (1.0 - _AttenuationInShallows);
+
+				// Sample displacement, rotate into frame
+				float4 disp = _WaveBuffer.SampleLevel(sampler_Crest_linear_repeat, float3(input.uv_uvWaves.zw, _WaveBufferSliceIndex), 0);
+				disp.xz = disp.x * _AxisX + disp.z * float2(-_AxisX.y, _AxisX.x);
+				return wt * disp;
+			}
+			ENDCG
+		}
+	}
+}

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/AnimWavesGerstner.shader
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/AnimWavesGerstner.shader
@@ -36,6 +36,7 @@ Shader "Hidden/Crest/Inputs/Animated Waves/Gerstner Global"
 			float _AverageWavelength;
 			float _AttenuationInShallows;
 			float2 _AxisX;
+			float _RespectShallowWaterAttenuation;
 			CBUFFER_END
 
 			struct Attributes
@@ -73,7 +74,8 @@ Shader "Hidden/Crest/Inputs/Animated Waves/Gerstner Global"
 				// Attenuate if depth is less than half of the average wavelength
 				const half depth = _LD_TexArray_SeaFloorDepth.SampleLevel(LODData_linear_clamp_sampler, float3(input.uv_uvWaves.xy, _LD_SliceIndex), 0.0).x;
 				half depth_wt = saturate(2.0 * depth / _AverageWavelength);
-				wt *= _AttenuationInShallows * depth_wt + (1.0 - _AttenuationInShallows);
+				const float attenuationAmount = _AttenuationInShallows * _RespectShallowWaterAttenuation;
+				wt *= attenuationAmount * depth_wt + (1.0 - attenuationAmount);
 
 				// Sample displacement, rotate into frame
 				float4 disp = _WaveBuffer.SampleLevel(sampler_Crest_linear_repeat, float3(input.uv_uvWaves.zw, _WaveBufferSliceIndex), 0);

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/AnimWavesGerstner.shader.meta
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/AnimWavesGerstner.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 2edf25ce84c11d049871c9c0dff30c2d
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/crest/Assets/Crest/Crest/Shaders/Resources/Gerstner.compute
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/Gerstner.compute
@@ -35,8 +35,6 @@ StructuredBuffer<GerstnerWaveComponent4> _GerstnerWaveData;
 
 RWTexture2DArray<half4> _WaveBuffer;
 
-// 7.7us
-
 void ComputeGerstner( float2 worldPosXZ, float worldSize, GerstnerWaveComponent4 data, inout float3 result, inout float2 displacementNormalized )
 {
 	// direction

--- a/crest/Assets/Crest/Crest/Shaders/Resources/Gerstner.compute
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/Gerstner.compute
@@ -1,0 +1,98 @@
+﻿// Crest Ocean System
+
+// This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
+
+// Computes a set of patches of waves, one for each scale.
+
+#pragma kernel Gerstner
+
+#include "HLSLSupport.cginc"
+
+#include "../OceanGlobals.hlsl"
+#include "../OceanInputsDriven.hlsl"
+#include "../OceanHelpersNew.hlsl"
+
+float _TextureRes;
+uint _FirstCascadeIndex;
+
+struct GerstnerCascadeParams
+{
+	int _startIndex;
+};
+StructuredBuffer<GerstnerCascadeParams> _GerstnerCascadeParams;
+
+struct GerstnerWaveComponent4
+{
+	float4 _twoPiOverWavelength;
+	float4 _amp;
+	float4 _waveDirX;
+	float4 _waveDirZ;
+	float4 _omega;
+	float4 _phase;
+	float4 _chopAmp;
+};
+StructuredBuffer<GerstnerWaveComponent4> _GerstnerWaveData;
+
+RWTexture2DArray<half4> _WaveBuffer;
+
+// 7.7us
+
+void ComputeGerstner( float2 worldPosXZ, float worldSize, GerstnerWaveComponent4 data, inout float3 result, inout float2 displacementNormalized )
+{
+	// direction
+	half4 Dx = data._waveDirX;
+	half4 Dz = data._waveDirZ;
+
+	// wave number
+	half4 k = data._twoPiOverWavelength;
+
+	half4 kx = k * Dx;
+	half4 kz = k * Dz;
+
+	// spatial location
+	float4 x = kx * worldPosXZ.x + kz * worldPosXZ.y;
+	half4 angle = data._phase - data._omega * _CrestTime;
+	angle += x;
+
+	// dx and dz could be baked into _ChopAmp
+	half4 disp = data._chopAmp * sin( angle );
+	half4 resultx = disp * Dx;
+	half4 resultz = disp * Dz;
+
+	half4 resulty = data._amp * cos( angle );
+
+	// sum the vector results
+	result.x += dot( resultx, 1.0 );
+	result.y += dot( resulty, 1.0 );
+	result.z += dot( resultz, 1.0 );
+
+	half4 sssFactor = min( 1.0, data._twoPiOverWavelength );
+	displacementNormalized.x += dot( resultx, sssFactor );
+	displacementNormalized.y += dot( resultz, sssFactor );
+}
+
+[numthreads(THREAD_GROUP_SIZE_X, THREAD_GROUP_SIZE_Y, 1)]
+void Gerstner(uint3 id : SV_DispatchThreadID)
+{
+	const uint cascadeIndex = id.z + _FirstCascadeIndex;
+	const float worldSize = 0.5f * (1 << cascadeIndex);
+
+	// Each cascade lies on XZ plane and starts from the origin
+	const float texelWidth = worldSize / _TextureRes;
+	const float2 worldPosXZ = (id.xy + 0.5) * texelWidth;
+
+	float3 result = 0.0;
+	float2 displacementNormalized = 0.0;
+
+	const int startIndex = _GerstnerCascadeParams[cascadeIndex]._startIndex;
+	const int endIndex = _GerstnerCascadeParams[cascadeIndex + 1]._startIndex;
+	for( int i = startIndex; i < endIndex; i++ )
+	{
+		// Sum up waves from another buffer
+		ComputeGerstner( worldPosXZ, worldSize, _GerstnerWaveData[i], result, displacementNormalized );
+	}
+
+	half sss = length( displacementNormalized );
+
+	_WaveBuffer[uint3(id.xy, cascadeIndex)] = float4(result, sss);
+}

--- a/crest/Assets/Crest/Crest/Shaders/Resources/Gerstner.compute.meta
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/Gerstner.compute.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d98227fd97724cf48a455a1acbc4308e
+ComputeShaderImporter:
+  externalObjects: {}
+  currentAPIMask: 4
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/crest/Assets/Crest/Crest/Shaders/Resources/ShapeCombine.compute
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/ShapeCombine.compute
@@ -77,9 +77,10 @@ void SampleDisplacementsCompute(
 
 void ShapeCombineBase(uint3 id)
 {
-	float width; float height; float depth;
+	float width, height;
 	{
-		_LD_TexArray_AnimatedWaves_Compute.GetDimensions(width, height, depth);
+		float dummy;
+		_LD_TexArray_AnimatedWaves_Compute.GetDimensions(width, height, dummy);
 	}
 	const float2 input_uv = IDtoUV(id.xy, width, height);
 	const CascadeParams cascadeData0 = _CrestCascadeData[_LD_SliceIndex];
@@ -94,7 +95,7 @@ void ShapeCombineBase(uint3 id)
 
 	float3 result = 0.0;
 	half sss = 0.;
-	// this lods waves
+	// Sample in waves for this cascade
 #if _FLOW_ON
 	half2 flow = 0.0;
 	SampleFlow(_LD_TexArray_Flow, uv_thisLod, 1.0, flow);
@@ -107,13 +108,9 @@ void ShapeCombineBase(uint3 id)
 	SampleDisplacements(_LD_TexArray_WaveBuffer, uv_thisLod_flow_0, weights[0], result, sss);
 	SampleDisplacements(_LD_TexArray_WaveBuffer, uv_thisLod_flow_1, weights[1], result, sss);
 #else
-	float4 data =_LD_TexArray_WaveBuffer.SampleLevel(LODData_linear_clamp_sampler, uv_thisLod, 0.0);
-	result += data.xyz;
-	sss = data.a;
+	SampleDisplacements(_LD_TexArray_WaveBuffer, uv_thisLod, 1.0, result, sss);
 #endif // _FLOW_ON
 
-	// C# Script determines whether this enabled or not by selecting appropriate
-	// kernel for each LOD.
 #if !_DISABLE_COMBINE
 	SampleDisplacementsCompute(_LD_TexArray_AnimatedWaves_Compute, width, height, uv_nextLod, 1.0, result, sss);
 #endif


### PR DESCRIPTION
**Status**: Ready to merge

This adds a new, leaner and meaner Gerstner system.

It renders the gerstner waves into a 'wave buffer' that is its own cascade independent of the other lod data, more slices but much lower X&Y res (32x32 by default). The wavelengths are snapped in a way that they always repeat spatially, so that the resulting patch can be tiled on the world XZ plane. Since it tiles, the patches are computed near the origin instead of moving with the viewer, which simplifies a few things.

The wave components are compiled in one list and generating the wave buffer is done in one dispatch. Thanks to this and the low resolution i was measuring <10us for the wave generation time on a 1060 gpu.

By default it does not resample the spectrum each frame in play mode. The gerstner sampling cost is non-negligible. This is on a toggle on the component. When this is disabled, the work done on the CPU by the gerstner system should be minimal, which should help a bunch (cf `OceanRenderer.LateUpdate()` cost in #624 , was around 4ms in those tests).

A new input shader `AnimWavesGerster` then samples the repeating tile and adds it to the displacements.

This change is additive and should have minimal impact on the existing systems. It is not added to any scene, i'll leave that for a future PR.

This new gerstner system also incorporates the wave direction fix #562.

**Performance before (main.unity, 1060 gpu)**

OceanRenderer.LateUpdate (CPU): 0.78ms
Wave generation (GPU): 0.330ms

**Performance after**

OceanRenderer.LateUpdate (CPU): 0.5ms
Wave generation (GPU): 0.00941ms generation + 0.206ms wave integration = 0.215ms
(The integration pass could be done in a single dispatch. for the global waves case at least.. but its not totally trivial to do this so ill leave this for future work.)
