### PR TITLE
Wave variance

### DIFF
--- a/crest/Assets/Crest/Crest-Examples/Main/Scenes/main.unity
+++ b/crest/Assets/Crest/Crest-Examples/Main/Scenes/main.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.40711796, g: 0.5924692, b: 0.9424595, a: 1}
+  m_IndirectSpecularColor: {r: 0.40652782, g: 0.59053, b: 0.9443165, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &4
 LightmapSettings:
@@ -54,7 +54,7 @@ LightmapSettings:
     m_EnableBakedLightmaps: 1
     m_EnableRealtimeLightmaps: 0
   m_LightmapEditorSettings:
-    serializedVersion: 10
+    serializedVersion: 12
     m_Resolution: 1
     m_BakeResolution: 50
     m_AtlasSize: 1024
@@ -62,6 +62,7 @@ LightmapSettings:
     m_AOMaxDistance: 1
     m_CompAOExponent: 0
     m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
     m_Padding: 2
     m_LightmapParameters: {fileID: 0}
     m_LightmapsBakeMode: 1
@@ -76,10 +77,16 @@ LightmapSettings:
     m_PVRDirectSampleCount: 32
     m_PVRSampleCount: 500
     m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 500
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 2
+    m_PVRDenoiserTypeDirect: 0
+    m_PVRDenoiserTypeIndirect: 0
+    m_PVRDenoiserTypeAO: 0
     m_PVRFilterTypeDirect: 0
     m_PVRFilterTypeIndirect: 0
     m_PVRFilterTypeAO: 0
-    m_PVRFilteringMode: 1
+    m_PVREnvironmentMIS: 0
     m_PVRCulling: 1
     m_PVRFilteringGaussRadiusDirect: 1
     m_PVRFilteringGaussRadiusIndirect: 5
@@ -87,7 +94,9 @@ LightmapSettings:
     m_PVRFilteringAtrousPositionSigmaDirect: 0.5
     m_PVRFilteringAtrousPositionSigmaIndirect: 2
     m_PVRFilteringAtrousPositionSigmaAO: 1
-    m_ShowResolutionOverlay: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
   m_LightingDataAsset: {fileID: 0}
   m_UseShadowmask: 0
 --- !u!196 &5
@@ -119,10 +128,40 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 9037604615445586478, guid: ddf71bfb72c45407fb8cea42d3aaeac4,
+    - target: {fileID: 1935528129688418602, guid: ddf71bfb72c45407fb8cea42d3aaeac4,
         type: 3}
-      propertyPath: m_Name
-      value: MainScene
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8066748594655780890, guid: ddf71bfb72c45407fb8cea42d3aaeac4,
+        type: 3}
+      propertyPath: _primaryLight
+      value: 
+      objectReference: {fileID: 1299488651}
+    - target: {fileID: 8066748594655780890, guid: ddf71bfb72c45407fb8cea42d3aaeac4,
+        type: 3}
+      propertyPath: _timeProvider
+      value: 
+      objectReference: {fileID: 1030721469}
+    - target: {fileID: 8066748594655780890, guid: ddf71bfb72c45407fb8cea42d3aaeac4,
+        type: 3}
+      propertyPath: _createFoamSim
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8463273387121746141, guid: ddf71bfb72c45407fb8cea42d3aaeac4,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 198.83
+      objectReference: {fileID: 0}
+    - target: {fileID: 8463273387121746141, guid: ddf71bfb72c45407fb8cea42d3aaeac4,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 11.8
+      objectReference: {fileID: 0}
+    - target: {fileID: 9037604615445586465, guid: ddf71bfb72c45407fb8cea42d3aaeac4,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 9037604615445586465, guid: ddf71bfb72c45407fb8cea42d3aaeac4,
         type: 3}
@@ -141,6 +180,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 9037604615445586465, guid: ddf71bfb72c45407fb8cea42d3aaeac4,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9037604615445586465, guid: ddf71bfb72c45407fb8cea42d3aaeac4,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
@@ -152,16 +196,6 @@ PrefabInstance:
     - target: {fileID: 9037604615445586465, guid: ddf71bfb72c45407fb8cea42d3aaeac4,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9037604615445586465, guid: ddf71bfb72c45407fb8cea42d3aaeac4,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 9037604615445586465, guid: ddf71bfb72c45407fb8cea42d3aaeac4,
-        type: 3}
-      propertyPath: m_RootOrder
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 9037604615445586465, guid: ddf71bfb72c45407fb8cea42d3aaeac4,
@@ -179,5 +213,191 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 9037604615445586478, guid: ddf71bfb72c45407fb8cea42d3aaeac4,
+        type: 3}
+      propertyPath: m_Name
+      value: MainScene
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: ddf71bfb72c45407fb8cea42d3aaeac4, type: 3}
+--- !u!1 &1030721468 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 457536134579858462, guid: ddf71bfb72c45407fb8cea42d3aaeac4,
+    type: 3}
+  m_PrefabInstance: {fileID: 1030721467}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1030721469
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1030721468}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f02c000dd23b95349acae40e1938c4a8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _time: 0
+  _deltaTime: 0
+--- !u!114 &1210736645
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 33068fc021dadc04dab6e00e4ff45c00, type: 3}
+  m_Name: Default Waves (auto)
+  m_EditorClassIdentifier: 
+  _windSpeed: 10
+  _fetch: 500000
+  _waveDirectionVariance: 90
+  _gravityScale: 1
+  _smallWavelengthMultiplier: 1
+  _multiplier: 1
+  _powerLog:
+  - -6
+  - -6
+  - -6
+  - -4.0088496
+  - -3.4452133
+  - -2.6996124
+  - -2.615044
+  - -1.2080691
+  - -0.53905386
+  - 0.27448857
+  - 0.53627354
+  - 1.0282621
+  - 1.4403292
+  - -6
+  _powerDisabled: 0000000000000000000000000000
+  _chopScales:
+  - 1
+  - 1
+  - 1
+  - 1
+  - 1
+  - 1
+  - 1
+  - 1
+  - 1
+  - 1
+  - 1
+  - 1
+  - 1
+  - 1
+  _gravityScales:
+  - 1
+  - 1
+  - 1
+  - 1
+  - 1
+  - 1
+  - 1
+  - 1
+  - 1
+  - 1
+  - 1
+  - 1
+  - 1
+  - 1
+  _chop: 1.6
+  _showAdvancedControls: 0
+  _model: 0
+--- !u!108 &1299488651 stripped
+Light:
+  m_CorrespondingSourceObject: {fileID: 5936606776992183399, guid: ddf71bfb72c45407fb8cea42d3aaeac4,
+    type: 3}
+  m_PrefabInstance: {fileID: 1030721467}
+  m_PrefabAsset: {fileID: 0}
+--- !u!84 &1606027543
+RenderTexture:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: GerstnerCascades
+  m_ImageContentsHash:
+    serializedVersion: 2
+    Hash: 00000000000000000000000000000000
+  m_ForcedFallbackFormat: 4
+  m_DownscaleFallback: 0
+  serializedVersion: 3
+  m_Width: 32
+  m_Height: 32
+  m_AntiAliasing: 1
+  m_MipCount: -1
+  m_DepthFormat: 0
+  m_ColorFormat: 48
+  m_MipMap: 0
+  m_GenerateMips: 1
+  m_SRGB: 0
+  m_UseDynamicScale: 0
+  m_BindMS: 0
+  m_EnableCompatibleFormat: 1
+  m_TextureSettings:
+    serializedVersion: 2
+    m_FilterMode: 1
+    m_Aniso: 0
+    m_MipBias: 0
+    m_WrapU: 1
+    m_WrapV: 1
+    m_WrapW: 1
+  m_Dimension: 5
+  m_VolumeDepth: 16
+--- !u!1 &1857915673
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1857915675}
+  - component: {fileID: 1857915674}
+  m_Layer: 0
+  m_Name: GameObject
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1857915674
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1857915673}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 83cb23af551c5cd4b81f094099c1c6fd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _spectrum: {fileID: 1210736645}
+  _spectrumFixedAtRuntime: 1
+  _windDirectionAngle: -180
+  _weight: 1
+  _respectShallowWaterAttenuation: 1
+  _componentsPerOctave: 8
+  _randomSeed: 0
+  _resolution: 32
+  _debugDrawSlicesInEditor: 0
+  _waveBuffers: {fileID: 1606027543}
+--- !u!4 &1857915675
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1857915673}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 249.8119, y: 9.631463, z: 150.51352}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/crest/Assets/Crest/Crest-Examples/Main/Scenes/main.unity
+++ b/crest/Assets/Crest/Crest-Examples/Main/Scenes/main.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.40652782, g: 0.59053, b: 0.9443165, a: 1}
+  m_IndirectSpecularColor: {r: 0.40711796, g: 0.5924692, b: 0.9424595, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &4
 LightmapSettings:
@@ -54,7 +54,7 @@ LightmapSettings:
     m_EnableBakedLightmaps: 1
     m_EnableRealtimeLightmaps: 0
   m_LightmapEditorSettings:
-    serializedVersion: 12
+    serializedVersion: 10
     m_Resolution: 1
     m_BakeResolution: 50
     m_AtlasSize: 1024
@@ -62,7 +62,6 @@ LightmapSettings:
     m_AOMaxDistance: 1
     m_CompAOExponent: 0
     m_CompAOExponentDirect: 0
-    m_ExtractAmbientOcclusion: 0
     m_Padding: 2
     m_LightmapParameters: {fileID: 0}
     m_LightmapsBakeMode: 1
@@ -77,16 +76,10 @@ LightmapSettings:
     m_PVRDirectSampleCount: 32
     m_PVRSampleCount: 500
     m_PVRBounces: 2
-    m_PVREnvironmentSampleCount: 500
-    m_PVREnvironmentReferencePointCount: 2048
-    m_PVRFilteringMode: 2
-    m_PVRDenoiserTypeDirect: 0
-    m_PVRDenoiserTypeIndirect: 0
-    m_PVRDenoiserTypeAO: 0
     m_PVRFilterTypeDirect: 0
     m_PVRFilterTypeIndirect: 0
     m_PVRFilterTypeAO: 0
-    m_PVREnvironmentMIS: 0
+    m_PVRFilteringMode: 1
     m_PVRCulling: 1
     m_PVRFilteringGaussRadiusDirect: 1
     m_PVRFilteringGaussRadiusIndirect: 5
@@ -94,9 +87,7 @@ LightmapSettings:
     m_PVRFilteringAtrousPositionSigmaDirect: 0.5
     m_PVRFilteringAtrousPositionSigmaIndirect: 2
     m_PVRFilteringAtrousPositionSigmaAO: 1
-    m_ExportTrainingData: 0
-    m_TrainingDataDestination: TrainingData
-    m_LightProbeSampleCountMultiplier: 4
+    m_ShowResolutionOverlay: 1
   m_LightingDataAsset: {fileID: 0}
   m_UseShadowmask: 0
 --- !u!196 &5
@@ -128,40 +119,10 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 1935528129688418602, guid: ddf71bfb72c45407fb8cea42d3aaeac4,
+    - target: {fileID: 9037604615445586478, guid: ddf71bfb72c45407fb8cea42d3aaeac4,
         type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8066748594655780890, guid: ddf71bfb72c45407fb8cea42d3aaeac4,
-        type: 3}
-      propertyPath: _primaryLight
-      value: 
-      objectReference: {fileID: 1299488651}
-    - target: {fileID: 8066748594655780890, guid: ddf71bfb72c45407fb8cea42d3aaeac4,
-        type: 3}
-      propertyPath: _timeProvider
-      value: 
-      objectReference: {fileID: 1030721469}
-    - target: {fileID: 8066748594655780890, guid: ddf71bfb72c45407fb8cea42d3aaeac4,
-        type: 3}
-      propertyPath: _createFoamSim
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8463273387121746141, guid: ddf71bfb72c45407fb8cea42d3aaeac4,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 198.83
-      objectReference: {fileID: 0}
-    - target: {fileID: 8463273387121746141, guid: ddf71bfb72c45407fb8cea42d3aaeac4,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 11.8
-      objectReference: {fileID: 0}
-    - target: {fileID: 9037604615445586465, guid: ddf71bfb72c45407fb8cea42d3aaeac4,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
+      propertyPath: m_Name
+      value: MainScene
       objectReference: {fileID: 0}
     - target: {fileID: 9037604615445586465, guid: ddf71bfb72c45407fb8cea42d3aaeac4,
         type: 3}
@@ -180,11 +141,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 9037604615445586465, guid: ddf71bfb72c45407fb8cea42d3aaeac4,
         type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 9037604615445586465, guid: ddf71bfb72c45407fb8cea42d3aaeac4,
-        type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
@@ -196,6 +152,16 @@ PrefabInstance:
     - target: {fileID: 9037604615445586465, guid: ddf71bfb72c45407fb8cea42d3aaeac4,
         type: 3}
       propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9037604615445586465, guid: ddf71bfb72c45407fb8cea42d3aaeac4,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9037604615445586465, guid: ddf71bfb72c45407fb8cea42d3aaeac4,
+        type: 3}
+      propertyPath: m_RootOrder
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 9037604615445586465, guid: ddf71bfb72c45407fb8cea42d3aaeac4,
@@ -213,191 +179,5 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 9037604615445586478, guid: ddf71bfb72c45407fb8cea42d3aaeac4,
-        type: 3}
-      propertyPath: m_Name
-      value: MainScene
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: ddf71bfb72c45407fb8cea42d3aaeac4, type: 3}
---- !u!1 &1030721468 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 457536134579858462, guid: ddf71bfb72c45407fb8cea42d3aaeac4,
-    type: 3}
-  m_PrefabInstance: {fileID: 1030721467}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &1030721469
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1030721468}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f02c000dd23b95349acae40e1938c4a8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _time: 0
-  _deltaTime: 0
---- !u!114 &1210736645
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 33068fc021dadc04dab6e00e4ff45c00, type: 3}
-  m_Name: Default Waves (auto)
-  m_EditorClassIdentifier: 
-  _windSpeed: 10
-  _fetch: 500000
-  _waveDirectionVariance: 90
-  _gravityScale: 1
-  _smallWavelengthMultiplier: 1
-  _multiplier: 1
-  _powerLog:
-  - -6
-  - -6
-  - -6
-  - -4.0088496
-  - -3.4452133
-  - -2.6996124
-  - -2.615044
-  - -1.2080691
-  - -0.53905386
-  - 0.27448857
-  - 0.53627354
-  - 1.0282621
-  - 1.4403292
-  - -6
-  _powerDisabled: 0000000000000000000000000000
-  _chopScales:
-  - 1
-  - 1
-  - 1
-  - 1
-  - 1
-  - 1
-  - 1
-  - 1
-  - 1
-  - 1
-  - 1
-  - 1
-  - 1
-  - 1
-  _gravityScales:
-  - 1
-  - 1
-  - 1
-  - 1
-  - 1
-  - 1
-  - 1
-  - 1
-  - 1
-  - 1
-  - 1
-  - 1
-  - 1
-  - 1
-  _chop: 1.6
-  _showAdvancedControls: 0
-  _model: 0
---- !u!108 &1299488651 stripped
-Light:
-  m_CorrespondingSourceObject: {fileID: 5936606776992183399, guid: ddf71bfb72c45407fb8cea42d3aaeac4,
-    type: 3}
-  m_PrefabInstance: {fileID: 1030721467}
-  m_PrefabAsset: {fileID: 0}
---- !u!84 &1606027543
-RenderTexture:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: GerstnerCascades
-  m_ImageContentsHash:
-    serializedVersion: 2
-    Hash: 00000000000000000000000000000000
-  m_ForcedFallbackFormat: 4
-  m_DownscaleFallback: 0
-  serializedVersion: 3
-  m_Width: 32
-  m_Height: 32
-  m_AntiAliasing: 1
-  m_MipCount: -1
-  m_DepthFormat: 0
-  m_ColorFormat: 48
-  m_MipMap: 0
-  m_GenerateMips: 1
-  m_SRGB: 0
-  m_UseDynamicScale: 0
-  m_BindMS: 0
-  m_EnableCompatibleFormat: 1
-  m_TextureSettings:
-    serializedVersion: 2
-    m_FilterMode: 1
-    m_Aniso: 0
-    m_MipBias: 0
-    m_WrapU: 1
-    m_WrapV: 1
-    m_WrapW: 1
-  m_Dimension: 5
-  m_VolumeDepth: 16
---- !u!1 &1857915673
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1857915675}
-  - component: {fileID: 1857915674}
-  m_Layer: 0
-  m_Name: GameObject
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &1857915674
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1857915673}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 83cb23af551c5cd4b81f094099c1c6fd, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _spectrum: {fileID: 1210736645}
-  _spectrumFixedAtRuntime: 1
-  _windDirectionAngle: -180
-  _weight: 1
-  _respectShallowWaterAttenuation: 1
-  _componentsPerOctave: 8
-  _randomSeed: 0
-  _resolution: 32
-  _debugDrawSlicesInEditor: 0
-  _waveBuffers: {fileID: 1606027543}
---- !u!4 &1857915675
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1857915673}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 249.8119, y: 9.631463, z: 150.51352}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrAnimWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrAnimWaves.cs
@@ -19,7 +19,10 @@ namespace Crest
     ///  * The textures from this LodData are passed to the ocean material when the surface is drawn (by OceanChunkRenderer).
     ///  * LodDataDynamicWaves adds its results into this LodData. The dynamic waves piggy back off the combine
     ///    pass and subsequent assignment to the ocean material (see OceanScheduler).
-    ///  * The LodDataSeaFloorDepth sits on this same GameObject and borrows the camera. This could be a model for the other sim types..
+    ///
+    /// The RGB channels are the XYZ displacement from a rest plane at sea level to the corresponding displaced position on the
+    /// surface. The A channel holds the variance/energy in all the smaller wavelengths that are too small to go into the cascade
+    /// slice. This is used as a statistical measure for the missing waves and is used to ensure foam is generated everywhere.
     /// </summary>
     public class LodDataMgrAnimWaves : LodDataMgr
     {

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodTransform.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodTransform.cs
@@ -21,6 +21,7 @@ namespace Crest
             public float _textureRes;
             public Vector3 _posSnapped;
             public int _frame;
+            public float _maxWavelength;
 
             public RenderData Validate(int frameOffset, string context)
             {
@@ -90,12 +91,15 @@ namespace Crest
 
                 _renderData[lodIdx]._frame = OceanRenderer.FrameCount;
 
+                _renderData[lodIdx]._maxWavelength = MaxWavelength(lodIdx);
+
                 // detect first update and populate the render data if so - otherwise it can give divide by 0s and other nastiness
                 if (_renderDataSource[lodIdx]._textureRes == 0f)
                 {
                     _renderDataSource[lodIdx]._posSnapped = _renderData[lodIdx]._posSnapped;
                     _renderDataSource[lodIdx]._texelWidth = _renderData[lodIdx]._texelWidth;
                     _renderDataSource[lodIdx]._textureRes = _renderData[lodIdx]._textureRes;
+                    _renderDataSource[lodIdx]._maxWavelength = _renderData[lodIdx]._maxWavelength;
                 }
 
                 _worldToCameraMatrix[lodIdx] = CalculateWorldToCameraMatrixRHS(_renderData[lodIdx]._posSnapped + Vector3.up * 100f, Quaternion.AngleAxis(90f, Vector3.right));
@@ -153,6 +157,9 @@ namespace Crest
                 cascadeParamsSrc[lodIdx]._texelWidth = _renderDataSource[lodIdx]._texelWidth;
 
                 cascadeParamsTgt[lodIdx]._weight = cascadeParamsSrc[lodIdx]._weight = 1f;
+
+                cascadeParamsTgt[lodIdx]._maxWavelength = _renderData[lodIdx]._maxWavelength;
+                cascadeParamsSrc[lodIdx]._maxWavelength = _renderDataSource[lodIdx]._maxWavelength;
             }
 
             // Duplicate last element so that things can safely read off the end of the cascades

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -324,8 +324,7 @@ namespace Crest
 
             public float _weight;
 
-            // Align to 32 bytes
-            public float __padding;
+            public float _maxWavelength;
         }
         public ComputeBuffer _bufCascadeDataTgt;
         public ComputeBuffer _bufCascadeDataSrc;

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstner.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstner.cs
@@ -105,6 +105,7 @@ namespace Crest
         // Data for all components
         float[] _wavelengths;
         float[] _amplitudes;
+        float[] _powers;
         float[] _angleDegs;
         float[] _phases;
 
@@ -437,10 +438,14 @@ namespace Crest
             {
                 _amplitudes = new float[_wavelengths.Length];
             }
+            if (_powers == null || _powers.Length != _wavelengths.Length)
+            {
+                _powers = new float[_wavelengths.Length];
+            }
 
             for (int i = 0; i < _wavelengths.Length; i++)
             {
-                _amplitudes[i] = _weight * _spectrum.GetAmplitude(_wavelengths[i], _componentsPerOctave);
+                _amplitudes[i] = Random.value * _weight * _spectrum.GetAmplitude(_wavelengths[i], _componentsPerOctave, out _powers[i]);
             }
         }
 

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstner.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstner.cs
@@ -115,6 +115,7 @@ namespace Crest
         struct GerstnerCascadeParams
         {
             public int _startIndex;
+            public float _cumulativeVariance;
         }
         ComputeBuffer _bufCascadeParams;
         GerstnerCascadeParams[] _cascadeParams = new GerstnerCascadeParams[CASCADE_COUNT + 1];
@@ -377,6 +378,26 @@ namespace Crest
                 _cascadeParams[cascadeIdx]._startIndex = outputIdx / 4;
                 //Debug.Log($"{cascadeIdx}: start {_cascadeParams[cascadeIdx]._startIndex} minWL {minWl}");
             }
+
+            _lastCascade = CASCADE_COUNT - 1;
+
+            // Compute a measure of variance, cumulative from low cascades to high
+            for (int i = 0; i < CASCADE_COUNT; i++)
+            {
+                // Accumulate from lower cascades
+                _cascadeParams[i]._cumulativeVariance = i > 0 ? _cascadeParams[i - 1]._cumulativeVariance : 0f;
+
+                var wl = MinWavelength(i) * 1.5f;
+                var octaveIndex = OceanWaveSpectrum.GetOctaveIndex(wl);
+                octaveIndex = Mathf.Min(octaveIndex, _spectrum._chopScales.Length - 1);
+
+                // Heuristic - horiz disp is roughly amp*chop, divide by wavelength to normalize
+                var amp = _spectrum.GetAmplitude(wl, 1f, out _);
+                var chop = _spectrum._chopScales[octaveIndex];
+                float amp_over_wl = chop * amp / wl;
+                _cascadeParams[i]._cumulativeVariance += amp_over_wl;
+            }
+            _cascadeParams[CASCADE_COUNT]._cumulativeVariance = _cascadeParams[CASCADE_COUNT - 1]._cumulativeVariance;
 
             _bufCascadeParams.SetData(_cascadeParams);
             _bufWaveData.SetData(_waveData);

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
@@ -266,7 +266,7 @@ namespace Crest
 
             for (int i = 0; i < _wavelengths.Length; i++)
             {
-                _amplitudes[i] = _weight * _spectrum.GetAmplitude(_wavelengths[i], _componentsPerOctave);
+                _amplitudes[i] = Random.value * _weight * _spectrum.GetAmplitude(_wavelengths[i], _componentsPerOctave, out _);
             }
         }
 

--- a/crest/Assets/Crest/Crest/Shaders/Ocean.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Ocean.shader
@@ -329,8 +329,7 @@ Shader "Crest/Ocean"
 					const float3 uv_slice_smallerLod = WorldToUV(positionWS_XZ_before, cascadeData0, _LD_SliceIndex);
 
 					#if !_DEBUGDISABLESHAPETEXTURES_ON
-					half sss = 0.;
-					SampleDisplacements(_LD_TexArray_AnimatedWaves, uv_slice_smallerLod, wt_smallerLod, o.worldPos, sss);
+					SampleDisplacements(_LD_TexArray_AnimatedWaves, uv_slice_smallerLod, wt_smallerLod, o.worldPos);
 					#endif
 
 					#if _FOAM_ON
@@ -346,8 +345,7 @@ Shader "Crest/Ocean"
 					const float3 uv_slice_biggerLod = WorldToUV(positionWS_XZ_before, cascadeData1, _LD_SliceIndex + 1);
 
 					#if !_DEBUGDISABLESHAPETEXTURES_ON
-					half sss = 0.;
-					SampleDisplacements(_LD_TexArray_AnimatedWaves, uv_slice_biggerLod, wt_biggerLod, o.worldPos, sss);
+					SampleDisplacements(_LD_TexArray_AnimatedWaves, uv_slice_biggerLod, wt_biggerLod, o.worldPos);
 					#endif
 
 					#if _FOAM_ON

--- a/crest/Assets/Crest/Crest/Shaders/OceanEmission.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanEmission.hlsl
@@ -144,10 +144,9 @@ void ApplyCaustics(in const half3 i_view, in const half3 i_lightDir, in const fl
 	const float3 scenePosUV = WorldToUV(scenePos.xz, cascadeData1, _LD_SliceIndex + 1);
 
 	half3 disp = 0.;
-	half sss = 0.;
 	// this gives height at displaced position, not exactly at query position.. but it helps. i cant pass this from vert shader
 	// because i dont know it at scene pos.
-	SampleDisplacements(_LD_TexArray_AnimatedWaves, scenePosUV, 1.0, disp, sss);
+	SampleDisplacements(_LD_TexArray_AnimatedWaves, scenePosUV, 1.0, disp);
 	half waterHeight = _OceanCenterPosWorld.y + disp.y;
 	half sceneDepth = waterHeight - scenePos.y;
 	// Compute mip index manually, with bias based on sea floor depth. We compute it manually because if it is computed automatically it produces ugly patches

--- a/crest/Assets/Crest/Crest/Shaders/OceanHelpersNew.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanHelpersNew.hlsl
@@ -71,9 +71,8 @@ void SampleDisplacementsNormals(in Texture2DArray i_dispSampler, in float3 i_uv_
 	// SSS - based off pinch
 #if _SUBSURFACESCATTERING_ON
 	{
-		// Don't use variance - yet
-		// float varianceBeforeThisCascade = data.w;
 		float2x2 jacobian = (float2x2(disp_x.xz, disp_z.xz) - disp.xzxz) / i_texelSize;
+		// Determinant is < 1 for pinched, < 0 for overlap/inversion
 		float det = determinant( jacobian );
 		io_sss += i_wt * saturate( 0.60 - det * 0.12 );
 	}

--- a/crest/Assets/Crest/Crest/Shaders/OceanHelpersNew.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanHelpersNew.hlsl
@@ -71,10 +71,12 @@ void SampleDisplacementsNormals(in Texture2DArray i_dispSampler, in float3 i_uv_
 	// SSS - based off pinch
 #if _SUBSURFACESCATTERING_ON
 	{
-		float2x2 jacobian = (float2x2(disp_x.xz, disp_z.xz) - disp.xzxz) / i_texelSize;
+		const float2x2 jacobian = (float2x2(disp_x.xz, disp_z.xz) - disp.xzxz) / i_texelSize;
 		// Determinant is < 1 for pinched, < 0 for overlap/inversion
-		float det = determinant( jacobian );
-		io_sss += i_wt * saturate( 0.60 - det * 0.12 );
+		const float det = determinant( jacobian );
+		const float sssMax = 0.6;
+		const float sssRange = 0.12;
+		io_sss += i_wt * saturate( sssMax - sssRange * det );
 	}
 #endif // _SUBSURFACESCATTERING_ON
 

--- a/crest/Assets/Crest/Crest/Shaders/OceanHelpersNew.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanHelpersNew.hlsl
@@ -69,6 +69,7 @@ void SampleDisplacementsNormals(in Texture2DArray i_dispSampler, in float3 i_uv_
 	}
 
 	// SSS - based off pinch
+#if _SUBSURFACESCATTERING_ON
 	{
 		// Don't use variance - yet
 		// float varianceBeforeThisCascade = data.w;
@@ -76,6 +77,7 @@ void SampleDisplacementsNormals(in Texture2DArray i_dispSampler, in float3 i_uv_
 		float det = determinant( jacobian );
 		io_sss += i_wt * saturate( 0.60 - det * 0.12 );
 	}
+#endif // _SUBSURFACESCATTERING_ON
 
 	io_nxz += i_wt * n.xz;
 }

--- a/crest/Assets/Crest/Crest/Shaders/OceanHelpersNew.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanHelpersNew.hlsl
@@ -7,6 +7,9 @@
 #ifndef CREST_OCEAN_HELPERS_H
 #define CREST_OCEAN_HELPERS_H
 
+#define SampleLod(i_lodTextureArray, i_uv_slice) (i_lodTextureArray.SampleLevel(LODData_linear_clamp_sampler, i_uv_slice, 0.0))
+#define SampleLodLevel(i_lodTextureArray, i_uv_slice, mips) (i_lodTextureArray.SampleLevel(LODData_linear_clamp_sampler, i_uv_slice, mips))
+
 float2 WorldToUV(in float2 i_samplePos, in CascadeParams i_cascadeParams)
 {
 	return (i_samplePos - i_cascadeParams._posSnapped) / (i_cascadeParams._texelWidth * i_cascadeParams._textureRes) + 0.5;
@@ -32,26 +35,48 @@ float2 IDtoUV(in float2 i_id, in float i_width, in float i_height)
 }
 
 // Sampling functions
-void SampleDisplacements(in Texture2DArray i_dispSampler, in float3 i_uv_slice, in float i_wt, inout float3 io_worldPos, inout half io_sss)
+
+// Displacements. Variance is a statistical measure of how many waves are in the smaller cascades (below this cascade slice). This gives a measure
+// of how much wave content is missing when we sample a particular LOD, and can be used to compensate. The foam sim uses it to compensate for missing
+// waves when computing surface pinch.
+void SampleDisplacements(in Texture2DArray i_dispSampler, in float3 i_uv_slice, in float i_wt, inout float3 io_worldPos, inout half io_variance)
 {
 	const half4 data = i_dispSampler.SampleLevel(LODData_linear_clamp_sampler, i_uv_slice, 0.0);
 	io_worldPos += i_wt * data.xyz;
-	io_sss += i_wt * data.a;
+	io_variance += i_wt * data.w;
+}
+
+void SampleDisplacements( in Texture2DArray i_dispSampler, in float3 i_uv_slice, in float i_wt, inout float3 io_worldPos )
+{
+	half unusedVariance = 0.0;
+	SampleDisplacements( i_dispSampler, i_uv_slice, i_wt, io_worldPos, unusedVariance );
 }
 
 void SampleDisplacementsNormals(in Texture2DArray i_dispSampler, in float3 i_uv_slice, in float i_wt, in float i_invRes, in float i_texelSize, inout float3 io_worldPos, inout half2 io_nxz, inout half io_sss)
 {
 	const half4 data = i_dispSampler.SampleLevel(LODData_linear_clamp_sampler, i_uv_slice, 0.0);
-	io_sss += i_wt * data.a;
 	const half3 disp = data.xyz;
 	io_worldPos += i_wt * disp;
 
-	float3 n; {
-		float3 dd = float3(i_invRes, 0.0, i_texelSize);
-		half3 disp_x = dd.zyy + i_dispSampler.SampleLevel(LODData_linear_clamp_sampler, i_uv_slice + float3(dd.xy, 0.0), dd.y).xyz;
-		half3 disp_z = dd.yyz + i_dispSampler.SampleLevel(LODData_linear_clamp_sampler, i_uv_slice + float3(dd.yx, 0.0), dd.y).xyz;
+	float3 dd = float3(i_invRes, 0.0, i_texelSize);
+	half3 disp_x = dd.zyy + i_dispSampler.SampleLevel( LODData_linear_clamp_sampler, i_uv_slice + float3(dd.xy, 0.0), 0.0 ).xyz;
+	half3 disp_z = dd.yyz + i_dispSampler.SampleLevel( LODData_linear_clamp_sampler, i_uv_slice + float3(dd.yx, 0.0), 0.0 ).xyz;
+
+	// Normal
+	float3 n;
+	{
 		n = normalize(cross(disp_z - disp, disp_x - disp));
 	}
+
+	// SSS - based off pinch
+	{
+		// Don't use variance - yet
+		// float varianceBeforeThisCascade = data.w;
+		float4 du = float4(disp_x.xz, disp_z.xz) - disp.xzxz;
+		float det = (du.x * du.w - du.y * du.z) / (i_texelSize * i_texelSize);
+		io_sss += i_wt * saturate( .03 * (20.0 - (det * 4.0 /*- varianceBeforeThisCascade * 20.0*/)) );
+	}
+
 	io_nxz += i_wt * n.xz;
 }
 
@@ -111,9 +136,6 @@ void PosToSliceIndices
 		lodAlpha = min(lodAlpha + _MeshScaleLerp, 1.0);
 	}
 }
-
-#define SampleLod(i_lodTextureArray, i_uv_slice) (i_lodTextureArray.SampleLevel(LODData_linear_clamp_sampler, i_uv_slice, 0.0))
-#define SampleLodLevel(i_lodTextureArray, i_uv_slice, mips) (i_lodTextureArray.SampleLevel(LODData_linear_clamp_sampler, i_uv_slice, mips))
 
 // Perform iteration to invert the displacement vector field - find position that displaces to query position.
 float3 InvertDisplacement

--- a/crest/Assets/Crest/Crest/Shaders/OceanHelpersNew.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanHelpersNew.hlsl
@@ -72,9 +72,9 @@ void SampleDisplacementsNormals(in Texture2DArray i_dispSampler, in float3 i_uv_
 	{
 		// Don't use variance - yet
 		// float varianceBeforeThisCascade = data.w;
-		float4 du = float4(disp_x.xz, disp_z.xz) - disp.xzxz;
-		float det = (du.x * du.w - du.y * du.z) / (i_texelSize * i_texelSize);
-		io_sss += i_wt * saturate( .03 * (20.0 - (det * 4.0 /*- varianceBeforeThisCascade * 20.0*/)) );
+		float2x2 jacobian = (float2x2(disp_x.xz, disp_z.xz) - disp.xzxz) / i_texelSize;
+		float det = determinant( jacobian );
+		io_sss += i_wt * saturate( 0.60 - det * 0.12 );
 	}
 
 	io_nxz += i_wt * n.xz;

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/AnimWavesAddFromTex.shader
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/AnimWavesAddFromTex.shader
@@ -6,11 +6,9 @@ Shader "Crest/Inputs/Animated Waves/Add From Texture"
 {
 	Properties
 	{
-		_MainTex("Texture", 2D) = "white" {}
+		_MainTex("Texture", 2D) = "black" {}
 		_Strength( "Strength", float ) = 1
 		[Toggle] _HeightsOnly("Heights Only", Float) = 1
-		[Toggle] _SSSFromAlpha("Sub Surface Scattering (SSS) from Alpha", Float) = 0
-		_SSSStrength("SSS Strength", Float) = 0.5
 	}
 
 	SubShader
@@ -27,7 +25,6 @@ Shader "Crest/Inputs/Animated Waves/Add From Texture"
 			#pragma fragment Frag
 
 			#pragma shader_feature_local _HEIGHTSONLY_ON
-			#pragma shader_feature_local _SSSFROMALPHA_ON
 
 			#include "UnityCG.cginc"
 
@@ -36,7 +33,6 @@ Shader "Crest/Inputs/Animated Waves/Add From Texture"
 			CBUFFER_START(CrestPerOceanInput)
 			float4 _MainTex_ST;
 			float _Strength;
-			float _SSSStrength;
 			float _Weight;
 			float3 _DisplacementAtInputPosition;
 			CBUFFER_END
@@ -68,22 +64,16 @@ Shader "Crest/Inputs/Animated Waves/Add From Texture"
 
 			half4 Frag(Varyings input) : SV_Target
 			{
-				half3 displacement = 0.0;
-				half sss = 0.0;
+				half3 texSample = tex2D(_MainTex, input.uv).xyz;
 
-				half4 texSample = tex2D(_MainTex, input.uv);
-
+				half3 displacement = (half3)0.0;
 #if _HEIGHTSONLY_ON
 				displacement.y = texSample.x * _Strength;
 #else
-				displacement.xyz = texSample.xyz * _Strength;
+				displacement.xyz = texSample * _Strength;
 #endif
 
-#if _SSSFROMALPHA_ON
-				sss = texSample.x * _SSSStrength;
-#endif
-
-				return _Weight * half4(displacement, sss);
+				return _Weight * half4(displacement, 0.0);
 			}
 
 			ENDCG

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/AnimWavesGerstnerBatchGeometry.shader
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/AnimWavesGerstnerBatchGeometry.shader
@@ -98,7 +98,7 @@ Shader "Crest/Inputs/Animated Waves/Gerstner Batch Geometry"
 				wt *= saturate(1.0 - (r_l1 - (0.5 - _FeatherWidth)) / _FeatherWidth);
 #endif
 
-				return wt * ComputeGerstner(input.worldPosXZ_uv.xy, input.uv_slice_wt.xyz);
+				return half4(wt * ComputeGerstner(input.worldPosXZ_uv.xy, input.uv_slice_wt.xyz), 0.0);
 			}
 			ENDCG
 		}

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/GerstnerShared.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/GerstnerShared.hlsl
@@ -23,10 +23,8 @@ half4 _ChopAmps[BATCH_SIZE / 4];
 float4 _TargetPointData;
 CBUFFER_END
 
-half4 ComputeGerstner(float2 worldPosXZ, float3 uv_slice)
+half3 ComputeGerstner(float2 worldPosXZ, float3 uv_slice)
 {
-	float2 displacementNormalized = 0.0;
-
 	// sample ocean depth (this render target should 1:1 match depth texture, so UVs are trivial)
 	const half depth = _LD_TexArray_SeaFloorDepth.Sample(LODData_linear_clamp_sampler, uv_slice).x;
 
@@ -81,13 +79,6 @@ half4 ComputeGerstner(float2 worldPosXZ, float3 uv_slice)
 		result.x += dot(resultx, wt);
 		result.y += dot(resulty, wt);
 		result.z += dot(resultz, wt);
-
-		half4 sssFactor = min(1.0, _TwoPiOverWavelengths[vi]);
-		displacementNormalized.x += dot(resultx * sssFactor, wt);
-		displacementNormalized.y += dot(resultz * sssFactor, wt);
 	}
-
-	half sss = length(displacementNormalized);
-
-	return _Weight * half4(result, sss);
+	return _Weight * result;
 }

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/AnimWavesGerstner.shader
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/AnimWavesGerstner.shader
@@ -78,9 +78,18 @@ Shader "Hidden/Crest/Inputs/Animated Waves/Gerstner Global"
 				wt *= attenuationAmount * depth_wt + (1.0 - attenuationAmount);
 
 				// Sample displacement, rotate into frame
-				float4 disp = _WaveBuffer.SampleLevel(sampler_Crest_linear_repeat, float3(input.uv_uvWaves.zw, _WaveBufferSliceIndex), 0);
-				disp.xz = disp.x * _AxisX + disp.z * float2(-_AxisX.y, _AxisX.x);
-				return wt * disp;
+				float4 disp_variance = _WaveBuffer.SampleLevel(sampler_Crest_linear_repeat, float3(input.uv_uvWaves.zw, _WaveBufferSliceIndex), 0);
+				disp_variance.xz = disp_variance.x * _AxisX + disp_variance.z * float2(-_AxisX.y, _AxisX.x);
+
+				// The large waves are added to the last two lods. Don't write cumulative variances for these - cumulative variance
+				// for the last fitting wave cascade captures everything needed.
+				const float minWavelength = _AverageWavelength / 1.5;
+				if( minWavelength > _CrestCascadeData[_LD_SliceIndex]._maxWavelength )
+				{
+					disp_variance.w = 0.0;
+				}
+
+				return wt * disp_variance;
 			}
 			ENDCG
 		}

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/AnimWavesGerstnerBatch.shader
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/AnimWavesGerstnerBatch.shader
@@ -59,7 +59,7 @@ Shader "Hidden/Crest/Inputs/Animated Waves/Gerstner Batch Global"
 
 			half4 Frag(Varyings input) : SV_Target
 			{
-				return ComputeGerstner(input.worldPosXZ, input.uv_slice);
+				return half4(ComputeGerstner(input.worldPosXZ, input.uv_slice), 0.0);
 			}
 			ENDCG
 		}

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputsDriven.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputsDriven.hlsl
@@ -21,8 +21,7 @@ struct CascadeParams
 	float _oneOverTextureRes;
 	float _texelWidth;
 	float _weight;
-	// Align to 32 bytes
-	float __padding;
+	float _maxWavelength;
 };
 
 StructuredBuffer<CascadeParams> _CrestCascadeData;

--- a/crest/Assets/Crest/Crest/Shaders/OceanSurfaceAlpha.shader
+++ b/crest/Assets/Crest/Crest/Shaders/OceanSurfaceAlpha.shader
@@ -88,20 +88,21 @@ Shader "Crest/Ocean Surface Alpha"
 
 				// sample displacement textures, add results to current world pos / normal / foam
 				half foam = 0.0;
-				half sss = 0.;
 				// sample weight. params.z allows shape to be faded out (used on last lod to support pop-less scale transitions)
 				const float cascadeWt0 = cascadeData0._weight;
 				float wt_smallerLod = (1.0 - lodAlpha) * cascadeWt0;
 				{
 					const float3 uv_slice = WorldToUV(worldPos.xz, cascadeData0, _LD_SliceIndex);
-					SampleDisplacements(_LD_TexArray_AnimatedWaves, uv_slice, wt_smallerLod, worldPos, sss);
+					half variance = 0.0;
+					SampleDisplacements(_LD_TexArray_AnimatedWaves, uv_slice, wt_smallerLod, worldPos, variance);
 				}
 				{
 					// sample weight. params.z allows shape to be faded out (used on last lod to support pop-less scale transitions)
 					const float cascadeWt1 = cascadeData1._weight;
 					const float wt_biggerLod = (1.0 - wt_smallerLod) * cascadeWt1;
 					const float3 uv_slice = WorldToUV(worldPos.xz, cascadeData1, _LD_SliceIndex + 1);
-					SampleDisplacements(_LD_TexArray_AnimatedWaves, uv_slice, wt_biggerLod, worldPos, sss);
+					half variance = 0.0;
+					SampleDisplacements(_LD_TexArray_AnimatedWaves, uv_slice, wt_biggerLod, worldPos, variance);
 				}
 
 				// move to sea level

--- a/crest/Assets/Crest/Crest/Shaders/Resources/Gerstner.compute
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/Gerstner.compute
@@ -18,6 +18,7 @@ uint _FirstCascadeIndex;
 struct GerstnerCascadeParams
 {
 	int _startIndex;
+	float _cumulativeVariance;
 };
 StructuredBuffer<GerstnerCascadeParams> _GerstnerCascadeParams;
 
@@ -35,7 +36,7 @@ StructuredBuffer<GerstnerWaveComponent4> _GerstnerWaveData;
 
 RWTexture2DArray<half4> _WaveBuffer;
 
-void ComputeGerstner( float2 worldPosXZ, float worldSize, GerstnerWaveComponent4 data, inout float3 result, inout float2 displacementNormalized )
+void ComputeGerstner( float2 worldPosXZ, float worldSize, GerstnerWaveComponent4 data, inout float3 result )
 {
 	// direction
 	half4 Dx = data._waveDirX;
@@ -63,10 +64,6 @@ void ComputeGerstner( float2 worldPosXZ, float worldSize, GerstnerWaveComponent4
 	result.x += dot( resultx, 1.0 );
 	result.y += dot( resulty, 1.0 );
 	result.z += dot( resultz, 1.0 );
-
-	half4 sssFactor = min( 1.0, data._twoPiOverWavelength );
-	displacementNormalized.x += dot( resultx, sssFactor );
-	displacementNormalized.y += dot( resultz, sssFactor );
 }
 
 [numthreads(THREAD_GROUP_SIZE_X, THREAD_GROUP_SIZE_Y, 1)]
@@ -80,17 +77,18 @@ void Gerstner(uint3 id : SV_DispatchThreadID)
 	const float2 worldPosXZ = (id.xy + 0.5) * texelWidth;
 
 	float3 result = 0.0;
-	float2 displacementNormalized = 0.0;
 
 	const int startIndex = _GerstnerCascadeParams[cascadeIndex]._startIndex;
 	const int endIndex = _GerstnerCascadeParams[cascadeIndex + 1]._startIndex;
 	for( int i = startIndex; i < endIndex; i++ )
 	{
 		// Sum up waves from another buffer
-		ComputeGerstner( worldPosXZ, worldSize, _GerstnerWaveData[i], result, displacementNormalized );
+		ComputeGerstner( worldPosXZ, worldSize, _GerstnerWaveData[i], result );
 	}
 
-	half sss = length( displacementNormalized );
+	// Get variance term up until just before this cascade. Gives a statistical measure of wave content
+	// in lower cascades.
+	float _cumulativeVarianceBeforeThisCascade = cascadeIndex > 0 ? _GerstnerCascadeParams[cascadeIndex - 1]._cumulativeVariance : 0.0;
 
-	_WaveBuffer[uint3(id.xy, cascadeIndex)] = float4(result, sss);
+	_WaveBuffer[uint3(id.xy, cascadeIndex)] = float4(result, _cumulativeVarianceBeforeThisCascade);
 }

--- a/crest/Assets/Crest/Crest/Shaders/Resources/ShapeCombine.compute
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/ShapeCombine.compute
@@ -39,7 +39,7 @@ void Flow(in const CascadeParams cascadeData, out float2 offsets, out float2 wei
 void SampleDisplacementsCompute(
 	in RWTexture2DArray<half4> i_dispSampler,
 	in float i_width, in float i_height, in float3 i_uv_slice,
-	in float i_wt, inout float3 io_worldPos, inout half io_sss
+	in float i_wt, inout float3 io_worldPos
 ) {
 	// NOTE: We have to roll our own bilinear filter in Compute shaders when
 	// reading from a RWTexture. The documentation below explains how SRV
@@ -72,7 +72,6 @@ void SampleDisplacementsCompute(
 	);
 
 	io_worldPos += i_wt * dataLerped.xyz;
-	io_sss += dataLerped.a;
 }
 
 void ShapeCombineBase(uint3 id)
@@ -94,8 +93,9 @@ void ShapeCombineBase(uint3 id)
 	float3 uv_thisLod = float3(input_uv, _LD_SliceIndex);
 
 	float3 result = 0.0;
-	half sss = 0.;
-	// Sample in waves for this cascade
+	half variance = 0.0;
+
+	// Sample in waves for this cascade.
 #if _FLOW_ON
 	half2 flow = 0.0;
 	SampleFlow(_LD_TexArray_Flow, uv_thisLod, 1.0, flow);
@@ -105,14 +105,16 @@ void ShapeCombineBase(uint3 id)
 
 	const float3 uv_thisLod_flow_0 = WorldToUV(worldPosXZ - offsets[0] * flow, cascadeData0, _LD_SliceIndex);
 	const float3 uv_thisLod_flow_1 = WorldToUV(worldPosXZ - offsets[1] * flow, cascadeData0, _LD_SliceIndex);
-	SampleDisplacements(_LD_TexArray_WaveBuffer, uv_thisLod_flow_0, weights[0], result, sss);
-	SampleDisplacements(_LD_TexArray_WaveBuffer, uv_thisLod_flow_1, weights[1], result, sss);
+	SampleDisplacements(_LD_TexArray_WaveBuffer, uv_thisLod_flow_0, weights[0], result, variance );
+	SampleDisplacements(_LD_TexArray_WaveBuffer, uv_thisLod_flow_1, weights[1], result, variance );
 #else
-	SampleDisplacements(_LD_TexArray_WaveBuffer, uv_thisLod, 1.0, result, sss);
+	SampleDisplacements(_LD_TexArray_WaveBuffer, uv_thisLod, 1.0, result, variance);
 #endif // _FLOW_ON
 
 #if !_DISABLE_COMBINE
-	SampleDisplacementsCompute(_LD_TexArray_AnimatedWaves_Compute, width, height, uv_nextLod, 1.0, result, sss);
+	// Waves to combine down from the next lod up the chain.
+	// Do not combine variance. Variance is already cumulative - from low cascades up.
+	SampleDisplacementsCompute(_LD_TexArray_AnimatedWaves_Compute, width, height, uv_nextLod, 1.0, result);
 #endif
 
 #if _DYNAMIC_WAVE_SIM_ON
@@ -142,7 +144,7 @@ void ShapeCombineBase(uint3 id)
 	}
 #endif // _DYNAMIC_WAVE_SIM_ON
 
-	_LD_TexArray_AnimatedWaves_Compute[uint3(id.xy, _LD_SliceIndex)] = half4(result, sss);
+	_LD_TexArray_AnimatedWaves_Compute[uint3(id.xy, _LD_SliceIndex)] = half4(result, variance);
 }
 
 

--- a/crest/Assets/Crest/Crest/Shaders/Resources/ShapeCombine.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/ShapeCombine.shader
@@ -76,8 +76,9 @@ Shader "Hidden/Crest/Simulation/Combine Animated Wave LODs"
 				const float3 uv_nextLod = WorldToUV(worldPosXZ, cascadeData1, _LD_SliceIndex + 1);
 
 				float3 result = 0.0;
-				half sss = 0.0;
+				float variance = 0.0;
 
+				// Sample in waves for this cascade.
 #if CREST_FLOW_ON_INTERNAL
 				half2 flow = 0.0;
 				SampleFlow(_LD_TexArray_Flow, uv_thisLod, 1.0, flow);
@@ -87,12 +88,12 @@ Shader "Hidden/Crest/Simulation/Combine Animated Wave LODs"
 
 				const float3 uv_thisLod_flow_0 = WorldToUV(worldPosXZ - offsets[0] * flow, cascadeData0, _LD_SliceIndex);
 				const float3 uv_thisLod_flow_1 = WorldToUV(worldPosXZ - offsets[1] * flow, cascadeData0, _LD_SliceIndex);
-				SampleDisplacements(_LD_TexArray_WaveBuffer, uv_thisLod_flow_0, weights[0], result, sss);
-				SampleDisplacements(_LD_TexArray_WaveBuffer, uv_thisLod_flow_1, weights[1], result, sss);
+				SampleDisplacements(_LD_TexArray_WaveBuffer, uv_thisLod_flow_0, weights[0], result, variance);
+				SampleDisplacements(_LD_TexArray_WaveBuffer, uv_thisLod_flow_1, weights[1], result, variance);
 #else
 				float4 data = _LD_TexArray_WaveBuffer.SampleLevel(LODData_linear_clamp_sampler, uv_thisLod, 0.0);
-				result += data.xyz;
-				sss = data.w;
+				result = data.xyz;
+				variance = data.w;
 #endif // CREST_FLOW_ON_INTERNAL
 
 				float arrayDepth;
@@ -101,12 +102,12 @@ Shader "Hidden/Crest/Simulation/Combine Animated Wave LODs"
 					_LD_TexArray_AnimatedWaves.GetDimensions(w, h, arrayDepth);
 				}
 
-				// waves to combine down from the next lod up the chain
+				// Waves to combine down from the next lod up the chain.
 				if ((float)_LD_SliceIndex < arrayDepth - 1.0)
 				{
 					float4 dataNextLod = _LD_TexArray_AnimatedWaves.SampleLevel(LODData_linear_clamp_sampler, uv_nextLod, 0.0);
 					result += dataNextLod.xyz;
-					sss += dataNextLod.w;
+					// Do not combine variance. Variance is already cumulative - from low cascades up
 				}
 
 #if CREST_DYNAMIC_WAVE_SIM_ON_INTERNAL
@@ -136,7 +137,7 @@ Shader "Hidden/Crest/Simulation/Combine Animated Wave LODs"
 				}
 #endif // CREST_DYNAMIC_WAVE_SIM_ON_INTERNAL
 
-				return half4(result, sss);
+				return half4(result, variance);
 			}
 			ENDCG
 		}

--- a/crest/Assets/Crest/Crest/Shaders/Resources/UpdateFoam.compute
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/UpdateFoam.compute
@@ -69,9 +69,11 @@ void UpdateFoam(uint3 id : SV_DispatchThreadID)
 	// fade
 	foam *= max(0.0, 1.0 - _FoamFadeRate * _SimDeltaTime);
 
-	// sample displacement texture and generate foam from it
+	// Sample displacement texture and generate foam from it
 	const float3 dd = float3(cascadeData._oneOverTextureRes, 0.0, cascadeData._texelWidth);
-	half3 s = SampleLod(_LD_TexArray_AnimatedWaves, uv_slice).xyz;
+	half4 data = SampleLod( _LD_TexArray_AnimatedWaves, uv_slice );
+	half3 s = data.xyz;
+	float foamBase = data.w;
 	half3 sx = SampleLodLevel(_LD_TexArray_AnimatedWaves, uv_slice + float3(dd.xy, 0.0), dd.y).xyz;
 	half3 sz = SampleLodLevel(_LD_TexArray_AnimatedWaves, uv_slice + float3(dd.yx, 0.0), dd.y).xyz;
 	float3 disp = s.xyz;
@@ -83,9 +85,9 @@ void UpdateFoam(uint3 id : SV_DispatchThreadID)
 	// < 0: Overlap
 	float4 du = float4(disp_x.xz, disp_z.xz) - disp.xzxz;
 	float det = (du.x * du.w - du.y * du.z) / (cascadeData._texelWidth * cascadeData._texelWidth);
-	foam += 5.0 * _SimDeltaTime * _WaveFoamStrength * saturate(_WaveFoamCoverage - det);
+	foam += 5.0 * _SimDeltaTime * _WaveFoamStrength * saturate( _WaveFoamCoverage - det + foamBase*0.7 );
 
-	// add foam in shallow water. use the displaced position to ensure we add foam where world objects are.
+	// Add foam in shallow water. use the displaced position to ensure we add foam where world objects are.
 	const float3 uv_slice_displaced = WorldToUV(worldPosXZ + disp.xz, cascadeData, sliceIndex);
 	float signedOceanDepth = SampleLodLevel(_LD_TexArray_SeaFloorDepth, uv_slice_displaced, 0.0).x + disp.y;
 	foam += _ShorelineFoamStrength * _SimDeltaTime * saturate(1.0 - signedOceanDepth / _ShorelineFoamMaxDepth);

--- a/crest/Assets/Crest/Crest/Shaders/Resources/UpdateFoam.compute
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/UpdateFoam.compute
@@ -83,8 +83,9 @@ void UpdateFoam(uint3 id : SV_DispatchThreadID)
 	// > 1: Stretch
 	// < 1: Squash
 	// < 0: Overlap
-	float4 du = float4(disp_x.xz, disp_z.xz) - disp.xzxz;
-	float det = (du.x * du.w - du.y * du.z) / (cascadeData._texelWidth * cascadeData._texelWidth);
+	const float2x2 jacobian = (float2x2(disp_x.xz, disp_z.xz) - disp.xzxz) / cascadeData._texelWidth;
+	// Determinant is < 1 for pinched, < 0 for overlap/inversion
+	const float det = determinant( jacobian );
 	foam += 5.0 * _SimDeltaTime * _WaveFoamStrength * saturate( _WaveFoamCoverage - det + foamBase * 0.7 );
 
 	// Add foam in shallow water. use the displaced position to ensure we add foam where world objects are.

--- a/crest/Assets/Crest/Crest/Shaders/Resources/UpdateFoam.compute
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/UpdateFoam.compute
@@ -85,7 +85,7 @@ void UpdateFoam(uint3 id : SV_DispatchThreadID)
 	// < 0: Overlap
 	float4 du = float4(disp_x.xz, disp_z.xz) - disp.xzxz;
 	float det = (du.x * du.w - du.y * du.z) / (cascadeData._texelWidth * cascadeData._texelWidth);
-	foam += 5.0 * _SimDeltaTime * _WaveFoamStrength * saturate( _WaveFoamCoverage - det + foamBase*0.7 );
+	foam += 5.0 * _SimDeltaTime * _WaveFoamStrength * saturate( _WaveFoamCoverage - det + foamBase * 0.7 );
 
 	// Add foam in shallow water. use the displaced position to ensure we add foam where world objects are.
 	const float3 uv_slice_displaced = WorldToUV(worldPosXZ + disp.xz, cascadeData, sliceIndex);

--- a/crest/Assets/Crest/Crest/Shaders/Underwater/UnderwaterCurtain.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Underwater/UnderwaterCurtain.shader
@@ -199,14 +199,10 @@ Shader "Crest/Underwater Curtain"
 				const half3 n_pixel = 0.0;
 				const half3 bubbleCol = 0.0;
 
-				float3 dummy = 0.0;
-				half sss = 0.;
-				const float3 uv_slice = WorldToUV(_WorldSpaceCameraPos.xz, cascadeData0, _LD_SliceIndex);
-				SampleDisplacements(_LD_TexArray_AnimatedWaves, uv_slice, 1.0, dummy, sss);
-
-				// depth and shadow are computed in ScatterColour when underwater==true, using the LOD1 texture.
+				// Depth and shadow are computed in ScatterColour when underwater==true, using the LOD1 texture. SSS is ommitted for now for perf reasons.
 				const float depth = 0.0;
 				const half shadow = 1.0;
+				const half sss = 0.0;
 
 				const float meshScaleLerp = _CrestPerCascadeInstanceData[_LD_SliceIndex]._meshScaleLerp;
 				const float baseCascadeScale = _CrestCascadeData[0]._scale;

--- a/crest/Assets/Crest/Crest/Shaders/Underwater/UnderwaterShared.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/Underwater/UnderwaterShared.hlsl
@@ -19,9 +19,8 @@ float IntersectRayWithWaterSurface(const float3 pos, const float3 dir, in const 
 	{
 		// Sample displacement textures, add results to current world pos / normal / foam
 		disp = float3(sampleXZ.x, _OceanCenterPosWorld.y, sampleXZ.y);
-		half sss = 0.;
 		const float3 uv = WorldToUV(sampleXZ, cascadeData, _LD_SliceIndex);
-		SampleDisplacements(_LD_TexArray_AnimatedWaves, uv, 1.0, disp, sss);
+		SampleDisplacements(_LD_TexArray_AnimatedWaves, uv, 1.0, disp);
 		float3 nearestPointOnRay = pos + dir * dot(disp - pos, dir);
 		const float2 error = disp.xz - nearestPointOnRay.xz;
 		sampleXZ -= error;
@@ -29,9 +28,8 @@ float IntersectRayWithWaterSurface(const float3 pos, const float3 dir, in const 
 	{
 		// Sample displacement textures, add results to current world pos / normal / foam
 		disp = float3(sampleXZ.x, _OceanCenterPosWorld.y, sampleXZ.y);
-		half sss = 0.;
 		const float3 uv = WorldToUV(sampleXZ, cascadeData, _LD_SliceIndex);
-		SampleDisplacements(_LD_TexArray_AnimatedWaves, uv, 1.0, disp, sss);
+		SampleDisplacements(_LD_TexArray_AnimatedWaves, uv, 1.0, disp);
 		float3 nearestPointOnRay = pos + dir * dot(disp - pos, dir);
 		const float2 error = disp.xz - nearestPointOnRay.xz;
 		sampleXZ -= error;
@@ -39,9 +37,8 @@ float IntersectRayWithWaterSurface(const float3 pos, const float3 dir, in const 
 	{
 		// Sample displacement textures, add results to current world pos / normal / foam
 		disp = float3(sampleXZ.x, _OceanCenterPosWorld.y, sampleXZ.y);
-		half sss = 0.;
 		const float3 uv = WorldToUV(sampleXZ, cascadeData, _LD_SliceIndex);
-		SampleDisplacements(_LD_TexArray_AnimatedWaves, uv, 1.0, disp, sss);
+		SampleDisplacements(_LD_TexArray_AnimatedWaves, uv, 1.0, disp);
 		float3 nearestPointOnRay = pos + dir * dot(disp - pos, dir);
 		const float2 error = disp.xz - nearestPointOnRay.xz;
 		sampleXZ -= error;
@@ -49,9 +46,8 @@ float IntersectRayWithWaterSurface(const float3 pos, const float3 dir, in const 
 	{
 		// Sample displacement textures, add results to current world pos / normal / foam
 		disp = float3(sampleXZ.x, _OceanCenterPosWorld.y, sampleXZ.y);
-		half sss = 0.;
 		const float3 uv = WorldToUV(sampleXZ, cascadeData, _LD_SliceIndex);
-		SampleDisplacements(_LD_TexArray_AnimatedWaves, uv, 1.0, disp, sss);
+		SampleDisplacements(_LD_TexArray_AnimatedWaves, uv, 1.0, disp);
 		float3 nearestPointOnRay = pos + dir * dot(disp - pos, dir);
 		const float2 error = disp.xz - nearestPointOnRay.xz;
 		sampleXZ -= error;
@@ -59,9 +55,8 @@ float IntersectRayWithWaterSurface(const float3 pos, const float3 dir, in const 
 	{
 		// Sample displacement textures, add results to current world pos / normal / foam
 		disp = float3(sampleXZ.x, _OceanCenterPosWorld.y, sampleXZ.y);
-		half sss = 0.;
 		const float3 uv = WorldToUV(sampleXZ, cascadeData, _LD_SliceIndex);
-		SampleDisplacements(_LD_TexArray_AnimatedWaves, uv, 1.0, disp, sss);
+		SampleDisplacements(_LD_TexArray_AnimatedWaves, uv, 1.0, disp);
 		float3 nearestPointOnRay = pos + dir * dot(disp - pos, dir);
 		const float2 error = disp.xz - nearestPointOnRay.xz;
 		sampleXZ -= error;
@@ -69,9 +64,8 @@ float IntersectRayWithWaterSurface(const float3 pos, const float3 dir, in const 
 	{
 		// Sample displacement textures, add results to current world pos / normal / foam
 		disp = float3(sampleXZ.x, _OceanCenterPosWorld.y, sampleXZ.y);
-		half sss = 0.;
 		const float3 uv = WorldToUV(sampleXZ, cascadeData, _LD_SliceIndex);
-		SampleDisplacements(_LD_TexArray_AnimatedWaves, uv, 1.0, disp, sss);
+		SampleDisplacements(_LD_TexArray_AnimatedWaves, uv, 1.0, disp);
 		float3 nearestPointOnRay = pos + dir * dot(disp - pos, dir);
 		const float2 error = disp.xz - nearestPointOnRay.xz;
 		sampleXZ -= error;


### PR DESCRIPTION
**Status**: Ready for review. I have arranged these changes into logical commits so reviewing by-commit is a good option.

**Overview**:
Wave variance is statistical measure of how many waves there are in each slice of the displacement cascade. When sampling a low LOD of the waves, there are a lot of small wavelengths missing. The variance is a measure of the cumulative amount of missing content for a given slice. This measure can be used to compensate for the missing data. The killer use case of this is the foam at wave crests - right now we dont get foam at all in the mid-to-background as the pinchy waves are missing from the lower lods. The variance is used to compensate for this missing data and foam is now generated reliably at all LODs.

The variance is stored in the W channel of the displacement texture. Variance can be spatially varying so its put into the textures rather than factored out. This channel used to be used for SSS. **SSS has been moved away from this channel and put back into the ocean shader which computes it from surface pinch**. This is the way it used to be originally, and the results are very comparable.

Variance can in theory be useful for accounting for missing waves when approximating SSS, and also for driving surface material roughness in the distance. I didnt have a good fail case for the former, so i've left it disabled for now. I had a quick stab at the latter and it did work, but needs more love to make it mergeable, and it wasnt clear that driving it procedurally was a good idea rather than setting it manually, and this experiment is parked in `feature/variance-roughness`.

This only works with the new gerstner system. For the old gerstner system, the behaviour is unchanged from what it was before (the variance measure will just come through as 0 and have no impact).

**Testing**:
I have set up main.unity with the new gerstner component so can be used to test the changes.
