### PR TITLE
Fix gaps and cracks issues

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -812,6 +812,7 @@ namespace Crest
             // Don't land very close to regular positions where things are likely to snap to, because different tiles might
             // land on either side of a snap boundary due to numerical error and snap to the wrong positions. Nudge away from
             // common by using increments of 1/60 which have lots of factors.
+            // :OceanGridPrecisionErrors
             if (Mathf.Abs(pos.x * 60f - Mathf.Round(pos.x * 60f)) < 0.001f)
             {
                 pos.x += 0.002f;

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -809,6 +809,18 @@ namespace Crest
             // maintain y coordinate - sea level
             pos.y = Root.position.y;
 
+            // Don't land very close to regular positions where things are likely to snap to, because different tiles might
+            // land on either side of a snap boundary due to numerical error and snap to the wrong positions. Nudge away from
+            // common by using increments of 1/60 which have lots of factors.
+            if (Mathf.Abs(pos.x * 60f - Mathf.Round(pos.x * 60f)) < 0.001f)
+            {
+                pos.x += 0.002f;
+            }
+            if (Mathf.Abs(pos.z * 60f - Mathf.Round(pos.z * 60f)) < 0.001f)
+            {
+                pos.z += 0.002f;
+            }
+
             Root.position = pos;
 
             Shader.SetGlobalVector(sp_oceanCenterPosWorld, Root.position);

--- a/crest/Assets/Crest/Crest/Shaders/Ocean.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Ocean.shader
@@ -291,10 +291,6 @@ Shader "Crest/Ocean"
 				UNITY_INITIALIZE_OUTPUT(Varyings, o);
 				UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
 
-				// Scale up by small "epsilon" to solve numerical issues.
-				// :OceanGridPrecisionErrors
-				v.vertex.xyz *= 1.00001;
-
 				const CascadeParams cascadeData0 = _CrestCascadeData[_LD_SliceIndex];
 				const CascadeParams cascadeData1 = _CrestCascadeData[_LD_SliceIndex + 1];
 				const PerCascadeInstanceData instanceData = _CrestPerCascadeInstanceData[_LD_SliceIndex];
@@ -307,6 +303,12 @@ Shader "Crest/Ocean"
 				const float meshScaleLerp = instanceData._meshScaleLerp;
 				const float gridSize = instanceData._geoGridWidth;
 				SnapAndTransitionVertLayout(meshScaleLerp, cascadeData0, gridSize, o.worldPos, lodAlpha);
+
+				// Scale up by small "epsilon" to solve numerical issues. Expand slightly about tile center.
+				// :OceanGridPrecisionErrors
+				const float2 tileCenterXZ = UNITY_MATRIX_M._m03_m23;
+				o.worldPos.xz = lerp( tileCenterXZ, o.worldPos.xz, 1.0001 );
+
 				o.lodAlpha_worldXZUndisplaced_oceanDepth.x = lodAlpha;
 				o.lodAlpha_worldXZUndisplaced_oceanDepth.yz = o.worldPos.xz;
 

--- a/crest/Assets/Crest/Crest/Shaders/OceanVertHelpers.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanVertHelpers.hlsl
@@ -33,8 +33,6 @@ float ComputeLodAlpha(float3 i_worldPos, float i_meshScaleAlpha, in const Cascad
 
 void SnapAndTransitionVertLayout(in const float i_meshScaleAlpha, in const CascadeParams i_cascadeData0, in const float i_geometryGridSize, inout float3 io_worldPos, out float o_lodAlpha)
 {
-	// Grid includes small "epsilon" to solve numerical issues.
-	// :OceanGridPrecisionErrors
 	const float GRID_SIZE_2 = 2.0 * i_geometryGridSize, GRID_SIZE_4 = 4.0 * i_geometryGridSize;
 
 	// snap the verts to the grid

--- a/crest/Assets/Crest/Crest/Shaders/OceanVertHelpers.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanVertHelpers.hlsl
@@ -35,7 +35,7 @@ void SnapAndTransitionVertLayout(in const float i_meshScaleAlpha, in const Casca
 {
 	// Grid includes small "epsilon" to solve numerical issues.
 	// :OceanGridPrecisionErrors
-	const float GRID_SIZE_2 = 2.000001 * i_geometryGridSize, GRID_SIZE_4 = 4.0 * i_geometryGridSize;
+	const float GRID_SIZE_2 = 2.0 * i_geometryGridSize, GRID_SIZE_4 = 4.0 * i_geometryGridSize;
 
 	// snap the verts to the grid
 	// The snap size should be twice the original size to keep the shape of the eight triangles (otherwise the edge layout changes).


### PR DESCRIPTION
**Status**: Ready to merge

Fix for two issues, both tracked by #665 

**Gaps**: When ocean placed near a regular position (such as an integral boundary or multiple of 0.333333, etc), precision issues related either to how transforms propagate in the unity hierarchy or how the values arrive to the shader mean different tiles can snap to different locations and leave a gap. This adds a slight nudge to push the ocean away from a bunch of common boundaries). The nudge is very small and will not affect the ocean simulation/rendering as everything snaps to much larger values than the nudge. In the future, if gaps appear, it may be the boundary is not on 1/60. The boundary might be lod resolution / lod 0 width. If we get a report of gaps, we should get the camera transform and oceanrenderer settings, and see if we can compute the boundary.

**Thin cracks**: The scale of each tile is increased by a small epsilon. This should be subpixel, but should be large enough to overcome precision issues. If cracks appear in the future, this value could be increased. It might be that this value is too small when far from the origin, we could potentially scale the epsilon by dist from origin to help combat this if needed.

@daleeidd could you let me know what you think and please give this a run on mac if you could. Thanks!
