### PR TITLE
Refactor: Move ScaleDifferencePow2 to LodTransform

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgr.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgr.cs
@@ -49,12 +49,6 @@ namespace Crest
         // shape texture resolution
         int _shapeRes = -1;
 
-        // ocean scale last frame - used to detect scale changes
-        float _oceanLocalScalePrev = -1f;
-
-        int _scaleDifferencePow2 = 0;
-        protected int ScaleDifferencePow2 => _scaleDifferencePow2;
-
         public bool enabled { get; protected set; }
 
         protected OceanRenderer _ocean;
@@ -142,14 +136,6 @@ namespace Crest
 
                 _shapeRes = width;
             }
-
-            // determine if this LOD has changed scale and by how much (in exponent of 2)
-            float oceanLocalScale = OceanRenderer.Instance.Root.localScale.x;
-            if (_oceanLocalScalePrev == -1f) _oceanLocalScalePrev = oceanLocalScale;
-            float ratio = oceanLocalScale / _oceanLocalScalePrev;
-            _oceanLocalScalePrev = oceanLocalScale;
-            float ratio_l2 = Mathf.Log(ratio) / Mathf.Log(2f);
-            _scaleDifferencePow2 = Mathf.RoundToInt(ratio_l2);
         }
 
 

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrPersistent.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrPersistent.cs
@@ -121,7 +121,7 @@ namespace Crest
 
                 // compute which lod data we are sampling source data from. if a scale change has happened this can be any lod up or down the chain.
                 // this is only valid on the first update step, after that the scale src/target data are in the right places.
-                var srcDataIdxChange = ((stepi == 0) ? ScaleDifferencePow2 : 0);
+                var srcDataIdxChange = ((stepi == 0) ? OceanRenderer.Instance._lodTransform.ScaleDifferencePow2 : 0);
 
                 // only take transform from previous frame on first substep
                 var usePreviousFrameTransform = stepi == 0;

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodTransform.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodTransform.cs
@@ -19,6 +19,11 @@ namespace Crest
 
         protected int[] _transformUpdateFrame;
 
+        // ocean scale last frame - used to detect scale changes
+        float _oceanLocalScalePrev = -1f;
+        int _scaleDifferencePow2 = 0;
+        public int ScaleDifferencePow2 => _scaleDifferencePow2;
+
         [System.Serializable]
         public struct RenderData
         {
@@ -111,6 +116,8 @@ namespace Crest
 
                 _projectionMatrix[lodIdx] = Matrix4x4.Ortho(-2f * lodScale, 2f * lodScale, -2f * lodScale, 2f * lodScale, 1f, k_RenderAboveSeaLevel + k_RenderBelowSeaLevel);
             }
+
+            UpdateScaleDifference();
         }
 
         // Borrowed from LWRP code: https://github.com/Unity-Technologies/ScriptableRenderPipeline/blob/2a68d8073c4eeef7af3be9e4811327a522434d5f/com.unity.render-pipelines.high-definition/Runtime/Core/Utilities/GeometryUtils.cs
@@ -140,6 +147,17 @@ namespace Crest
                 _renderData[lodIdx]._posSnapped -= newOrigin;
                 _renderDataSource[lodIdx]._posSnapped -= newOrigin;
             }
+        }
+
+        void UpdateScaleDifference()
+        {
+            // Determine if LOD transform has changed scale and by how much (in exponent of 2).
+            float oceanLocalScale = OceanRenderer.Instance.Root.localScale.x;
+            if (_oceanLocalScalePrev == -1f) _oceanLocalScalePrev = oceanLocalScale;
+            float ratio = oceanLocalScale / _oceanLocalScalePrev;
+            _oceanLocalScalePrev = oceanLocalScale;
+            float ratio_l2 = Mathf.Log(ratio) / Mathf.Log(2f);
+            _scaleDifferencePow2 = Mathf.RoundToInt(ratio_l2);
         }
 
         public void WriteCascadeParams(OceanRenderer.CascadeParams[] cascadeParamsTgt, OceanRenderer.CascadeParams[] cascadeParamsSrc)

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Shadows/LodDataMgrShadow.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Shadows/LodDataMgrShadow.cs
@@ -244,7 +244,7 @@ namespace Crest
                     _renderProperties.SetVector(sp_Scale, new Vector3(scale, 1f, scale));
 
                     // compute which lod data we are sampling previous frame shadows from. if a scale change has happened this can be any lod up or down the chain.
-                    var srcDataIdx = lodIdx + ScaleDifferencePow2;
+                    var srcDataIdx = lodIdx + OceanRenderer.Instance._lodTransform.ScaleDifferencePow2;
                     srcDataIdx = Mathf.Clamp(srcDataIdx, 0, lt.LodCount - 1);
                     _renderProperties.SetInt(sp_LD_SliceIndex, lodIdx);
                     _renderProperties.SetInt(sp_LD_SliceIndex_Source, srcDataIdx);


### PR DESCRIPTION
Saves the calculation from per lod to only once.

The only difference in functionality is that if the LOD was disabled mid-game, and then becomes enable, the value will be different in this edge case. It can be solved by ignoring ScaleDifferencePow2 if LOD's first render. But I might be overthinking. Thoughts?