### PR TITLE
Fix Terrain "Draw Instanced" not working with Ocean Depth Cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,6 @@ If you encounter an issue, please search the [Issues page](https://github.com/hu
 There are a few issues worth calling out here:
 
 * Sky solutions such as Azure[Sky] requires some code to be added to the ocean shader for the fogging/scattering to work. This is a requirement of these products which typically come with instructions for what needs to be added. See the [wiki](https://github.com/crest-ocean/crest/wiki) for examples.
-* This built-in render pipeline version of crest requires the *Draw Instanced* option on terrains to be disabled at start time. It can be re-enabled subsequently after the depth cache is populated. See [issue #158](https://github.com/crest-ocean/crest/issues/158).
 * *Crest* does not support OpenGL or WebGL backends
 
 [legacy branch]: https://github.com/crest-ocean/crest/tree/legacy/unity-2018

--- a/USERGUIDE.md
+++ b/USERGUIDE.md
@@ -270,7 +270,6 @@ By default the cache is populated in the `Start()` function. It can instead be c
 
 Once populated the cache contents can be saved to disk by clicking the *Save cache to file* button that will appear in the Inspector in play mode. Once saved, the *Type* can be set to *Baked* and the saved data can be assigned to the *Saved Cache* field.
 
-**Note:** This built-in render pipeline version of crest requires the *Draw Instanced* option on terrains to be disabled at start time. It can be re-enabled subsequently after the depth cache is populated. See issue #158.
 
 
 # Limiting water area
@@ -481,6 +480,3 @@ However, the dynamic wave sim is not fully deterministic and can not currently b
 
 **Can the density of the fog in the water be reduced?**
 The density of the fog underwater can be controlled using the *Fog Density* parameter on the ocean material. This applies to both above water and underwater.
-
-**My terrain does not appear to affect the water - no shorelines or shallow water waves.**
-This built-in render pipeline version of crest requires the *Draw Instanced* option on terrains to be disabled at start time. It can be re-enabled subsequently after the depth cache is populated. See issue #158.

--- a/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
@@ -2,8 +2,6 @@
 
 // This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
 
-// This is the original version that uses an auxillary camera and works with Unity's GPU terrain - issue 152.
-
 using System;
 using UnityEngine;
 
@@ -64,11 +62,6 @@ namespace Crest
 #pragma warning restore 649
         public Texture2D SavedCache => _savedCache;
 
-        [Tooltip("Check for any terrains that have the 'Draw Instanced' option enabled. Such instanced terrains will not populate into the depth cache and therefore will not contribute to shorelines and shallow water. This option must be disabled on the terrain when the depth cache is populated (but can be enabled afterwards)."), SerializeField]
-#pragma warning disable 414
-        bool _checkTerrainDrawInstancedOption = true;
-#pragma warning restore 414
-
 #pragma warning disable 414
         [Tooltip("Editor only: run validation checks on Start() to check for issues."), SerializeField]
         bool _runValidationOnStart = true;
@@ -79,9 +72,16 @@ namespace Crest
 
         GameObject _drawCacheQuad;
         Camera _camDepthCache;
+        Material _copyDepthMaterial;
 
         void Start()
         {
+            if (OceanRenderer.Instance == null)
+            {
+                enabled = false;
+                return;
+            }
+
 #if UNITY_EDITOR
             if (EditorApplication.isPlaying && _runValidationOnStart)
             {
@@ -91,7 +91,7 @@ namespace Crest
 
             if (_type == OceanDepthCacheType.Baked)
             {
-                DrawCacheQuad();
+                InitCacheQuad();
             }
             else if (_type == OceanDepthCacheType.Realtime && _refreshMode == OceanDepthCacheRefreshMode.OnStart)
             {
@@ -109,84 +109,76 @@ namespace Crest
         }
 #endif
 
-        public void PopulateCache()
+        RenderTexture MakeRT(bool depthStencilTarget)
         {
-            if (_type == OceanDepthCacheType.Baked)
-                return;
+            RenderTextureFormat fmt;
 
-            var layerMask = 0;
-            var errorShown = false;
-            foreach (var layer in _layerNames)
+            if (depthStencilTarget)
             {
-                if (string.IsNullOrEmpty(layer))
-                {
-                    Debug.LogError("OceanDepthCache: An empty layer name was provided. Please provide a valid layer name. Click this message to highlight the cache in question.", this);
-                    errorShown = true;
-                    continue;
-                }
-
-                int layerIdx = LayerMask.NameToLayer(layer);
-                if (layerIdx == -1)
-                {
-                    Debug.LogError("OceanDepthCache: Invalid layer specified: \"" + layer +
-                        "\". Please add this layer to the project by putting the name in an empty layer slot in Edit/Project Settings/Tags and Layers. Click this message to highlight the cache in question.", this);
-
-                    errorShown = true;
-                }
-                else
-                {
-                    layerMask = layerMask | (1 << layerIdx);
-                }
+                fmt = RenderTextureFormat.Depth;
             }
-
-            if (layerMask == 0)
-            {
-                if (!errorShown)
-                {
-                    Debug.LogError("No valid layers for populating depth cache, aborting. Click this message to highlight the cache in question.", this);
-                }
-
-                return;
-            }
-
-#if UNITY_EDITOR
-            if (_type == OceanDepthCacheType.Realtime && _checkTerrainDrawInstancedOption)
-            {
-                // This issue only affects the built-in render pipeline. Issue 158: https://github.com/crest-ocean/crest/issues/158
-
-                var terrains = FindObjectsOfType<Terrain>();
-                foreach (var terrain in terrains)
-                {
-                    var mask = (int)Mathf.Pow(2f, terrain.gameObject.layer);
-
-                    if ((mask & layerMask) == 0) continue;
-
-                    if (terrain.drawInstanced)
-                    {
-                        Debug.LogError($"Terrain {terrain.gameObject.name} has 'Draw Instanced' enabled. This terrain will not populate into the depth cache and therefore will not contribute to shorelines and shallow water. This option must be disabled on the terrain when the depth cache is populated (but can be enabled afterwards).", terrain);
-                    }
-                }
-            }
-#endif
-
-            if (_cacheTexture == null)
+            else
             {
 #if UNITY_EDITOR_WIN
-                var fmt = RenderTextureFormat.DefaultHDR;
+                fmt = RenderTextureFormat.DefaultHDR;
 #else
-                var fmt = RenderTextureFormat.RHalf;
+                fmt = RenderTextureFormat.RHalf;
 #endif
-                Debug.Assert(SystemInfo.SupportsRenderTextureFormat(fmt), "The graphics device does not support the render texture format " + fmt.ToString());
-                _cacheTexture = new RenderTexture(_resolution, _resolution, 0);
-                _cacheTexture.name = gameObject.name + "_oceanDepth";
-                _cacheTexture.format = fmt;
-                _cacheTexture.useMipMap = false;
-                _cacheTexture.anisoLevel = 0;
-                _cacheTexture.Create();
+            }
+
+            Debug.Assert(SystemInfo.SupportsRenderTextureFormat(fmt), "The graphics device does not support the render texture format " + fmt.ToString());
+            var result = new RenderTexture(_resolution, _resolution, depthStencilTarget ? 24 : 0);
+            result.name = gameObject.name + "_oceanDepth_" + (depthStencilTarget ? "DepthOnly" : "Cache");
+            result.format = fmt;
+            result.useMipMap = false;
+            result.anisoLevel = 0;
+            return result;
+        }
+
+        bool InitObjects()
+        {
+            if (_cacheTexture == null)
+            {
+                _cacheTexture = MakeRT(false);
             }
 
             if (_camDepthCache == null)
             {
+                var errorShown = false;
+                var layerMask = 0;
+                foreach (var layer in _layerNames)
+                {
+                    if (string.IsNullOrEmpty(layer))
+                    {
+                        Debug.LogError("OceanDepthCache: An empty layer name was provided. Please provide a valid layer name. Click this message to highlight the cache in question.", this);
+                        errorShown = true;
+                        continue;
+                    }
+
+                    int layerIdx = LayerMask.NameToLayer(layer);
+                    if (layerIdx == -1)
+                    {
+                        Debug.LogError("OceanDepthCache: Invalid layer specified: \"" + layer +
+                            "\". Please add this layer to the project by putting the name in an empty layer slot in Edit/Project Settings/Tags and Layers. Click this message to highlight the cache in question.", this);
+
+                        errorShown = true;
+                    }
+                    else
+                    {
+                        layerMask = layerMask | (1 << layerIdx);
+                    }
+                }
+
+                if (layerMask == 0)
+                {
+                    if (!errorShown)
+                    {
+                        Debug.LogError("No valid layers for populating depth cache, aborting.", this);
+                    }
+
+                    return false;
+                }
+
                 _camDepthCache = new GameObject("DepthCacheCam").AddComponent<Camera>();
                 _camDepthCache.gameObject.hideFlags = _hideDepthCacheCam ? HideFlags.HideAndDontSave : HideFlags.DontSave;
                 _camDepthCache.transform.position = transform.position + Vector3.up * _cameraMaxTerrainHeight;
@@ -194,7 +186,6 @@ namespace Crest
                 _camDepthCache.transform.localEulerAngles = 90f * Vector3.right;
                 _camDepthCache.orthographic = true;
                 _camDepthCache.orthographicSize = Mathf.Max(transform.lossyScale.x / 2f, transform.lossyScale.z / 2f);
-                _camDepthCache.targetTexture = _cacheTexture;
                 _camDepthCache.cullingMask = layerMask;
                 _camDepthCache.clearFlags = CameraClearFlags.SolidColor;
                 // Clear to 'very deep'
@@ -204,55 +195,44 @@ namespace Crest
                 // Stops behaviour from changing in VR. I tried disabling XR before/after camera render but it makes the editor
                 // go bonkers with split windows.
                 _camDepthCache.cameraType = CameraType.Reflection;
-                // I'd prefer to destroy the cam object, but I found sometimes (on first start of editor) it will fail to render.
+                // I'd prefer to destroy the camera object, but I found sometimes (on first start of editor) it will fail to render.
                 _camDepthCache.gameObject.SetActive(false);
             }
 
-            // Make sure this global is set - I found this was necessary to set it here. However this can cause glitchiness in editor
-            // as it messes with this global vector, so only do it if not in edit mode
-#if UNITY_EDITOR
-            if (EditorApplication.isPlaying)
-#endif
+            if (_camDepthCache.targetTexture == null)
             {
-                // Shader needs sea level to determine water depth
-                var centerPoint = Vector3.zero;
-                if (OceanRenderer.Instance != null)
-                {
-                    centerPoint.y = OceanRenderer.Instance.Root.position.y;
-                }
-                else
-                {
-                    centerPoint.y = transform.position.y;
-                }
-
-                Shader.SetGlobalVector("_OceanCenterPosWorld", centerPoint);
+                _camDepthCache.targetTexture = MakeRT(true);
             }
 
-            _camDepthCache.RenderWithShader(Shader.Find("Crest/Inputs/Depth/Ocean Depth From Geometry"), null);
+            InitCacheQuad();
 
-            DrawCacheQuad();
+            return true;
         }
 
-        void DrawCacheQuad()
+        void InitCacheQuad()
         {
-            if (_drawCacheQuad != null)
-            {
-                return;
-            }
+            Renderer qr;
 
-            _drawCacheQuad = GameObject.CreatePrimitive(PrimitiveType.Quad);
-            _drawCacheQuad.hideFlags = HideFlags.DontSave;
+            if (_drawCacheQuad == null)
+            {
+                _drawCacheQuad = GameObject.CreatePrimitive(PrimitiveType.Quad);
+                _drawCacheQuad.hideFlags = HideFlags.DontSave;
 #if UNITY_EDITOR
-            DestroyImmediate(_drawCacheQuad.GetComponent<Collider>());
+                DestroyImmediate(_drawCacheQuad.GetComponent<Collider>());
 #else
-            Destroy(_drawCacheQuad.GetComponent<Collider>());
+                Destroy(_drawCacheQuad.GetComponent<Collider>());
 #endif
-            _drawCacheQuad.name = "DepthCache_" + gameObject.name;
-            _drawCacheQuad.transform.SetParent(transform, false);
-            _drawCacheQuad.transform.localEulerAngles = 90f * Vector3.right;
-            _drawCacheQuad.AddComponent<RegisterSeaFloorDepthInput>()._assignOceanDepthMaterial = false;
-            var qr = _drawCacheQuad.GetComponent<Renderer>();
-            qr.sharedMaterial = new Material(Shader.Find(LodDataMgrSeaFloorDepth.ShaderName));
+                _drawCacheQuad.name = "DepthCache_" + gameObject.name + "_NOSAVE";
+                _drawCacheQuad.transform.SetParent(transform, false);
+                _drawCacheQuad.transform.localEulerAngles = 90f * Vector3.right;
+                _drawCacheQuad.AddComponent<RegisterSeaFloorDepthInput>()._assignOceanDepthMaterial = false;
+                qr = _drawCacheQuad.GetComponent<Renderer>();
+                qr.sharedMaterial = new Material(Shader.Find(LodDataMgrSeaFloorDepth.ShaderName));
+            }
+            else
+            {
+                qr = _drawCacheQuad.GetComponent<Renderer>();
+            }
 
             if (_type == OceanDepthCacheType.Baked)
             {
@@ -264,6 +244,60 @@ namespace Crest
             }
 
             qr.enabled = false;
+        }
+
+        public void PopulateCache()
+        {
+            // Make sure we have required objects
+            if (!InitObjects())
+            {
+                return;
+            }
+
+            // Render scene, saving depths in depth buffer.
+            _camDepthCache.Render();
+
+            if (_copyDepthMaterial == null)
+            {
+                _copyDepthMaterial = new Material(Shader.Find("Crest/Copy Depth Buffer Into Cache"));
+            }
+
+            // Shader needs sea level to determine water depth. Ocean instance might not be available in prefabs.
+            var centerPoint = Vector3.zero;
+            centerPoint.y = OceanRenderer.Instance != null
+                ? OceanRenderer.Instance.Root.position.y : transform.position.y;
+
+            _copyDepthMaterial.SetVector("_OceanCenterPosWorld", centerPoint);
+
+            _copyDepthMaterial.SetTexture("_CamDepthBuffer", _camDepthCache.targetTexture);
+
+            // Zbuffer params
+            //float4 _ZBufferParams;            // x: 1-far/near,     y: far/near, z: x/far,     w: y/far
+            float near = _camDepthCache.nearClipPlane, far = _camDepthCache.farClipPlane;
+            _copyDepthMaterial.SetVector("_CustomZBufferParams", new Vector4(1f - far / near, far / near, (1f - far / near) / far, (far / near) / far));
+
+            // Altitudes for near and far planes
+            float ymax = _camDepthCache.transform.position.y - near;
+            float ymin = ymax - far;
+            _copyDepthMaterial.SetVector("_HeightNearHeightFar", new Vector2(ymax, ymin));
+
+            // Copy from depth buffer into the cache
+            Graphics.Blit(null, _cacheTexture, _copyDepthMaterial);
+
+            var leaveEnabled = _forceAlwaysUpdateDebug;
+
+            if (!leaveEnabled)
+            {
+                _camDepthCache.targetTexture = null;
+
+#if UNITY_EDITOR
+                if (EditorApplication.isPlaying)
+#endif
+                {
+                    // Only disable component when in play mode, otherwise it changes authoring data
+                    enabled = false;
+                }
+            }
         }
 
 #if UNITY_EDITOR
@@ -286,7 +320,7 @@ namespace Crest
     [CustomEditor(typeof(OceanDepthCache))]
     public class OceanDepthCacheEditor : ValidatedEditor
     {
-        readonly string[] _propertiesToExclude = new string[] { "m_Script", "_type", "_refreshMode", "_savedCache", "_layerNames", "_resolution", "_cameraMaxTerrainHeight", "_forceAlwaysUpdateDebug", "_checkTerrainDrawInstancedOption" };
+        readonly string[] _propertiesToExclude = new string[] { "m_Script", "_type", "_refreshMode", "_savedCache", "_layerNames", "_resolution", "_cameraMaxTerrainHeight", "_forceAlwaysUpdateDebug" };
 
         public override void OnInspectorGUI()
         {
@@ -312,7 +346,6 @@ namespace Crest
                 EditorGUILayout.PropertyField(serializedObject.FindProperty("_resolution"));
                 EditorGUILayout.PropertyField(serializedObject.FindProperty("_cameraMaxTerrainHeight"));
                 EditorGUILayout.PropertyField(serializedObject.FindProperty("_forceAlwaysUpdateDebug"));
-                EditorGUILayout.PropertyField(serializedObject.FindProperty("_checkTerrainDrawInstancedOption"));
             }
             else
             {

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/CopyDepthIntoCache.shader
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/CopyDepthIntoCache.shader
@@ -1,0 +1,78 @@
+﻿// Crest Ocean System
+
+// This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
+
+Shader "Crest/Copy Depth Buffer Into Cache"
+{
+	SubShader
+	{
+		Tags { "RenderType" = "Opaque" }
+
+		Pass
+		{
+			Name "CopyDepthBufferIntoCache"
+			ZTest Always ZWrite Off Blend Off
+
+			CGPROGRAM
+			// Required to compile gles 2.0 with standard srp library
+			#pragma prefer_hlslcc gles
+			#pragma exclude_renderers d3d11_9x
+			#pragma vertex vert
+			#pragma fragment frag
+
+			#include "UnityCG.cginc"
+
+			#include "../../OceanGlobals.hlsl"
+
+			CBUFFER_START(CrestPerOceanInput)
+			float4 _HeightNearHeightFar;
+			float4 _CustomZBufferParams;
+			CBUFFER_END
+
+			sampler2D _CamDepthBuffer;
+
+			struct Attributes
+			{
+				float3 positionOS   : POSITION;
+				float2 uv           : TEXCOORD0;
+			};
+
+			struct Varyings
+			{
+				float4 positionCS   : SV_POSITION;
+				float2 uv           : TEXCOORD0;
+			};
+
+			Varyings vert(Attributes input)
+			{
+				Varyings output;
+				output.uv = input.uv;
+				output.positionCS = UnityObjectToClipPos(input.positionOS.xyz);
+				return output;
+			}
+
+			float CustomLinear01Depth(float z)
+			{
+				z *= _CustomZBufferParams.x;
+				return (1.0 - z) / _CustomZBufferParams.y;
+			}
+
+			float4 frag(Varyings input) : SV_Target
+			{
+				float deviceDepth = SAMPLE_DEPTH_TEXTURE(_CamDepthBuffer, input.uv);
+				float linear01Z = CustomLinear01Depth(deviceDepth);
+
+				float altitude;
+#if UNITY_REVERSED_Z
+				altitude = lerp(_HeightNearHeightFar.y, _HeightNearHeightFar.x, linear01Z);
+#else
+				altitude = lerp(_HeightNearHeightFar.x, _HeightNearHeightFar.y, linear01Z);
+#endif
+
+				return float4(_OceanCenterPosWorld.y - altitude, 0.0, 0.0, 1.0);
+			}
+
+			ENDCG
+		}
+	}
+}

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/CopyDepthIntoCache.shader.meta
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/CopyDepthIntoCache.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 58d3509571029fb4399dfe7ffc7c5128
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Fixes #158 #371

Based on @huwb's branch: [fix/cache-terrain-depths](https://github.com/crest-ocean/crest/tree/fix/cache-terrain-depths)

Brings over fixes from downstream. Copies depth instead of rendering geometry into ocean depth cache. This didn't work before in 2018 but now works in 2019. Tested on MacOS in build and standalone.

These files are now same as downstream with a few exceptions:
- The copy depth shader use CG instead of HLSL, but they are only a few lines that are different.
- This C# file has a few additional lines which will be added downstream. Allows the depth cache to be used in a prefab

The diff is messy so it is easier to compare these files with the downstream files.

![1](https://user-images.githubusercontent.com/5249806/104393959-7ff12780-54fa-11eb-83d1-e759419b8fca.jpg)
