### PR TITLE
Orthographic Projection

### DIFF
--- a/USERGUIDE.md
+++ b/USERGUIDE.md
@@ -70,6 +70,14 @@ This base reflection can then be overridden by dynamic planar reflections. This 
 
 A good strategy for debugging the use of Unity's specular cubemap is to put another reflective/glossy object in the scene near the surface, and verify that it is lit and reflects the scene properly. Crest tries to use the same inputs for lighting/reflections, so if it works for a test object it should work for the water surface as well.
 
+### Orthographic Projection
+
+Crest supports orthographic projection out-of-the-box, but it might require some configuration to get a desired appearance.
+
+Crest uses the camera's position for the LOD system which can be awkward for orthographic which uses the size property on the camera.
+Use the *Viewpoint* property on the *Ocean Renderer* to override the camera's position.
+
+Underwater effects do *not* support orthographic projection.
 
 ## Ocean construction parameters
 
@@ -484,3 +492,6 @@ The density of the fog underwater can be controlled using the *Fog Density* para
 
 **My terrain does not appear to affect the water - no shorelines or shallow water waves.**
 This built-in render pipeline version of crest requires the *Draw Instanced* option on terrains to be disabled at start time. It can be re-enabled subsequently after the depth cache is populated. See issue #158.
+
+**Does Crest support orthographic projection?**
+It does. Please see the [Orthographic Projection](#orthographic-projection) section.

--- a/crest/Assets/Crest/Crest/Shaders/Ocean.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Ocean.shader
@@ -240,7 +240,7 @@ Shader "Crest/Ocean"
 			#pragma shader_feature_local _CLIPSURFACE_ON
 			#pragma shader_feature_local _CLIPUNDERTERRAIN_ON
 
-			#pragma multi_compile_local _PROJECTION_BOTH _PROJECTION_PERSPECTIVE _PROJECTION_ORTHOGRAPHIC
+			#pragma shader_feature_local _PROJECTION_BOTH _PROJECTION_PERSPECTIVE _PROJECTION_ORTHOGRAPHIC
 
 			#pragma shader_feature_local _DEBUGDISABLESHAPETEXTURES_ON
 			#pragma shader_feature_local _DEBUGVISUALISESHAPESAMPLE_ON

--- a/crest/Assets/Crest/Crest/Shaders/OceanEmission.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanEmission.hlsl
@@ -195,7 +195,7 @@ void ApplyCaustics(in const half3 i_view, in const half3 i_lightDir, in const fl
 
 
 half3 OceanEmission(in const half3 i_view, in const half3 i_n_pixel, in const float3 i_lightDir,
-	in const half4 i_grabPos, in const float i_pixelZ, in const half2 i_uvDepth, in const float i_sceneZ, in const float i_sceneZ01,
+	in const half4 i_grabPos, in const float i_pixelZ, in const half2 i_uvDepth, in const float i_sceneZ,
 	in const half3 i_bubbleCol, in sampler2D i_normals, in const bool i_underwater, in const half3 i_scatterCol,
 	in const CascadeParams cascadeData0, in const CascadeParams cascadeData1)
 {
@@ -217,7 +217,9 @@ half3 OceanEmission(in const half3 i_view, in const half3 i_n_pixel, in const fl
 	if (!i_underwater)
 	{
 		const half2 refractOffset = _RefractionStrength * i_n_pixel.xz * min(1.0, 0.5*(i_sceneZ - i_pixelZ)) / i_sceneZ;
-		const float sceneZRefract = LinearEyeDepth(UNITY_SAMPLE_SCREENSPACE_TEXTURE(_CameraDepthTexture, i_uvDepth + refractOffset).x);
+		// Raw depth is logarithmic for perspective, and linear (0-1) for orthographic.
+		const float rawDepth = SAMPLE_DEPTH_TEXTURE(_CameraDepthTexture, i_uvDepth + refractOffset).x;
+		const float sceneZRefract = CrestLinearEyeDepth(rawDepth);
 		half2 uvBackgroundRefract;
 
 		// Compute depth fog alpha based on refracted position if it landed on an underwater surface, or on unrefracted depth otherwise

--- a/crest/Assets/Crest/Crest/Shaders/OceanShaderHelpers.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanShaderHelpers.hlsl
@@ -1,0 +1,43 @@
+// Crest Ocean System
+
+// This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
+
+// Helpers that will only be used when rendering to a screen (eg depth, lighting etc).
+
+#ifndef CREST_OCEAN_SHADER_HELPERS_H
+#define CREST_OCEAN_SHADER_HELPERS_H
+
+float CrestLinearEyeDepth(const float i_rawDepth)
+{
+#if defined(_PROJECTION_BOTH) || defined(_PROJECTION_PERSPECTIVE)
+	// Handles UNITY_REVERSED_Z for us.
+	float perspective = LinearEyeDepth(i_rawDepth);
+#endif // _PROJECTION
+
+#if defined(_PROJECTION_BOTH) || defined(_PROJECTION_ORTHOGRAPHIC)
+	// Orthographic Depth taken and modified from:
+	// https://github.com/keijiro/DepthInverseProjection/blob/master/Assets/InverseProjection/Resources/InverseProjection.shader
+	float near = _ProjectionParams.y;
+	float far  = _ProjectionParams.z;
+	float isOrthographic = unity_OrthoParams.w;
+
+#if defined(UNITY_REVERSED_Z)
+	float orthographic = lerp(far, near, i_rawDepth);
+#else
+	float orthographic = lerp(near, far, i_rawDepth);
+#endif // UNITY_REVERSED_Z
+#endif // _PROJECTION
+
+#if defined(_PROJECTION_BOTH)
+	return lerp(perspective, orthographic, isOrthographic);
+#elif defined(_PROJECTION_ORTHOGRAPHIC)
+	return orthographic;
+#elif defined(_PROJECTION_PERSPECTIVE)
+	return perspective;
+#else
+	// If a shader does not have the projection enumeration, then assume they want perspective.
+	return LinearEyeDepth(i_rawDepth);
+#endif // _PROJECTION
+}
+
+#endif // CREST_OCEAN_SHADER_HELPERS_H

--- a/crest/Assets/Crest/Crest/Shaders/OceanShaderHelpers.hlsl.meta
+++ b/crest/Assets/Crest/Crest/Shaders/OceanShaderHelpers.hlsl.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 080462513fcbf3849b63159153ec0138
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/crest/Assets/Crest/Crest/Shaders/Underwater/UnderwaterCurtain.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Underwater/UnderwaterCurtain.shader
@@ -58,6 +58,7 @@ Shader "Crest/Underwater Curtain"
 			#include "../OceanGlobals.hlsl"
 			#include "../OceanInputsDriven.hlsl"
 			#include "../OceanHelpersNew.hlsl"
+			#include "../OceanShaderHelpers.hlsl"
 			#include "UnderwaterShared.hlsl"
 
 			float _HeightOffset;


### PR DESCRIPTION
Fixes #426

Adds orthographic projection support. By default the ocean shader supports both orthographic and perspective. But users can choose a mode on the material using a keyword enum to save on performance.

Supporting orthographic projection was just a matter of fixing depth when the camera is orthographic.

I also cleaned up some unused depth references in the shader.