### PR TITLE
Fix Ocean Depth Cache baked texture size limit

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
@@ -433,6 +433,8 @@ namespace Crest
                 ti.wrapMode = TextureWrapMode.Clamp;
                 // Values are slightly different with NPOT Scale applied.
                 ti.npotScale = TextureImporterNPOTScale.None;
+                // Round up so it encompasses desired resolution.
+                ti.maxTextureSize = Mathf.RoundToInt(Mathf.Pow(2f, Mathf.Ceil(Mathf.Log(dc._resolution, 2f))));
                 ti.SaveAndReimport();
 
                 Debug.Log("Crest: Cache saved to " + path, AssetDatabase.LoadAssetAtPath<UnityEngine.Object>(path));

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -34,6 +34,7 @@ Fixed
    -  Fix several *Texture2D* and *RenderTexture* memory and reference leaks.
    -  Fix excessively long build times when no *Underwater Renderer* is present in scene.
    -  Fix *Underwater Renderer* not working with varying water level.
+   -  Fix *Ocean Depth Cache* baked texture size being restricted by texture import settings.
 
 .. only:: birp
 


### PR DESCRIPTION
Texture import settings can limit the baked texture size. If users specify a resolution in ODC UI, then they would expect the bake to be the same I think. Reported on Discord that baked texture was limited to 2K.