### PR TITLE
Refactor camera depth helpers

### DIFF
--- a/crest/Assets/Crest/Crest/Shaders/Helpers/BIRP/Common.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/Helpers/BIRP/Common.hlsl
@@ -2,6 +2,149 @@
 
 // Adds functions from SRP.
 
+#ifndef UNITY_COMMON_INCLUDED
+#define UNITY_COMMON_INCLUDED
+
+
+//
+// MACROS
+//
+
+// Taken from:
+// com.unity.render-pipelines.core@10.5.0/ShaderLibrary/API/D3D11.hlsl
+// com.unity.render-pipelines.core@10.5.0/ShaderLibrary/API/Metal.hlsl
+// com.unity.render-pipelines.core@10.5.0/ShaderLibrary/API/Switch.hlsl
+// com.unity.render-pipelines.core@10.5.0/ShaderLibrary/API/Vulkan.hlsl
+
+// GameCore, PSSL etc require an NDA so hard to confirm how some of these APIs are implemented, but the PPv2 package has
+// some of APIs (the ones we use) and they are the same:
+// com.unity.postprocessing/PostProcessing/Shaders/API/
+
+// Texture abstraction.
+
+#define TEXTURE2D(textureName)                Texture2D textureName
+#define TEXTURE2D_ARRAY(textureName)          Texture2DArray textureName
+// #define TEXTURECUBE(textureName)              TextureCube textureName
+// #define TEXTURECUBE_ARRAY(textureName)        TextureCubeArray textureName
+// #define TEXTURE3D(textureName)                Texture3D textureName
+
+// #ifdef SHADER_API_D3D11
+
+// #define TEXTURE2D_FLOAT(textureName)          TEXTURE2D(textureName)
+// #define TEXTURE2D_ARRAY_FLOAT(textureName)    TEXTURE2D_ARRAY(textureName)
+// #define TEXTURECUBE_FLOAT(textureName)        TEXTURECUBE(textureName)
+// #define TEXTURECUBE_ARRAY_FLOAT(textureName)  TEXTURECUBE_ARRAY(textureName)
+// #define TEXTURE3D_FLOAT(textureName)          TEXTURE3D(textureName)
+
+// #define TEXTURE2D_HALF(textureName)           TEXTURE2D(textureName)
+// #define TEXTURE2D_ARRAY_HALF(textureName)     TEXTURE2D_ARRAY(textureName)
+// #define TEXTURECUBE_HALF(textureName)         TEXTURECUBE(textureName)
+// #define TEXTURECUBE_ARRAY_HALF(textureName)   TEXTURECUBE_ARRAY(textureName)
+// #define TEXTURE3D_HALF(textureName)           TEXTURE3D(textureName)
+
+// #else // !SHADER_API_D3D11
+
+// #define TEXTURE2D_FLOAT(textureName)          Texture2D_float textureName
+// #define TEXTURE2D_ARRAY_FLOAT(textureName)    Texture2DArray_float textureName
+// #define TEXTURECUBE_FLOAT(textureName)        TextureCube_float textureName
+// #define TEXTURECUBE_ARRAY_FLOAT(textureName)  TextureCubeArray_float textureName
+// #define TEXTURE3D_FLOAT(textureName)          Texture3D_float textureName
+
+// #define TEXTURE2D_HALF(textureName)           Texture2D_half textureName
+// #define TEXTURE2D_ARRAY_HALF(textureName)     Texture2DArray_half textureName
+// #define TEXTURECUBE_HALF(textureName)         TextureCube_half textureName
+// #define TEXTURECUBE_ARRAY_HALF(textureName)   TextureCubeArray_half textureName
+// #define TEXTURE3D_HALF(textureName)           Texture3D_half textureName
+
+// #endif // SHADER_API_D3D11
+
+// #define TEXTURE2D_SHADOW(textureName)         TEXTURE2D(textureName)
+// #define TEXTURE2D_ARRAY_SHADOW(textureName)   TEXTURE2D_ARRAY(textureName)
+// #define TEXTURECUBE_SHADOW(textureName)       TEXTURECUBE(textureName)
+// #define TEXTURECUBE_ARRAY_SHADOW(textureName) TEXTURECUBE_ARRAY(textureName)
+
+// #define RW_TEXTURE2D(type, textureName)       RWTexture2D<type> textureName
+// #define RW_TEXTURE2D_ARRAY(type, textureName) RWTexture2DArray<type> textureName
+// #define RW_TEXTURE3D(type, textureName)       RWTexture3D<type> textureName
+
+#define SAMPLER(samplerName)                  SamplerState samplerName
+// #define SAMPLER_CMP(samplerName)              SamplerComparisonState samplerName
+// #define ASSIGN_SAMPLER(samplerName, samplerValue) samplerName = samplerValue
+
+// #define TEXTURE2D_PARAM(textureName, samplerName)                 TEXTURE2D(textureName),         SAMPLER(samplerName)
+// #define TEXTURE2D_ARRAY_PARAM(textureName, samplerName)           TEXTURE2D_ARRAY(textureName),   SAMPLER(samplerName)
+// #define TEXTURECUBE_PARAM(textureName, samplerName)               TEXTURECUBE(textureName),       SAMPLER(samplerName)
+// #define TEXTURECUBE_ARRAY_PARAM(textureName, samplerName)         TEXTURECUBE_ARRAY(textureName), SAMPLER(samplerName)
+// #define TEXTURE3D_PARAM(textureName, samplerName)                 TEXTURE3D(textureName),         SAMPLER(samplerName)
+
+// #define TEXTURE2D_SHADOW_PARAM(textureName, samplerName)          TEXTURE2D(textureName),         SAMPLER_CMP(samplerName)
+// #define TEXTURE2D_ARRAY_SHADOW_PARAM(textureName, samplerName)    TEXTURE2D_ARRAY(textureName),   SAMPLER_CMP(samplerName)
+// #define TEXTURECUBE_SHADOW_PARAM(textureName, samplerName)        TEXTURECUBE(textureName),       SAMPLER_CMP(samplerName)
+// #define TEXTURECUBE_ARRAY_SHADOW_PARAM(textureName, samplerName)  TEXTURECUBE_ARRAY(textureName), SAMPLER_CMP(samplerName)
+
+// #define TEXTURE2D_ARGS(textureName, samplerName)                textureName, samplerName
+// #define TEXTURE2D_ARRAY_ARGS(textureName, samplerName)          textureName, samplerName
+// #define TEXTURECUBE_ARGS(textureName, samplerName)              textureName, samplerName
+// #define TEXTURECUBE_ARRAY_ARGS(textureName, samplerName)        textureName, samplerName
+// #define TEXTURE3D_ARGS(textureName, samplerName)                textureName, samplerName
+
+// #define TEXTURE2D_SHADOW_ARGS(textureName, samplerName)         textureName, samplerName
+// #define TEXTURE2D_ARRAY_SHADOW_ARGS(textureName, samplerName)   textureName, samplerName
+// #define TEXTURECUBE_SHADOW_ARGS(textureName, samplerName)       textureName, samplerName
+// #define TEXTURECUBE_ARRAY_SHADOW_ARGS(textureName, samplerName) textureName, samplerName
+
+#define SAMPLE_TEXTURE2D(textureName, samplerName, coord2)                               textureName.Sample(samplerName, coord2)
+// #define SAMPLE_TEXTURE2D_LOD(textureName, samplerName, coord2, lod)                      textureName.SampleLevel(samplerName, coord2, lod)
+// #define SAMPLE_TEXTURE2D_BIAS(textureName, samplerName, coord2, bias)                    textureName.SampleBias(samplerName, coord2, bias)
+// #define SAMPLE_TEXTURE2D_GRAD(textureName, samplerName, coord2, dpdx, dpdy)              textureName.SampleGrad(samplerName, coord2, dpdx, dpdy)
+#define SAMPLE_TEXTURE2D_ARRAY(textureName, samplerName, coord2, index)                  textureName.Sample(samplerName, float3(coord2, index))
+// #define SAMPLE_TEXTURE2D_ARRAY_LOD(textureName, samplerName, coord2, index, lod)         textureName.SampleLevel(samplerName, float3(coord2, index), lod)
+// #define SAMPLE_TEXTURE2D_ARRAY_BIAS(textureName, samplerName, coord2, index, bias)       textureName.SampleBias(samplerName, float3(coord2, index), bias)
+// #define SAMPLE_TEXTURE2D_ARRAY_GRAD(textureName, samplerName, coord2, index, dpdx, dpdy) textureName.SampleGrad(samplerName, float3(coord2, index), dpdx, dpdy)
+// #define SAMPLE_TEXTURECUBE(textureName, samplerName, coord3)                             textureName.Sample(samplerName, coord3)
+// #define SAMPLE_TEXTURECUBE_LOD(textureName, samplerName, coord3, lod)                    textureName.SampleLevel(samplerName, coord3, lod)
+// #define SAMPLE_TEXTURECUBE_BIAS(textureName, samplerName, coord3, bias)                  textureName.SampleBias(samplerName, coord3, bias)
+// #define SAMPLE_TEXTURECUBE_ARRAY(textureName, samplerName, coord3, index)                textureName.Sample(samplerName, float4(coord3, index))
+// #define SAMPLE_TEXTURECUBE_ARRAY_LOD(textureName, samplerName, coord3, index, lod)       textureName.SampleLevel(samplerName, float4(coord3, index), lod)
+// #define SAMPLE_TEXTURECUBE_ARRAY_BIAS(textureName, samplerName, coord3, index, bias)     textureName.SampleBias(samplerName, float4(coord3, index), bias)
+// #define SAMPLE_TEXTURE3D(textureName, samplerName, coord3)                               textureName.Sample(samplerName, coord3)
+// #define SAMPLE_TEXTURE3D_LOD(textureName, samplerName, coord3, lod)                      textureName.SampleLevel(samplerName, coord3, lod)
+
+// #define SAMPLE_TEXTURE2D_SHADOW(textureName, samplerName, coord3)                    textureName.SampleCmpLevelZero(samplerName, (coord3).xy, (coord3).z)
+// #define SAMPLE_TEXTURE2D_ARRAY_SHADOW(textureName, samplerName, coord3, index)       textureName.SampleCmpLevelZero(samplerName, float3((coord3).xy, index), (coord3).z)
+// #define SAMPLE_TEXTURECUBE_SHADOW(textureName, samplerName, coord4)                  textureName.SampleCmpLevelZero(samplerName, (coord4).xyz, (coord4).w)
+// #define SAMPLE_TEXTURECUBE_ARRAY_SHADOW(textureName, samplerName, coord4, index)     textureName.SampleCmpLevelZero(samplerName, float4((coord4).xyz, index), (coord4).w)
+
+#undef SAMPLE_DEPTH_TEXTURE
+// #undef SAMPLE_DEPTH_TEXTURE_LOD
+#define SAMPLE_DEPTH_TEXTURE(textureName, samplerName, coord2)          SAMPLE_TEXTURE2D(textureName, samplerName, coord2).r
+// #define SAMPLE_DEPTH_TEXTURE_LOD(textureName, samplerName, coord2, lod) SAMPLE_TEXTURE2D_LOD(textureName, samplerName, coord2, lod).r
+
+#define LOAD_TEXTURE2D(textureName, unCoord2)                                   textureName.Load(int3(unCoord2, 0))
+// #define LOAD_TEXTURE2D_LOD(textureName, unCoord2, lod)                          textureName.Load(int3(unCoord2, lod))
+// #define LOAD_TEXTURE2D_MSAA(textureName, unCoord2, sampleIndex)                 textureName.Load(unCoord2, sampleIndex)
+#define LOAD_TEXTURE2D_ARRAY(textureName, unCoord2, index)                      textureName.Load(int4(unCoord2, index, 0))
+// #ifndef SHADER_API_SWITCH
+// #define LOAD_TEXTURE2D_ARRAY_MSAA(textureName, unCoord2, index, sampleIndex)    textureName.Load(int3(unCoord2, index), sampleIndex)
+// #endif
+// #define LOAD_TEXTURE2D_ARRAY_LOD(textureName, unCoord2, index, lod)             textureName.Load(int4(unCoord2, index, lod))
+// #define LOAD_TEXTURE3D(textureName, unCoord3)                                   textureName.Load(int4(unCoord3, 0))
+// #define LOAD_TEXTURE3D_LOD(textureName, unCoord3, lod)                          textureName.Load(int4(unCoord3, lod))
+
+// #define GATHER_TEXTURE2D(textureName, samplerName, coord2)                textureName.Gather(samplerName, coord2)
+// #define GATHER_TEXTURE2D_ARRAY(textureName, samplerName, coord2, index)   textureName.Gather(samplerName, float3(coord2, index))
+// #define GATHER_TEXTURECUBE(textureName, samplerName, coord3)              textureName.Gather(samplerName, coord3)
+// #define GATHER_TEXTURECUBE_ARRAY(textureName, samplerName, coord3, index) textureName.Gather(samplerName, float4(coord3, index))
+// #define GATHER_RED_TEXTURE2D(textureName, samplerName, coord2)            textureName.GatherRed(samplerName, coord2)
+// #define GATHER_GREEN_TEXTURE2D(textureName, samplerName, coord2)          textureName.GatherGreen(samplerName, coord2)
+// #define GATHER_BLUE_TEXTURE2D(textureName, samplerName, coord2)           textureName.GatherBlue(samplerName, coord2)
+// #define GATHER_ALPHA_TEXTURE2D(textureName, samplerName, coord2)          textureName.GatherAlpha(samplerName, coord2)
+
+
+//
+// FUNCTIONS
+//
+
 // Taken and modified from:
 // com.unity.render-pipelines.core@10.5.0/ShaderLibrary/Common.hlsl
 float4 ComputeClipSpacePosition(float2 positionNDC, float deviceDepth)
@@ -19,3 +162,5 @@ float3 ComputeWorldSpacePosition(float2 positionNDC, float deviceDepth, float4x4
 	float4 hpositionWS = mul(invViewProjMatrix, positionCS);
 	return hpositionWS.xyz / hpositionWS.w;
 }
+
+#endif // UNITY_COMMON_INCLUDED

--- a/crest/Assets/Crest/Crest/Shaders/Helpers/BIRP/Core.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/Helpers/BIRP/Core.hlsl
@@ -1,0 +1,60 @@
+// Crest Ocean System
+
+// Adds functions from SRP.
+
+#ifndef BUILTIN_PIPELINE_CORE_INCLUDED
+#define BUILTIN_PIPELINE_CORE_INCLUDED
+
+#include "Common.hlsl"
+
+// Taken from:
+// com.unity.shadergraph@12.0.0/Editor/Generation/Targets/BuiltIn/ShaderLibrary/Core.hlsl
+
+// Stereo-related bits
+#if defined(UNITY_STEREO_INSTANCING_ENABLED) || defined(UNITY_STEREO_MULTIVIEW_ENABLED)
+
+	#define SLICE_ARRAY_INDEX   unity_StereoEyeIndex
+
+	#define TEXTURE2D_X(textureName)                                        TEXTURE2D_ARRAY(textureName)
+	// #define TEXTURE2D_X_PARAM(textureName, samplerName)                     TEXTURE2D_ARRAY_PARAM(textureName, samplerName)
+	// #define TEXTURE2D_X_ARGS(textureName, samplerName)                      TEXTURE2D_ARRAY_ARGS(textureName, samplerName)
+	// #define TEXTURE2D_X_HALF(textureName)                                   TEXTURE2D_ARRAY_HALF(textureName)
+	// #define TEXTURE2D_X_FLOAT(textureName)                                  TEXTURE2D_ARRAY_FLOAT(textureName)
+
+	#define LOAD_TEXTURE2D_X(textureName, unCoord2)                         LOAD_TEXTURE2D_ARRAY(textureName, unCoord2, SLICE_ARRAY_INDEX)
+	// #define LOAD_TEXTURE2D_X_LOD(textureName, unCoord2, lod)                LOAD_TEXTURE2D_ARRAY_LOD(textureName, unCoord2, SLICE_ARRAY_INDEX, lod)
+	#define SAMPLE_TEXTURE2D_X(textureName, samplerName, coord2)            SAMPLE_TEXTURE2D_ARRAY(textureName, samplerName, coord2, SLICE_ARRAY_INDEX)
+	// #define SAMPLE_TEXTURE2D_X_LOD(textureName, samplerName, coord2, lod)   SAMPLE_TEXTURE2D_ARRAY_LOD(textureName, samplerName, coord2, SLICE_ARRAY_INDEX, lod)
+	// #define GATHER_TEXTURE2D_X(textureName, samplerName, coord2)            GATHER_TEXTURE2D_ARRAY(textureName, samplerName, coord2, SLICE_ARRAY_INDEX)
+	// #define GATHER_RED_TEXTURE2D_X(textureName, samplerName, coord2)        GATHER_RED_TEXTURE2D(textureName, samplerName, float3(coord2, SLICE_ARRAY_INDEX))
+	// #define GATHER_GREEN_TEXTURE2D_X(textureName, samplerName, coord2)      GATHER_GREEN_TEXTURE2D(textureName, samplerName, float3(coord2, SLICE_ARRAY_INDEX))
+	// #define GATHER_BLUE_TEXTURE2D_X(textureName, samplerName, coord2)       GATHER_BLUE_TEXTURE2D(textureName, samplerName, float3(coord2, SLICE_ARRAY_INDEX))
+
+	#define SAMPLE_DEPTH_TEXTURE_X(textureName, samplerName, coord2)          SAMPLE_TEXTURE2D_X(textureName, samplerName, coord2).r
+	// #define SAMPLE_DEPTH_TEXTURE_LOD_X(textureName, samplerName, coord2, lod) SAMPLE_TEXTURE2D_LOD_X(textureName, samplerName, coord2, lod).r
+
+#else // UNITY_STEREO
+
+	#define SLICE_ARRAY_INDEX       0
+
+	#define TEXTURE2D_X(textureName)                                        TEXTURE2D(textureName)
+	// #define TEXTURE2D_X_PARAM(textureName, samplerName)                     TEXTURE2D_PARAM(textureName, samplerName)
+	// #define TEXTURE2D_X_ARGS(textureName, samplerName)                      TEXTURE2D_ARGS(textureName, samplerName)
+	// #define TEXTURE2D_X_HALF(textureName)                                   TEXTURE2D_HALF(textureName)
+	// #define TEXTURE2D_X_FLOAT(textureName)                                  TEXTURE2D_FLOAT(textureName)
+
+	#define LOAD_TEXTURE2D_X(textureName, unCoord2)                         LOAD_TEXTURE2D(textureName, unCoord2)
+	// #define LOAD_TEXTURE2D_X_LOD(textureName, unCoord2, lod)                LOAD_TEXTURE2D_LOD(textureName, unCoord2, lod)
+	#define SAMPLE_TEXTURE2D_X(textureName, samplerName, coord2)            SAMPLE_TEXTURE2D(textureName, samplerName, coord2)
+	// #define SAMPLE_TEXTURE2D_X_LOD(textureName, samplerName, coord2, lod)   SAMPLE_TEXTURE2D_LOD(textureName, samplerName, coord2, lod)
+	// #define GATHER_TEXTURE2D_X(textureName, samplerName, coord2)            GATHER_TEXTURE2D(textureName, samplerName, coord2)
+	// #define GATHER_RED_TEXTURE2D_X(textureName, samplerName, coord2)        GATHER_RED_TEXTURE2D(textureName, samplerName, coord2)
+	// #define GATHER_GREEN_TEXTURE2D_X(textureName, samplerName, coord2)      GATHER_GREEN_TEXTURE2D(textureName, samplerName, coord2)
+	// #define GATHER_BLUE_TEXTURE2D_X(textureName, samplerName, coord2)       GATHER_BLUE_TEXTURE2D(textureName, samplerName, coord2)
+
+	#define SAMPLE_DEPTH_TEXTURE_X(textureName, samplerName, coord2)          SAMPLE_TEXTURE2D_X(textureName, samplerName, coord2).r
+	// #define SAMPLE_DEPTH_TEXTURE_LOD_X(textureName, samplerName, coord2, lod) SAMPLE_TEXTURE2D_LOD_X(textureName, samplerName, coord2, lod).r
+
+#endif // UNITY_STEREO
+
+#endif // BUILTIN_PIPELINE_CORE_INCLUDED

--- a/crest/Assets/Crest/Crest/Shaders/Helpers/BIRP/Core.hlsl.meta
+++ b/crest/Assets/Crest/Crest/Shaders/Helpers/BIRP/Core.hlsl.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: ed73691f6e6c74234ae0ecda16f6e925
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/crest/Assets/Crest/Crest/Shaders/Ocean.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Ocean.shader
@@ -267,6 +267,9 @@ Shader "Crest/Ocean"
 			#include "UnityCG.cginc"
 			#include "Lighting.cginc"
 
+			#include "Helpers/BIRP/Core.hlsl"
+			#include "Helpers/BIRP/InputsDriven.hlsl"
+
 			#include "OceanGlobals.hlsl"
 			#include "OceanInputsDriven.hlsl"
 			#include "OceanShaderData.hlsl"
@@ -486,7 +489,7 @@ Shader "Crest/Ocean"
 				half3 screenPos = input.screenPosXYW;
 				half2 uvDepth = screenPos.xy / screenPos.z;
 				// Raw depth is logarithmic for perspective, and linear (0-1) for orthographic.
-				float rawDepth = SAMPLE_DEPTH_TEXTURE(_CameraDepthTexture, uvDepth);
+				float rawDepth = CREST_SAMPLE_SCENE_DEPTH_X(uvDepth);
 				float sceneZ = CrestLinearEyeDepth(rawDepth);
 
 				float3 lightDir = WorldSpaceLightDir(input.worldPos);
@@ -630,7 +633,7 @@ Shader "Crest/Ocean"
 				// Soften reflection at intersections with objects/surfaces
 				#if _TRANSPARENCY_ON
 				// Above water depth outline is handled in OceanEmission.
-				sceneZ = (underwater ? CrestLinearEyeDepth(CrestMultiSampleSceneDepth(rawDepth, uvDepth)) : sceneZ);
+				sceneZ = (underwater ? CrestLinearEyeDepth(CREST_MULTISAMPLE_SCENE_DEPTH(uvDepth, rawDepth)) : sceneZ);
 				float reflAlpha = saturate((sceneZ  - pixelZ) / 0.2);
 				#else
 				// This addresses the problem where screenspace depth doesnt work in VR, and so neither will this. In VR people currently

--- a/crest/Assets/Crest/Crest/Shaders/OceanEmission.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanEmission.hlsl
@@ -158,7 +158,7 @@ half3 OceanEmission
 	if (!i_underwater)
 	{
 		const half2 refractOffset = _RefractionStrength * i_n_pixel.xz * min(1.0, 0.5*(i_sceneZ - i_pixelZ)) / i_sceneZ;
-		const float rawDepth = SAMPLE_DEPTH_TEXTURE(_CameraDepthTexture, i_uvDepth + refractOffset).x;
+		const float rawDepth = CREST_SAMPLE_SCENE_DEPTH_X(i_uvDepth + refractOffset);
 		half2 uvBackgroundRefract;
 
 		// Compute depth fog alpha based on refracted position if it landed on an underwater surface, or on unrefracted depth otherwise
@@ -169,12 +169,12 @@ half3 OceanEmission
 #endif
 		{
 			uvBackgroundRefract = uvBackground + refractOffset;
-			depthFogDistance = CrestLinearEyeDepth(CrestMultiSampleSceneDepth(rawDepth, uvBackgroundRefract)) - i_pixelZ;
+			depthFogDistance = CrestLinearEyeDepth(CREST_MULTISAMPLE_SCENE_DEPTH(uvBackgroundRefract, rawDepth)) - i_pixelZ;
 		}
 		else
 		{
 			// It seems that when MSAA is enabled this can sometimes be negative
-			depthFogDistance = max(CrestLinearEyeDepth(CrestMultiSampleSceneDepth(i_rawDepth, uvBackground)) - i_pixelZ, 0.0);
+			depthFogDistance = max(CrestLinearEyeDepth(CREST_MULTISAMPLE_SCENE_DEPTH(uvBackground, i_rawDepth)) - i_pixelZ, 0.0);
 
 			// We have refracted onto a surface in front of the water. Cancel the refraction offset.
 			uvBackgroundRefract = uvBackground;

--- a/crest/Assets/Crest/Crest/Shaders/OceanShaderData.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanShaderData.hlsl
@@ -10,7 +10,7 @@
 /////////////////////////////
 // Samplers
 
-UNITY_DECLARE_SCREENSPACE_TEXTURE(_CameraDepthTexture);
+TEXTURE2D_X(_CameraDepthTexture); SAMPLER(sampler_CameraDepthTexture);
 UNITY_DECLARE_SCREENSPACE_TEXTURE(_BackgroundTexture);
 
 float4 _CameraDepthTexture_TexelSize;

--- a/crest/Assets/Crest/Crest/Shaders/Underwater/Resources/UnderwaterMask.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Underwater/Resources/UnderwaterMask.shader
@@ -21,8 +21,8 @@ Shader "Hidden/Crest/Underwater/Ocean Mask"
 
 			#include "UnityCG.cginc"
 
-			UNITY_DECLARE_SCREENSPACE_TEXTURE(_CameraDepthTexture);
-			float4 _CameraDepthTexture_TexelSize;
+			#include "../../Helpers/BIRP/Core.hlsl"
+			#include "../../Helpers/BIRP/InputsDriven.hlsl"
 
 			#include "../UnderwaterMaskShared.hlsl"
 			ENDCG
@@ -42,7 +42,7 @@ Shader "Hidden/Crest/Underwater/Ocean Mask"
 
 			#include "UnityCG.cginc"
 
-			#include "../../Helpers/BIRP/Common.hlsl"
+			#include "../../Helpers/BIRP/Core.hlsl"
 			#include "../../Helpers/BIRP/InputsDriven.hlsl"
 			#include "../../FullScreenTriangle.hlsl"
 

--- a/crest/Assets/Crest/Crest/Shaders/Underwater/UnderwaterCurtain.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Underwater/UnderwaterCurtain.shader
@@ -55,6 +55,8 @@ Shader "Crest/Underwater Curtain"
 			#include "UnityCG.cginc"
 			#include "Lighting.cginc"
 
+			#include "../Helpers/BIRP/Core.hlsl"
+
 			#include "../OceanGlobals.hlsl"
 			#include "../OceanInputsDriven.hlsl"
 			#include "../OceanShaderData.hlsl"
@@ -187,7 +189,7 @@ Shader "Crest/Underwater Curtain"
 				const float pixelZ = LinearEyeDepth(input.positionCS.z);
 				const half3 screenPos = input.foam_screenPos.yzw;
 				const half2 uvDepth = screenPos.xy / screenPos.z;
-				const float sceneZ01 = UNITY_SAMPLE_SCREENSPACE_TEXTURE(_CameraDepthTexture, uvDepth).x;
+				const float sceneZ01 = SAMPLE_TEXTURE2D_X(_CameraDepthTexture, sampler_CameraDepthTexture, uvDepth).x;
 				const float sceneZ = LinearEyeDepth(sceneZ01);
 
 				const CascadeParams cascadeData0 = _CrestCascadeData[_LD_SliceIndex];

--- a/crest/Assets/Crest/Crest/Shaders/Underwater/UnderwaterEffectShared.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/Underwater/UnderwaterEffectShared.hlsl
@@ -9,8 +9,6 @@ half3 _AmbientLighting;
 half _DataSliceOffset;
 float2 _HorizonNormal;
 
-float4 _CrestOceanMaskDepthTexture_TexelSize;
-
 float4 DebugRenderOceanMask(const bool isOceanSurface, const bool isUnderwater, const float mask, const float3 sceneColour)
 {
 	if (isOceanSurface)
@@ -23,55 +21,29 @@ float4 DebugRenderOceanMask(const bool isOceanSurface, const bool isUnderwater, 
 	}
 }
 
-float MeniscusSampleOceanMask(const float2 uvScreenSpace, const float2 offset, const half magnitude)
-{
-	float2 uv = uvScreenSpace + offset * magnitude;
-	return UNITY_SAMPLE_SCREENSPACE_TEXTURE(_CrestOceanMaskTexture, uv).r;
-}
-
-half ComputeMeniscusWeight(const float2 uvScreenSpace, const float mask, const float2 horizonNormal, const float sceneZ)
+half ComputeMeniscusWeight(const int2 positionSS, const float mask, const float2 horizonNormal, const float sceneZ)
 {
 	float weight = 1.0;
 #if CREST_MENISCUS
 #if !_FULL_SCREEN_EFFECT
 	// Render meniscus by checking the mask along the horizon normal which is flipped using the surface normal from
 	// mask. Adding the mask value will flip the UV when mask is below surface.
-	float2 offset = float2(-1.0 + mask, -1.0 + mask) * horizonNormal / length(_ScreenParams.xy * horizonNormal);
+	float2 offset = float2(-1.0 + mask, -1.0 + mask) * horizonNormal;
 	float multiplier = 0.9;
 
 	// Sample three pixels along the normal. If the sample is different than the current mask, apply meniscus.
-	weight *= (MeniscusSampleOceanMask(uvScreenSpace, offset, 1.0) != mask) ? multiplier : 1.0;
-	weight *= (MeniscusSampleOceanMask(uvScreenSpace, offset, 2.0) != mask) ? multiplier : 1.0;
-	weight *= (MeniscusSampleOceanMask(uvScreenSpace, offset, 3.0) != mask) ? multiplier : 1.0;
+	// Offset must be added to positionSS as floats.
+	weight *= (LOAD_TEXTURE2D_X(_CrestOceanMaskTexture, positionSS + offset * 1.0).r != mask) ? multiplier : 1.0;
+	weight *= (LOAD_TEXTURE2D_X(_CrestOceanMaskTexture, positionSS + offset * 2.0).r != mask) ? multiplier : 1.0;
+	weight *= (LOAD_TEXTURE2D_X(_CrestOceanMaskTexture, positionSS + offset * 3.0).r != mask) ? multiplier : 1.0;
 #endif // _FULL_SCREEN_EFFECT
 #endif // CREST_MENISCUS
 	return weight;
 }
 
-#if defined(UNITY_SAMPLE_SCREENSPACE_TEXTURE)
-float CrestMultiSampleOceanDepth(const float i_rawDepth, const float2 i_positionNDC)
-{
-	float rawDepth = i_rawDepth;
-
-	if (_CrestDepthTextureOffset > 0)
-	{
-		// We could use screen size instead.
-		float2 texelSize = _CrestOceanMaskDepthTexture_TexelSize.xy;
-		int3 offset = int3(-_CrestDepthTextureOffset, 0, _CrestDepthTextureOffset);
-
-		rawDepth = CREST_DEPTH_COMPARE(rawDepth, UNITY_SAMPLE_SCREENSPACE_TEXTURE(_CrestOceanMaskDepthTexture, i_positionNDC + offset.xy * texelSize));
-		rawDepth = CREST_DEPTH_COMPARE(rawDepth, UNITY_SAMPLE_SCREENSPACE_TEXTURE(_CrestOceanMaskDepthTexture, i_positionNDC + offset.yx * texelSize));
-		rawDepth = CREST_DEPTH_COMPARE(rawDepth, UNITY_SAMPLE_SCREENSPACE_TEXTURE(_CrestOceanMaskDepthTexture, i_positionNDC + offset.yz * texelSize));
-		rawDepth = CREST_DEPTH_COMPARE(rawDepth, UNITY_SAMPLE_SCREENSPACE_TEXTURE(_CrestOceanMaskDepthTexture, i_positionNDC + offset.zy * texelSize));
-	}
-
-	return rawDepth;
-}
-#endif
-
 void GetOceanSurfaceAndUnderwaterData
 (
-	const float2 positionNDC,
+	const int2 positionSS,
 	const float rawOceanDepth,
 	const float mask,
 	inout float rawDepth,
@@ -88,11 +60,11 @@ void GetOceanSurfaceAndUnderwaterData
 	if (isOceanSurface)
 	{
 		rawDepth = rawOceanDepth;
-		sceneZ = CrestLinearEyeDepth(CrestMultiSampleOceanDepth(rawDepth, positionNDC));
+		sceneZ = CrestLinearEyeDepth(CREST_MULTILOAD_DEPTH(_CrestOceanMaskDepthTexture, positionSS, rawDepth));
 	}
 	else
 	{
-		sceneZ = CrestLinearEyeDepth(CrestMultiSampleSceneDepth(rawDepth, positionNDC));
+		sceneZ = CrestLinearEyeDepth(CREST_MULTILOAD_SCENE_DEPTH(positionSS, rawDepth));
 	}
 }
 


### PR DESCRIPTION
When I added the multisample depth helpers to fix MSAA outlines, it ended up being a bit of a mess which gave me some grief. This PR does the following:

- remove global variable dependency in includes file
- add texture macros from SRP
- use load instead of sample in underwater which simplifies a few things
- add multisample macros
- simplified shared RP code

I have kept most of the macros disabled as we should enable them as we use them.